### PR TITLE
EPUB accessibility conformance

### DIFF
--- a/UX-Guide-Metadata/techniques/epub-metadata.html
+++ b/UX-Guide-Metadata/techniques/epub-metadata.html
@@ -268,8 +268,9 @@
 					</section>
 				</section>
 			</section>
-			<section id="accessibility-conformance">
-				<h3>Accessibility Conformance</h3>
+
+            <section id="accessibility-conformance-links">
+				<h3>Accessibility Conformance Links</h3>
 				<p><b>Value</b>: Textual Link based on Metadata or raw URL found in EPUB Package Document</p>
 				<p>This technique relates to <a href="../principles/#accessibility-conformance">Accessibility Conformance principle</a>.</p>
 					
@@ -281,13 +282,13 @@
 					<ul>
 						<li><q>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</q> report it as <q><a
 									href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a"
-										><b>WCAG-A</b></a></q> which links to this URL.</li>
+										><b>EPUB Accessibility, WCAG2.0-A</b></a></q> which links to this URL.</li>
 						<li><q>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa</q> report it as <q><a
 									href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"
-										><b>WCAG-AA</b></a></q> which links to this URL.</li>
+										><b>EPUB Accessibility, WCAG2.0-AA</b></a></q> which links to this URL.</li>
 						<li><q>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa</q> report it as <q><a
 									href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a"
-										><b>WCAG-AAA</b></a></q> which links to this URL.</li>
+										><b>EPUB Accessibility, WCAG2.0-AAA</b></a></q> which links to this URL.</li>
 					</ul>
 				</div>
 				<p>If the URL is anything other than the three listed above, then providing the raw URL which is also a
@@ -310,7 +311,7 @@
 					<section id="ui-9">
 						<h5>UI</h5>
 						<p>Accessibility Conformance: <a
-								href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa">WCAG-AA</a></p>
+								href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa">EPUB Accessibility, WCAG2.0-AA</a></p>
 						<p>(Because this links to one of the three URIs outlined above)</p>
 					</section>
 				</section>
@@ -341,6 +342,8 @@
 					</section>
 				</section>
 			</section>
+            
+            
 			<section id="certified-by">
 				<h3>Certified By</h3>
 				<p><b>Value</b>: Textual Data from metadata</p>

--- a/UX-Guide-Metadata/techniques/epub-metadata.html
+++ b/UX-Guide-Metadata/techniques/epub-metadata.html
@@ -269,12 +269,75 @@
 				</section>
 			</section>
 
+            <section id="accessibility-conformance-string">
+				<h3>Accessibility Conformance (Strings)</h3>
+                <p><b>Predefined Token Values</b>: </p>
+                <ul>
+                    <li>EPUB-A11Y-11_WCAG-20-A</li>
+                    <li>EPUB-A11Y-11_WCAG-20-AA</li>
+                    <li>EPUB-A11Y-11_WCAG-20-AAA</li>
+                    <li>EPUB-A11Y-11_WCAG-21-A</li>
+                    <li>EPUB-A11Y-11_WCAG-21-AA</li>
+                    <li>EPUB-A11Y-11_WCAG-21-AAA</li>    
+                </ul>
+               
+				<p>This technique relates to <a href="../principles/#accessibility-conformance">Accessibility Conformance principle</a>.</p>
+				
+  				<aside class="example" id="cp-property">
+					<pre><code>&lt;meta property="dcterms:conformsTo"&gt;</code></pre>
+				</aside>
+				<div class="note">
+					<p>If the String is one of our predefined token values:</p>
+					<ul>
+						<li><q>EPUB-A11Y-11_WCAG-20-A</q> report it as <q><b>EPUB Accessibility, WCAG2.0-A</b></q></li>
+						<li><q>EPUB-A11Y-11_WCAG-20-AA</q> report it as <q><b>EPUB Accessibility, WCAG2.0-AA</b></q></li>
+						<li><q>EPUB-A11Y-11_WCAG-20-AAA</q> report it as <q><b>EPUB Accessibility, WCAG2.0-AAA</b></q></li>
+						<li><q>EPUB-A11Y-11_WCAG-21-A</q> report it as <q><b>EPUB Accessibility, WCAG2.1-A</b></q></li>
+						<li><q>EPUB-A11Y-11_WCAG-21-AA</q> report it as <q><b>EPUB Accessibility, WCAG2.1-AA</b></q></li>
+						<li><q>EPUB-A11Y-11_WCAG-21-AAA</q> report it as <q><b>EPUB Accessibility, WCAG2.1-AAA</b></q></li>
+					</ul>
+				</div>
+				<div class="note">
+				<p>If the value is anything other than the six tokens listed above, then providing the raw string value as is.</p>
+                </div>				
+				<section id="example-conformance-metadata-present-token">
+					<h4>Example Conformance (metadata present token)</h4>
+					<section id="metadata-9">
+						<h5>Metadata</h5>
+						<aside class="example" id="cb11">
+							<pre><code>&lt;meta property="dcterms:conformsTo"&gt;EPUB-A11Y-11_WCAG-21-AA&lt;/meta&gt;</code></pre>
+						</aside>
+					</section>
+					<section id="ui-9">
+						<h5>UI</h5>
+						<p>Accessibility Conformance: EPUB Accessibility, WCAG 2.1 AA</p>
+						
+					</section>
+				</section>
+			
+ 				<section id="example-conformance-metadata-present-string">
+					<h4>Example 4.1 (metadata present non-token string)</h4>
+					<section id="metadata-9a">
+						<h5>Metadata</h5>
+						<aside class="example" id="cb11">
+							<pre><code>&lt;meta property="dcterms:conformsTo"&gt;WCAG AA&lt;/meta&gt;</code></pre>
+						</aside>
+					</section>
+					<section id="ui-9">
+						<h5>UI</h5>
+						<p>Accessibility Conformance: WCAG AA</p>
+						
+					</section>
+				</section>
+          
+            </section>
+
             <section id="accessibility-conformance-links">
-				<h3>Accessibility Conformance Links</h3>
+				<h3>Accessibility Conformance (Links)</h3>
 				<p><b>Value</b>: Textual Link based on Metadata or raw URL found in EPUB Package Document</p>
 				<p>This technique relates to <a href="../principles/#accessibility-conformance">Accessibility Conformance principle</a>.</p>
 					
-				<aside class="example" id="cb10">
+				<aside class="example" id="cp-link">
 					<pre><code>&lt;link rel="dcterms:conformsTo"&gt;</code></pre>
 				</aside>
 				<div class="note">
@@ -300,7 +363,7 @@
 					the links available in the section <a href="#all-accessibility-metadata">All Accessibility
 						Metadata</a>, described below.</p>
 				<p class="note">The above three URLs could change in the future since they reference the IDPF domain. Updates to the EPUB Accessibility standard are now being conducted in the W3C, so when a new revision is released a new referencing scheme will likely be recommended.</p>
-				<section id="example-4.1-metadata-present">
+				<section id="example-conformance-metadata-present-link">
 					<h4>Example 4.1 (metadata present)</h4>
 					<section id="metadata-9">
 						<h5>Metadata</h5>
@@ -315,7 +378,7 @@
 						<p>(Because this links to one of the three URIs outlined above)</p>
 					</section>
 				</section>
-				<section id="example-4.2-metadata-pointing-to-another-specification">
+				<section id="example-conformance-metadata-pointing-to-another-specification">
 					<h4>Example 4.2 (metadata pointing to another specification)</h4>
 					<section id="metadata-10">
 						<h5>Metadata</h5>
@@ -330,11 +393,15 @@
 							conformance as an optimized publication.)</p>
 					</section>
 				</section>
-				<section id="example-4.3-metadata-missing">
+				<section id="example-conformance-metadata-missing">
 					<h4>Example 4.3 (metadata missing)</h4>
 					<section id="metadata-11">
 						<h5>Metadata</h5>
-						<p><i>{No Data}</i></p>
+						<p><i>{No Data}</i> in either</p>
+                        <pre><code>&lt;meta property="dcterms:conformsTo"&gt;</code></pre>
+                        <p>and</p>
+                        <pre><code>&lt;link rel="dcterms:conformsTo"&gt;</code></pre>
+                        
 					</section>
 					<section id="ui-11">
 						<h5>UI</h5>

--- a/UX-Guide-Metadata/techniques/epub-metadata.html
+++ b/UX-Guide-Metadata/techniques/epub-metadata.html
@@ -269,68 +269,6 @@
 				</section>
 			</section>
 
-            <section id="accessibility-conformance-string">
-				<h3>Accessibility Conformance (Strings)</h3>
-                <p><b>Predefined Token Values</b>: </p>
-                <ul>
-                    <li>EPUB-A11Y-11_WCAG-20-A</li>
-                    <li>EPUB-A11Y-11_WCAG-20-AA</li>
-                    <li>EPUB-A11Y-11_WCAG-20-AAA</li>
-                    <li>EPUB-A11Y-11_WCAG-21-A</li>
-                    <li>EPUB-A11Y-11_WCAG-21-AA</li>
-                    <li>EPUB-A11Y-11_WCAG-21-AAA</li>    
-                </ul>
-               
-				<p>This technique relates to <a href="../principles/#accessibility-conformance">Accessibility Conformance principle</a>.</p>
-				
-  				<aside class="example" id="cp-property">
-					<pre><code>&lt;meta property="dcterms:conformsTo"&gt;</code></pre>
-				</aside>
-				<div class="note">
-					<p>If the String is one of our predefined token values:</p>
-					<ul>
-						<li><q>EPUB-A11Y-11_WCAG-20-A</q> report it as <q><b>EPUB Accessibility, WCAG2.0-A</b></q></li>
-						<li><q>EPUB-A11Y-11_WCAG-20-AA</q> report it as <q><b>EPUB Accessibility, WCAG2.0-AA</b></q></li>
-						<li><q>EPUB-A11Y-11_WCAG-20-AAA</q> report it as <q><b>EPUB Accessibility, WCAG2.0-AAA</b></q></li>
-						<li><q>EPUB-A11Y-11_WCAG-21-A</q> report it as <q><b>EPUB Accessibility, WCAG2.1-A</b></q></li>
-						<li><q>EPUB-A11Y-11_WCAG-21-AA</q> report it as <q><b>EPUB Accessibility, WCAG2.1-AA</b></q></li>
-						<li><q>EPUB-A11Y-11_WCAG-21-AAA</q> report it as <q><b>EPUB Accessibility, WCAG2.1-AAA</b></q></li>
-					</ul>
-				</div>
-				<div class="note">
-				<p>If the value is anything other than the six tokens listed above, then providing the raw string value as is.</p>
-                </div>				
-				<section id="example-conformance-metadata-present-token">
-					<h4>Example Conformance (metadata present token)</h4>
-					<section id="metadata-9">
-						<h5>Metadata</h5>
-						<aside class="example" id="cb11">
-							<pre><code>&lt;meta property="dcterms:conformsTo"&gt;EPUB-A11Y-11_WCAG-21-AA&lt;/meta&gt;</code></pre>
-						</aside>
-					</section>
-					<section id="ui-9">
-						<h5>UI</h5>
-						<p>Accessibility Conformance: EPUB Accessibility, WCAG 2.1 AA</p>
-						
-					</section>
-				</section>
-			
- 				<section id="example-conformance-metadata-present-string">
-					<h4>Example 4.1 (metadata present non-token string)</h4>
-					<section id="metadata-9a">
-						<h5>Metadata</h5>
-						<aside class="example" id="cb11">
-							<pre><code>&lt;meta property="dcterms:conformsTo"&gt;WCAG AA&lt;/meta&gt;</code></pre>
-						</aside>
-					</section>
-					<section id="ui-9">
-						<h5>UI</h5>
-						<p>Accessibility Conformance: WCAG AA</p>
-						
-					</section>
-				</section>
-          
-            </section>
 
             <section id="accessibility-conformance-links">
 				<h3>Accessibility Conformance (Links)</h3>
@@ -409,6 +347,75 @@
 					</section>
 				</section>
 			</section>
+            
+            
+            <section id="accessibility-conformance-string">
+ 				<h3>Accessibility Conformance (Strings)</h3>
+
+               <div class="note">
+                    <p>These techniques are for public draft of EPUB Accessibility 1.1, and the pre defined strings may change</p>
+                </div>                
+                
+                <p>Predefined Token Values:</p>
+                <ul>
+                    <li>EPUB-A11Y-11_WCAG-20-A</li>
+                    <li>EPUB-A11Y-11_WCAG-20-AA</li>
+                    <li>EPUB-A11Y-11_WCAG-20-AAA</li>
+                    <li>EPUB-A11Y-11_WCAG-21-A</li>
+                    <li>EPUB-A11Y-11_WCAG-21-AA</li>
+                    <li>EPUB-A11Y-11_WCAG-21-AAA</li>    
+                </ul>
+               
+				<p>This technique relates to <a href="../principles/#accessibility-conformance">Accessibility Conformance principle</a>.</p>
+				
+  				<aside class="example" id="cp-property">
+					<pre><code>&lt;meta property="dcterms:conformsTo"&gt;</code></pre>
+				</aside>
+				<div class="note">
+					<p>If the string is one of our predefined token values defined in EPUB Accessibility 1.1:</p>
+					<ul>
+						<li><q>EPUB-A11Y-11_WCAG-20-A</q> report it as <q><b>EPUB Accessibility, WCAG2.0-A</b></q></li>
+						<li><q>EPUB-A11Y-11_WCAG-20-AA</q> report it as <q><b>EPUB Accessibility, WCAG2.0-AA</b></q></li>
+						<li><q>EPUB-A11Y-11_WCAG-20-AAA</q> report it as <q><b>EPUB Accessibility, WCAG2.0-AAA</b></q></li>
+						<li><q>EPUB-A11Y-11_WCAG-21-A</q> report it as <q><b>EPUB Accessibility, WCAG2.1-A</b></q></li>
+						<li><q>EPUB-A11Y-11_WCAG-21-AA</q> report it as <q><b>EPUB Accessibility, WCAG2.1-AA</b></q></li>
+						<li><q>EPUB-A11Y-11_WCAG-21-AAA</q> report it as <q><b>EPUB Accessibility, WCAG2.1-AAA</b></q></li>
+					</ul>
+				</div>
+				<div class="note">
+				<p>If the value is anything other than the six tokens listed above, then providing the raw string value as is.</p>
+                </div>				
+				<section id="example-conformance-metadata-present-token">
+					<h4>Example Conformance (metadata present token)</h4>
+					<section id="metadata-9">
+						<h5>Metadata</h5>
+						<aside class="example" id="cb11">
+							<pre><code>&lt;meta property="dcterms:conformsTo"&gt;EPUB-A11Y-11_WCAG-21-AA&lt;/meta&gt;</code></pre>
+						</aside>
+					</section>
+					<section id="ui-9">
+						<h5>UI</h5>
+						<p>Accessibility Conformance: EPUB Accessibility, WCAG 2.1 AA</p>
+						
+					</section>
+				</section>
+			
+ 				<section id="example-conformance-metadata-present-string">
+					<h4>Example 4.1 (metadata present non-token string)</h4>
+					<section id="metadata-9a">
+						<h5>Metadata</h5>
+						<aside class="example" id="cb11">
+							<pre><code>&lt;meta property="dcterms:conformsTo"&gt;WCAG AA&lt;/meta&gt;</code></pre>
+						</aside>
+					</section>
+					<section id="ui-9">
+						<h5>UI</h5>
+						<p>Accessibility Conformance: WCAG AA</p>
+						
+					</section>
+				</section>
+          
+            </section>
             
             
 			<section id="certified-by">


### PR DESCRIPTION
Here is my first crack at this, which separates out both conformance metadata via links and strings which can be one of our predefined tokens or any text representing a standard the other chooses.

This will eventually resolve #4 