### PR TITLE
Adding notes on issue 1767 (Is 0 tolerance for accessibility conformance practical?)

### DIFF
--- a/UX-Guide-Metadata/principles/index.html
+++ b/UX-Guide-Metadata/principles/index.html
@@ -272,7 +272,7 @@
                 	<div role="heading" class="issue-title marker" id="h-issue-1" aria-level="6">
                 		<a href="https://github.com/w3c/epub-specs/issues/1767"><span class="issue-number">Issue 1767</span></a><span class="issue-label">: Is 0 tolerance for accessibility conformance practical? <a class="respec-gh-label" href="https://github.com/w3c/epub-specs/issues/?q=is%3Aissue+is%3Aopen+label%3A%22Cat-Accessibility%22" style="background-color: rgb(229, 220, 251); color: rgb(0, 0, 0);" aria-label="GitHub label: Cat-Accessibility">Cat-Accessibility</a></span></div>
                 	<div class="">
-						<p>At the time of publication of this document there is an open issue regarding the tolerance level for accessibility conformance. Resolution of the issue could change the values that can be expressed for the Accessibility Conformance metadata.</p>
+						<p>At the time of publication of this document there is an open issue <a href="https://github.com/w3c/epub-specs/issues/1767">#1767</a> (Is zero tolerance for accessibility conformance practical?) in the working draft of EPUB Accessibility 1.1. It may change the values for the Accessibility Conformance metadata in the future revision of these guidelines.</p>
 					</div>
 				</div>
                 

--- a/UX-Guide-Metadata/principles/index.html
+++ b/UX-Guide-Metadata/principles/index.html
@@ -39,7 +39,51 @@
 				}
 			};
 			// ]]>
-	  </script>
+		</script>
+		<style>
+			.fake-issue {
+				padding: .5em;
+				border: .5em;
+				border-left-style: solid;
+				page-break-inside: avoid;
+				margin: 1em auto;
+			}
+
+			.fake-issue {
+				border-color: #e05252;
+				border-color: var(--issue-border);
+				background: #fbe9e9;
+				background: var(--issue-bg);
+				color: black;
+				color: var(--issue-text);
+				counter-increment: issue;
+				overflow: auto;
+			}
+
+			.fake-issue::before, .fake-issue > .marker {
+				color: #831616;
+				color: var(--issueheading-text);
+			}
+
+			.fake-issue::before, .fake-issue > .marker {
+				text-transform: uppercase;
+				padding-right: 1em;
+			}
+
+			.fake-issue a.respec-gh-label {
+				padding: 5px;
+				margin: 0 2px 0 2px;
+				font-size: 10px;
+				text-transform: none;
+				text-decoration: none;
+				font-weight: 700;
+				border-radius: 4px;
+				position: relative;
+				bottom: 2px;
+				border: none;
+				display: inline-block;
+			}
+		</style>
 	</head>
 	<body>
 		<section id="abstract">
@@ -223,13 +267,21 @@
 				<p class="note">If a publication is optimized for a particular user group, e.g. an audiobook, it would not conform to WCAG guidelines, but it may be perfectly useable by a particular group, e.g. persons who are blind. In this case, the accessibility conformance metadata should identify the specification used to create the optimized publication.</p>
 				<h4>Rationale</h4>
 				<p>Discovery metadata enables publications to have their accessibility exposed regardless of the overall accessibility of the publication. A publication optimized for a particular group, such as an audiobook, would not meet WCAG 2.0, but it would be fully accessible to many people. The conformance metadata details the accessibility of the publication, which allows end users and educators to evaluate the suitability of the publication for individuals.</p>
+                
+                <div class="fake-issue" id="issue-container-number-1767">
+                	<div role="heading" class="issue-title marker" id="h-issue-1" aria-level="6">
+                		<a href="https://github.com/w3c/epub-specs/issues/1767"><span class="issue-number">Issue 1767</span></a><span class="issue-label">: Is 0 tolerance for accessibility conformance practical? <a class="respec-gh-label" href="https://github.com/w3c/epub-specs/issues/?q=is%3Aissue+is%3Aopen+label%3A%22Cat-Accessibility%22" style="background-color: rgb(229, 220, 251); color: rgb(0, 0, 0);" aria-label="GitHub label: Cat-Accessibility">Cat-Accessibility</a></span></div>
+                	<div class="">
+						<p>At the time of publication of this document there is an open issue regarding the tolerance level for accessibility conformance. Resolution of the issue could change the values that can be expressed for the Accessibility Conformance metadata.</p>
+					</div>
+				</div>
+                
                 <h4>Implementation</h4>
                 <ul>
                      <li><a href="../techniques/epub-metadata.html#accessibility-conformance-links">EPUB Accessibility: Conformance (Links)</a></li>                     
                      <li><a href="../techniques/epub-metadata.html#accessibility-conformance-string">EPUB Accessibility: Conformance (Strings)</a></li>
                      <li><a href="../techniques/onix.html#accessibility-conformance">ONIX: Conformance</a></li>
                 </ul>
-
 			</section>
 			
 			<section id="certified-by">

--- a/UX-Guide-Metadata/techniques/epub-metadata.html
+++ b/UX-Guide-Metadata/techniques/epub-metadata.html
@@ -34,6 +34,50 @@
 			};
 			// ]]>
 	  </script>
+	  <style>
+			.fake-issue {
+				padding: .5em;
+				border: .5em;
+				border-left-style: solid;
+				page-break-inside: avoid;
+				margin: 1em auto;
+			}
+
+			.fake-issue {
+				border-color: #e05252;
+				border-color: var(--issue-border);
+				background: #fbe9e9;
+				background: var(--issue-bg);
+				color: black;
+				color: var(--issue-text);
+				counter-increment: issue;
+				overflow: auto;
+			}
+
+			.fake-issue::before, .fake-issue > .marker {
+				color: #831616;
+				color: var(--issueheading-text);
+			}
+
+			.fake-issue::before, .fake-issue > .marker {
+				text-transform: uppercase;
+				padding-right: 1em;
+			}
+
+			.fake-issue a.respec-gh-label {
+				padding: 5px;
+				margin: 0 2px 0 2px;
+				font-size: 10px;
+				text-transform: none;
+				text-decoration: none;
+				font-weight: 700;
+				border-radius: 4px;
+				position: relative;
+				bottom: 2px;
+				border: none;
+				display: inline-block;
+			}
+		</style>
 	</head>
 	<body>
 		<section id="abstract"></section>
@@ -296,6 +340,13 @@
 					the links available in the section <a href="#all-accessibility-metadata">All Accessibility
 						Metadata</a>, described below.</p>
 				<p class="note">The above three URLs could change in the future since they reference the IDPF domain. Updates to the EPUB Accessibility standard are now being conducted in the W3C, so when a new revision is released a new referencing scheme will likely be recommended.</p>
+				<div class="fake-issue" id="issue-container-number-1767">
+                	<div role="heading" class="issue-title marker" id="h-issue-1" aria-level="6">
+                		<a href="https://github.com/w3c/epub-specs/issues/1767"><span class="issue-number">Issue 1767</span></a><span class="issue-label">: Is 0 tolerance for accessibility conformance practical? <a class="respec-gh-label" href="https://github.com/w3c/epub-specs/issues/?q=is%3Aissue+is%3Aopen+label%3A%22Cat-Accessibility%22" style="background-color: rgb(229, 220, 251); color: rgb(0, 0, 0);" aria-label="GitHub label: Cat-Accessibility">Cat-Accessibility</a></span></div>
+                	<div class="">
+						<p>At the time of publication of this document there is an open issue regarding the tolerance level for accessibility conformance. Resolution of the issue could change the values that can be expressed for the Accessibility Conformance metadata.</p>
+					</div>
+				</div>
 				<section id="example-4.1">
 					<h4>Example 4.1 (metadata present)</h4>
 					<section id="metadata-4.1">
@@ -378,7 +429,14 @@
 				</div>
 				<div class="note">
 				<p>If the value is anything other than the six tokens listed above, then providing the raw string value as is.</p>
-                </div>				
+                </div>
+                <div class="fake-issue" id="issue-container-number-1767a">
+                	<div role="heading" class="issue-title marker" id="h-issue-1a" aria-level="6">
+                		<a href="https://github.com/w3c/epub-specs/issues/1767"><span class="issue-number">Issue 1767</span></a><span class="issue-label">: Is 0 tolerance for accessibility conformance practical? <a class="respec-gh-label" href="https://github.com/w3c/epub-specs/issues/?q=is%3Aissue+is%3Aopen+label%3A%22Cat-Accessibility%22" style="background-color: rgb(229, 220, 251); color: rgb(0, 0, 0);" aria-label="GitHub label: Cat-Accessibility">Cat-Accessibility</a></span></div>
+                	<div class="">
+						<p>At the time of publication of this document there is an open issue regarding the tolerance level for accessibility conformance. Resolution of the issue could change the values that can be expressed for the Accessibility Conformance metadata.</p>
+					</div>
+				</div>			
 				<section id="example-5.1">
 					<h4>Example 5.1 (metadata present token)</h4>
 					<section id="metadata-5.1">

--- a/UX-Guide-Metadata/techniques/epub-metadata.html
+++ b/UX-Guide-Metadata/techniques/epub-metadata.html
@@ -344,7 +344,7 @@
                 	<div role="heading" class="issue-title marker" id="h-issue-1" aria-level="6">
                 		<a href="https://github.com/w3c/epub-specs/issues/1767"><span class="issue-number">Issue 1767</span></a><span class="issue-label">: Is 0 tolerance for accessibility conformance practical? <a class="respec-gh-label" href="https://github.com/w3c/epub-specs/issues/?q=is%3Aissue+is%3Aopen+label%3A%22Cat-Accessibility%22" style="background-color: rgb(229, 220, 251); color: rgb(0, 0, 0);" aria-label="GitHub label: Cat-Accessibility">Cat-Accessibility</a></span></div>
                 	<div class="">
-						<p>At the time of publication of this document there is an open issue regarding the tolerance level for accessibility conformance. Resolution of the issue could change the values that can be expressed for the Accessibility Conformance metadata.</p>
+						<p>At the time of publication of this document there is an open issue <a href="https://github.com/w3c/epub-specs/issues/1767">#1767</a> (Is zero tolerance for accessibility conformance practical?) in the working draft of EPUB Accessibility 1.1. It may change the values for the Accessibility Conformance metadata in the future revision of these guidelines.</p>
 					</div>
 				</div>
 				<section id="example-4.1">
@@ -434,7 +434,7 @@
                 	<div role="heading" class="issue-title marker" id="h-issue-1a" aria-level="6">
                 		<a href="https://github.com/w3c/epub-specs/issues/1767"><span class="issue-number">Issue 1767</span></a><span class="issue-label">: Is 0 tolerance for accessibility conformance practical? <a class="respec-gh-label" href="https://github.com/w3c/epub-specs/issues/?q=is%3Aissue+is%3Aopen+label%3A%22Cat-Accessibility%22" style="background-color: rgb(229, 220, 251); color: rgb(0, 0, 0);" aria-label="GitHub label: Cat-Accessibility">Cat-Accessibility</a></span></div>
                 	<div class="">
-						<p>At the time of publication of this document there is an open issue regarding the tolerance level for accessibility conformance. Resolution of the issue could change the values that can be expressed for the Accessibility Conformance metadata.</p>
+						<p>At the time of publication of this document there is an open issue <a href="https://github.com/w3c/epub-specs/issues/1767">#1767</a> (Is zero tolerance for accessibility conformance practical?) in the working draft of EPUB Accessibility 1.1. It may change the values for the Accessibility Conformance metadata in the future revision of these guidelines.</p>
 					</div>
 				</div>			
 				<section id="example-5.1">


### PR DESCRIPTION
I inserted the note with the link to the issue and the following text:

> ISSUE 1767: Is 0 tolerance for accessibility conformance practical? Cat-Accessibility
> At the time of publication of this document there is an open issue regarding the tolerance level for accessibility conformance. Resolution of the issue could change the values that can be expressed for the Accessibility Conformance metadata.

Suggestions for description are welcome.

I wanted to insert it as an issue with ReSpec, but at the moment it is not possible because the issue is on a different repository than this one. I opened an issue on ReSpec about it.

I then inserted the note manually, but rendered it graphically (and semantically) like those generated by ReSpec.