### PR TITLE
Additional proofread

### DIFF
--- a/UX-Guide-Metadata/principles/index.html
+++ b/UX-Guide-Metadata/principles/index.html
@@ -89,7 +89,7 @@
 		<section id="abstract">
 			<p>Finding, buying, and finally reading a publication is a very personal experience. For most of us this is routine. We go to a bookstore, search for the title we are interested in or perhaps browse the best sellers list, then purchase and start reading the publication.</p>
 			<p>Now consider you are blind and rely on an assistive technology to read the publication. You wonder: will my screen reader work with this title; are there image descriptions that will be spoken to describe these images; are there page numbers which are accessible; is the reading order correct so I don't hear a <q>caution</q> after reading a paragraph which could be dangerous? These are just a few of the accessibility concerns consumers have when trying to purchase and ultimately read a digital publication.</p>
-			<p>The good news is more and more publishers are creating publications that are <a>Born Accessible</a> (i.e., accessible from the outset, not fixed later) and getting the accessibility validation or audit done by independent organizations.</p>
+			<p>The good news is more and more publishers are creating publications that are <q>Born Accessible</q> (i.e., accessible from the outset, not fixed later) and getting the accessibility validation or audit done by independent organizations.</p>
 			<p>This document proposes a shared framework for presenting publication accessibility metadata in a user-friendly manner.</p>
 		</section>
 		<section id="sotd"></section>
@@ -137,7 +137,7 @@
 			<p>While every user has different accessibility needs, meeting the Web Content Accessibility Guidelines
 				(WCAG) 2.0 requirements, even at level A, is a baseline that ensures a publication will be widely accessible.
 				Publication providers may therefore wish to create specific search capabilities to permit users to find publications
-				that have declared conformance to WCAG at any level. We suggest the creation of an "Accessible" search filter that only returns publications with metadata that indicates conformance to the user-selected WCAG Level &#8212; A, AA or AAA.</p>
+				that have declared conformance to WCAG at any level. We suggest the creation of an "Accessible" search filter that only returns publications with metadata that indicates conformance to the user-selected WCAG Level &#8212; A, AA, or AAA.</p>
 			<p>Publications with full audio created for mainstream use provide important access for many users with disabilities even
 				though they are not accessible to all. (Note that these publications differ from traditional audiobooks in that the audio
 				accompanies the full or partial text of the publication.) Publication providers may already have search tools aimed at finding
@@ -243,7 +243,7 @@
 				<p>An indication that this publication can be read in full auditorily. This designation applies even if the text is also available with the audio.</p>
 				<h4>Rationale</h4>
 				<p>Some users, including users with dyslexia or visual impairments, seek publications they can use entirely by listening. Full Audio metadata is important to the discovery process for these users. Publication providers may already be designating "audiobooks" as a separately searchable set based on the popular definition of an audiobook as an audio-only experience. Publications that include full text and full audio may not currently be grouped with audiobooks, so exposing this metadata adds additional publications to the list of titles audio users might be interested in.</p>
-                <p>Audiobooks presented without text are considered optimized publications. They do not meet all accessibility requirements, and therefore will not be discovered when filtering for "accessible" publications, but they provide access to the publication for specific users who require audio. Providing a way for users to search a collection for all publications with full audio will support these users, and including this information in the metadata displayed will also alert users for whom audio is inaccessible. This piece of metadata should be included only if the value is "Yes". Since most digital publications available do not include audio, it is only important to include this metadata in the user interface for those that do.</p>
+                <p>Audiobooks presented without text are considered optimized publications. They do not meet all accessibility requirements, and therefore will not be discovered when filtering for "accessible" publications, but they provide access to the publication for specific users who require audio. Providing a way for users to search a collection for all publications with full audio will support these users and including this information in the metadata displayed will also alert users for whom audio is inaccessible. This piece of metadata should be included only if the value is "Yes". Since most digital publications available do not include audio, it is only important to include this metadata in the user interface for those that do.</p>
                 <h4>Implementation</h4>
                 <ul>
                     <li><a href="../techniques/epub-metadata.html#full-audio">EPUB Accessibility: Full Audio</a></li>
@@ -273,7 +273,7 @@
 				<h4>Definition</h4>
 				<p>To report the accessibility conformance of a publication, metadata for accessibility conformance should be provided. It declares the accessibility standard or accessibility specifications to which the publication conforms. The value can be a URL or a code which identifies the accessibility standard or accessibility specifications.</p>
 				<p class="note">In case of EPUB publications, it will usually point to the EPUB Accessibility specifications or WCAG.</p>
-				<p class="note">If a publication is optimized for a particular user group, e.g. an audiobook, it would not conform to WCAG guidelines, but it may be perfectly useable by a particular group (e.g. persons who are blind). In this case, the accessibility conformance metadata should identify the specification used to create the optimized publication.</p>
+				<p class="note">If a publication is optimized for a particular user group (e.g., an audiobook), it would not conform to WCAG guidelines, but it may be perfectly useable by a particular group (e.g., persons who are blind). In this case, the accessibility conformance metadata should identify the specification used to create the optimized publication.</p>
 				<h4>Rationale</h4>
 				<p>Discovery metadata enables publications to have their accessibility exposed regardless of the overall accessibility of the publication. A publication optimized for a particular group, such as an audiobook, would not meet WCAG 2.0, but it would be fully accessible to many people. The conformance metadata details the accessibility of the publication, which allows end users and educators to evaluate the suitability of the publication for individuals.</p>
                 
@@ -297,7 +297,7 @@
 				<h3>Certified By</h3>
 				<p><b>Value</b>: Textual Data from metadata</p>
 				<h4>Definition</h4>
-				<p>The <i>Certified By</i> property specifies the name of the party that certified the content. The certifier of the content could be the same party that created or published the publication, but can also be a third-party accessibility certifier.</p>
+				<p>The <i>Certified By</i> property specifies the name of the party that certified the content. The certifier of the content could be the same party that created or published the publication, or a third-party accessibility certifier.</p>
 				<h4>Rationale</h4>
 				<p>When the metadata about a publication declares that it conforms to an accessibility specification reaching a certain level of WCAG conformance, the party making this assertion must be identified.</p>
                 <h4>Implementation</h4>
@@ -343,7 +343,7 @@
 				<p><b>Values</b>: flashing, motion simulation, sound, no flashing, no motion simulation, no
 					sound, none, or unknown.</p>
 				<h4>Definition</h4>
-				<p>Hazards are a list of possible ways in which this publication could be physiologically dangerous for some users (e.g. flashing elements, background sounds, motion simulation, etc.).</p>
+				<p>Hazards are a list of possible ways in which this publication could be physiologically dangerous for some users (e.g., flashing elements, background sounds, and motion simulation).</p>
 				<h4>Rationale</h4>
 				<p>Unlike other accessibility properties, the presence of hazards can be expressed either positively or negatively. This is because users are more often looking for content that is safe for them. This section should always be displayed; indicate that no metadata was provided if that is the case.</p>
                 <h4>Implementation</h4>

--- a/UX-Guide-Metadata/principles/index.html
+++ b/UX-Guide-Metadata/principles/index.html
@@ -88,7 +88,7 @@
 	<body>
 		<section id="abstract">
 			<p>Finding, buying, and finally reading a book is a very personal experience. For most of us this is routine where we go to a bookstore search for the title we are interested in or perhaps browse the best sellers list, then purchase and start reading the book.</p>
-			<p>Now consider you are blind and rely on assistive technology to read this book. Will my screen reader work with this title? Are there image descriptions that will be spoken to describe these images, are there page numbers which are accessible, is the reading order correct so I don't hear chapter 4 before chapter 3? These are just a few of the accessibility concerns consumers have when trying to purchase and ultimately read electronic publication.</p>
+			<p>Now consider you are blind and rely on assistive technology to read this book. Will my screen reader work with this title? Are there image descriptions that will be spoken to describe these images, are there page numbers which are accessible, is the reading order correct so I don't hear a <q>caution</q> after reading a paragraph which could be dangerous.? These are just a few of the accessibility concerns consumers have when trying to purchase and ultimately read an electronic publication.</p>
 			<p>The good news is more and more publishers are creating Born Accessible publications and also getting the accessibility validation or audit done by independent organizations.</p>
 			<p>This document proposes a shared framework for presenting publication accessibility metadata in a user-friendly manner.</p>
 		</section>
@@ -136,7 +136,7 @@
 			<p>While every user has different accessibility needs, meeting the Web Content Accessibility Guidelines
 				(WCAG) 2.0 requirements, even at level A, is a baseline that ensures a book will be widely accessible.
 				Book providers may therefore wish to create specific search capabilities to permit users to find books
-				that have declared conformance to WCAG at any level. A search filter called "Accessible" that retrieves all books with metadata that indicates conformance to WCAG Level A, AA or AAA.</p>
+				that have declared conformance to WCAG at any level. We suggest the creation of a search filter called "Accessible" that retrieves all books with metadata that indicates conformance to WCAG Level A, AA or AAA.</p>
 			<p>Books with full audio created for mainstream use provide important access for many users with disabilities even
 				though they are not accessible to others. Book providers may already have search tools aimed at finding
 				audiobooks, since they are popular and fairly common, but if not, this would be a good addition to the
@@ -151,11 +151,8 @@
 		</section>
 		<section id="ui-technical-details">
 			<h2>UI Technical Details</h2>
-			<p>When you have accessibility metadata about a digital publication it is important to share this information with the
-				user in a user-friendly way. At a very high level when displaying information about a digital publication you may just
-				want to acknowledge that there is <q>Accessibility Features</q> or <q>Accessibility Information</q>
-				available and if the user would like to get at this information they can click a text or image link which
-				will then provide the information that is discussed below.</p>
+			<p>When you have accessibility metadata about a digital publication, it is important to share this information with the
+				user in a user-friendly way. At a very high level when displaying information about a digital publication, you may just want to acknowledge that there is <q>Accessibility Features</q> or <q>Accessibility Information</q> available. If the user would like to get at this information, they can click a text or image link which will then provide the information that is discussed below.</p>
             
 			<div class="note">
 				<p>When there is no accessibility metadata for this publication a statement should be displayed informing that there was no accessibility information provided.</p>
@@ -182,7 +179,7 @@
             <section>
                 <h3>Techniques</h3>
                 <p>To assist developers in implementing these guidelines, in-depth notes are available to explain how to extract information from publishing industry metadata standards.</p>
-                <p>At the time of this document the available techniques for metadata standards are:</p>
+                <p>At the time of publishing this document the available techniques for metadata standards are:</p>
 				<ul>
 					<li><p><a href="../techniques/epub-metadata.html">EPUB Accessibility Metadata</a></p></li>
 					<li><p><a href="../techniques/onix.html">ONIX Accessibility Metadata</a></p></li>
@@ -197,7 +194,7 @@
             <p>
                 Ordering this information in a meaningful and consistent way is key so the most important information appears first to help the user quickly determine if this publication will meet their specific needs.</p>
             <p>
-                The two most important accessibility accommodations are if the publication is "Screen Reader Friendly" which implies all text in the book is accessible and any images if present are described. Secondly, if the publication has "Full Audio". 
+                The two most important accessibility accommodations are if the publication is "Screen Reader Friendly" which implies all text in the book is accessible and any images if present are described. Secondly, if the publication has <q>Full Audio</q>, the user will know the entire publication can be read through audio playback. 
             </p>
             <p>
                 The next important piece is the Accessibility Summary which is metadata describing all the accessibility accommodations provided by this publication.

--- a/UX-Guide-Metadata/principles/index.html
+++ b/UX-Guide-Metadata/principles/index.html
@@ -87,27 +87,29 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>Finding, buying, and finally reading a book is a very personal experience. For most of us this is routine where we go to a bookstore search for the title we are interested in or perhaps browse the best sellers list, then purchase and start reading the book.</p>
-			<p>Now consider you are blind and rely on assistive technology to read this book. Will my screen reader work with this title? Are there image descriptions that will be spoken to describe these images, are there page numbers which are accessible, is the reading order correct so I don't hear a <q>caution</q> after reading a paragraph which could be dangerous.? These are just a few of the accessibility concerns consumers have when trying to purchase and ultimately read an electronic publication.</p>
-			<p>The good news is more and more publishers are creating Born Accessible publications and also getting the accessibility validation or audit done by independent organizations.</p>
+			<p>Finding, buying, and finally reading a publication is a very personal experience. For most of us this is routine. We go to a bookstore, search for the title we are interested in or perhaps browse the best sellers list, then purchase and start reading the publication.</p>
+			<p>Now consider you are blind and rely on an assistive technology to read the publication. You wonder: will my screen reader work with this title; are there image descriptions that will be spoken to describe these images; are there page numbers which are accessible; is the reading order correct so I don't hear a <q>caution</q> after reading a paragraph which could be dangerous? These are just a few of the accessibility concerns consumers have when trying to purchase and ultimately read a digital publication.</p>
+			<p>The good news is more and more publishers are creating publications that are <a>Born Accessible</a> (i.e., accessible from the outset, not fixed later) and getting the accessibility validation or audit done by independent organizations.</p>
 			<p>This document proposes a shared framework for presenting publication accessibility metadata in a user-friendly manner.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="general-overview">
 			<h2>General Overview</h2>
-			<p>This document will help those who wish to provide accessibility metadata directly to users understand how
+			<p>This document helps those who wish to render accessibility metadata directly to users understand how
 				to represent machine-readable accessibility metadata in a user-friendly User Interface / User Experience
 				(UI/UX).</p>
 			<div class="note">
-				<p>This document presents high-level principles, without going into technical issues related to the different metadata standards in the publishing industry.</p>
-				<p>Therefore, <a href="#techniques">techniques are available</a>, illustrating to developers how to retrieve data to show the information outlined in this document.</p>
+				<p>This document presents high-level principles without going into technical issues related to the different metadata standards in the publishing industry.</p>
+				<p>Therefore, <a href="#techniques">techniques are available</a> that illustrate to developers how to retrieve data to show the information outlined in this document.</p>
 			</div>
-			<p>Metadata found either inside a digital publication or in the corresponding external record may have important accessibility information that will help end users find and determine if this publication can meet their specific accessibility needs.</p>
-			<p>Most metadata is meant to be machine-readable so that it can be used to aid in user search queries such
-				as <q>Find all digital publications that contain large print, or braille, or that has met a certain level of
-					accessibility conformance.</q> The exception to this is the accessibility summary which, if present,
-				describes in human-readable text all the accessibility features and any shortcomings present in this
-				book that can be directly presented to the end user.</p>
+			<p>Metadata found either inside a digital publication or in a corresponding external record may have important accessibility information that helps end users find and determine if the publication can meet their specific accessibility needs.</p>
+			<p>Most metadata is meant to be machine-readable so that it aids in user search queries such
+				as <q>Find all digital publications that contain large print, or braille, or that meet a certain level of
+					accessibility conformance.</q></p>
+			
+			<p>The exception to this rule is the accessibility summary which, if present,
+				describes in human-readable prose the accessibility features present in the
+				publication as well as any shortcomings, when applicable. This summary is intended for direct presentation to end users.</p>
 
 			<p>Here is an example of what a user-friendly accessibility metadata web page could look like:</p>
 			<aside class="example">
@@ -126,36 +128,35 @@
 		</section>
 		<section id="discovering-accessible-content">
 			<h2>Discovering Accessible Content</h2>
-			<p>The guidelines for presentation of accessibility metadata in this document are intended to improve the
-				user experience when readers browse the catalog entry for a book. However, accessibility metadata also
-				has a vital role to play in helping readers discover books that are accessible for them. Book providers,
-				vendors, and libraries are encouraged to create searching and filtering tools that interpret
-				accessibility metadata to aid in discovery; a full discussion of this topic is out of scope for this
-				document, but these brief notes may be helpful until further research and development leads to more
-				specific guidance.</p>
+			<p>The guidelines for presenting accessibility metadata detailed in this document are intended to improve the
+				user experience when readers browse the catalog entry for a publication. However, accessibility metadata also
+				has a vital role to play in helping readers discover publications that are accessible for them. Publication providers, such as
+				vendors and libraries, are encouraged to create searching and filtering tools that interpret
+				accessibility metadata to aid in discovery. (A full discussion of search and filtering issues is out of
+				scope for this document, but this section provides some guidance until further research can be carried out.)</p>
 			<p>While every user has different accessibility needs, meeting the Web Content Accessibility Guidelines
-				(WCAG) 2.0 requirements, even at level A, is a baseline that ensures a book will be widely accessible.
-				Book providers may therefore wish to create specific search capabilities to permit users to find books
-				that have declared conformance to WCAG at any level. We suggest the creation of a search filter called "Accessible" that retrieves all books with metadata that indicates conformance to WCAG Level A, AA or AAA.</p>
-			<p>Books with full audio created for mainstream use provide important access for many users with disabilities even
-				though they are not accessible to others. Book providers may already have search tools aimed at finding
-				audiobooks, since they are popular and fairly common, but if not, this would be a good addition to the
-				suite of tools for finding accessible books. Note that audiobooks may not pass WCAG requirements because
-				they are targeted at a specific audience rather than broadly accessible and so would not be found using
+				(WCAG) 2.0 requirements, even at level A, is a baseline that ensures a publication will be widely accessible.
+				Publication providers may therefore wish to create specific search capabilities to permit users to find publications
+				that have declared conformance to WCAG at any level. We suggest the creation of an "Accessible" search filter that only returns publications with metadata that indicates conformance to the user-selected WCAG Level &#8212; A, AA or AAA.</p>
+			<p>Publications with full audio created for mainstream use provide important access for many users with disabilities even
+				though they are not accessible to all. (Note that these publications differ from traditional audiobooks in that the audio
+				accompanies the full or partial text of the publication.) Publication providers may already have search tools aimed at finding
+				traditional audiobooks, since they are popular and common, but even if not, this would be a good addition to the
+				suite of tools for finding accessible publications. Publications with full audio may not pass WCAG requirements, however, because
+				they are targeted at a specific audience rather than broadly accessible. As a result, they would not be found using
 				the <q>Accessible</q> search suggested above.</p>
-			<p>Any of the metadata fields discussed in detail below could also be used as a filter; a <q>Screen-reader
-					accessible</q> search would be valued by screen reader users, and a way to ensure no books with
+			<p>Any of the metadata fields discussed in detail below could also be used as a filter &#8212; a <q>Screen-reader
+					accessible</q> search would be valued by screen reader users, and a way to ensure no publications with
 				hazards are downloaded would be valued by those with light-sensitive epilepsy or other hazard-related
-				conditions. But if a single additional search filter fits best in a site’s UI, a tool for finding
-				accessible materials that declare conformance to WCAG 2.0 is the most likely choice.</p>
+				conditions. But if only a single additional search filter fits best in a site's UI, a tool for finding
+				accessible materials that declare conformance to WCAG 2.0 is the best choice to provide.</p>
 		</section>
 		<section id="ui-technical-details">
 			<h2>UI Technical Details</h2>
-			<p>When you have accessibility metadata about a digital publication, it is important to share this information with the
-				user in a user-friendly way. At a very high level when displaying information about a digital publication, you may just want to acknowledge that there is <q>Accessibility Features</q> or <q>Accessibility Information</q> available. If the user would like to get at this information, they can click a text or image link which will then provide the information that is discussed below.</p>
+			<p>When you have accessibility metadata about a digital publication, it is important to share this information in as user-friendly a way as possible. At a very high level, when displaying information about a digital publication, you may only want to acknowledge that <q>Accessibility Features</q> or <q>Accessibility Information</q> is available. If the user would like to get at this information, they can click a text or image link which will then provide the information that is discussed below.</p>
             
 			<div class="note">
-				<p>When there is no accessibility metadata for this publication a statement should be displayed informing that there was no accessibility information provided.</p>
+				<p>When a publisher does not provide any accessibility metadata for a publication, a statement should be displayed to the user informing them that no information was supplied.</p>
 			</div>
             
 			<p>In this example, a link to the accessibility information is provided with a traditional textual link.</p>
@@ -168,7 +169,7 @@
 				<p>Book Features: <u>Accessibility Information</u>
 					<i>(textual link to accessibility information below)</i></p>
 			</aside>
-			<p>Alternatively this link to the accessibility information could be provided with a clickable image.</p>
+			<p>Alternatively, this link to the accessibility information could be provided with a clickable image.</p>
 			<aside id="ex-bookFeatures" class="example">
 				<p>Book Features:</p>
 				<p><img  src="./media/accessibility.svg" alt="Accessibility Information" width="75" /></p>
@@ -192,17 +193,11 @@
 		<section id="order-of-key-information">
 			<h2>Order of Key Information</h2>
             <p>
-                Ordering this information in a meaningful and consistent way is key so the most important information appears first to help the user quickly determine if this publication will meet their specific needs.</p>
-            <p>
-                The two most important accessibility accommodations are if the publication is "Screen Reader Friendly" which implies all text in the book is accessible and any images if present are described. Secondly, if the publication has <q>Full Audio</q>, the user will know the entire publication can be read through audio playback. 
-            </p>
-            <p>
-                The next important piece is the Accessibility Summary which is metadata describing all the accessibility accommodations provided by this publication.
-                Following this are the accessibility conformance information (what level of conformance was reached, who certified it, and any certification credentials).
-            </p>
-            <p> 
-                Finally displaying any hazards if present and linking to all the accessibility metadata including all the specific accessibility features such as: image descriptions, mathml, table of contents, etc.
-            </p>
+                Ordering the supplied metadata in a meaningful and consistent way for users helps them easily understand the
+                strengths and weaknesses of each publication. Consequently, the most important information appears first to help the user quickly determine if the publication will meet their specific needs.</p>
+			
+			<p>The recommended ordering of information is as follows:</p>
+			
 			<ol type="1">
 				<li><p><a href="#screen-reader-friendly">Screen Reader Friendly</a></p></li>
 				<li><p><a href="#full-audio">Full Audio</a> (if present)</p></li>
@@ -214,6 +209,18 @@
 				<li><p><a href="#hazards">Hazards</a></p></li>
 				<li><p><a href="#all-accessibility-metadata">All Accessibility Metadata</a></p></li>
 			</ol>
+			
+			<p>
+            	The two most important accessibility accommodations to list are if the publication is <q>Screen Reader Friendly</q> and has <q>Full Audio</q>. A screen reader friendly publication implies all text is accessible and any images are described, if necessary. A publication that indicates it includes full audio lets the user will know the entire publication can be read through audio playback. 
+            </p>
+            <p>
+                The next important piece is the Accessibility Summary which is metadata describing all the accessibility accommodations provided by this publication.
+                Following this are the accessibility conformance information (what level of conformance was reached, who certified it, and any certification credentials).
+            </p>
+            <p> 
+                Finally displaying any hazards if present and linking to all the accessibility metadata including all the specific accessibility features such as: image descriptions, MathML, a table of contents, etc.
+            </p>
+			<p>More detailed information about these fields is provided in the following sections.</p>
 			
 			<section id="screen-reader-friendly">
 				<h3>Screen Reader Friendly</h3>
@@ -233,10 +240,10 @@
 				<h3>Full Audio</h3>
 				<p><b>Values</b>: <i>Yes / (if No - Omit this section)</i></p>
 				<h4>Definition</h4>
-				<p>An indication that this publication can be used by listening. This designation can be applied if text will also appear on a display as long as the text is not required to use the publication.</p>
+				<p>An indication that this publication can be read in full auditorily. This designation applies even if the text is also available with the audio.</p>
 				<h4>Rationale</h4>
-				<p>Some users, including users with dyslexia or visual impairments, seek books they can use entirely by listening. Full Audio metadata is important to the discovery process for these users. Book providers, vendors, and libraries may already be designating "audiobooks" as a separately searchable set based on the popular definition of an audiobook as an audio-only experience. Publications that include full text and full audio may not currently be grouped with audiobooks, so exposing this metadata adds additional publications to the list of titles audio users might be interested in.</p>
-                <p>Audiobooks presented without text are considered optimized publications. They do not meet all accessibility requirements, and therefore will not be discovered when filtering for "accessible" books, but they provide access to the publication for specific users who require audio. Providing a way for users to search a collection for all books with full audio will support these users, and including this information in the metadata displayed will also alert users for whom audio is inaccessible. This piece of metadata should be included only if the value is "Yes". Since most digital publications available do not include audio, it is only important to include this metadata in the user interface for those that do.</p>
+				<p>Some users, including users with dyslexia or visual impairments, seek publications they can use entirely by listening. Full Audio metadata is important to the discovery process for these users. Publication providers may already be designating "audiobooks" as a separately searchable set based on the popular definition of an audiobook as an audio-only experience. Publications that include full text and full audio may not currently be grouped with audiobooks, so exposing this metadata adds additional publications to the list of titles audio users might be interested in.</p>
+                <p>Audiobooks presented without text are considered optimized publications. They do not meet all accessibility requirements, and therefore will not be discovered when filtering for "accessible" publications, but they provide access to the publication for specific users who require audio. Providing a way for users to search a collection for all publications with full audio will support these users, and including this information in the metadata displayed will also alert users for whom audio is inaccessible. This piece of metadata should be included only if the value is "Yes". Since most digital publications available do not include audio, it is only important to include this metadata in the user interface for those that do.</p>
                 <h4>Implementation</h4>
                 <ul>
                     <li><a href="../techniques/epub-metadata.html#full-audio">EPUB Accessibility: Full Audio</a></li>
@@ -266,7 +273,7 @@
 				<h4>Definition</h4>
 				<p>To report the accessibility conformance of a publication, metadata for accessibility conformance should be provided. It declares the accessibility standard or accessibility specifications to which the publication conforms. The value can be a URL or a code which identifies the accessibility standard or accessibility specifications.</p>
 				<p class="note">In case of EPUB publications, it will usually point to the EPUB Accessibility specifications or WCAG.</p>
-				<p class="note">If a publication is optimized for a particular user group, e.g. an audiobook, it would not conform to WCAG guidelines, but it may be perfectly useable by a particular group, e.g. persons who are blind. In this case, the accessibility conformance metadata should identify the specification used to create the optimized publication.</p>
+				<p class="note">If a publication is optimized for a particular user group, e.g. an audiobook, it would not conform to WCAG guidelines, but it may be perfectly useable by a particular group (e.g. persons who are blind). In this case, the accessibility conformance metadata should identify the specification used to create the optimized publication.</p>
 				<h4>Rationale</h4>
 				<p>Discovery metadata enables publications to have their accessibility exposed regardless of the overall accessibility of the publication. A publication optimized for a particular group, such as an audiobook, would not meet WCAG 2.0, but it would be fully accessible to many people. The conformance metadata details the accessibility of the publication, which allows end users and educators to evaluate the suitability of the publication for individuals.</p>
                 
@@ -322,7 +329,7 @@
 				<h4>Definition</h4>
 				<p>The <i>Certifier Report</i> is an URL pointing to a web page where the certifier publishes a report detailing the accessibility of the publication.</p>
 				<h4>Rationale</h4>
-				<p>Providing a link to the complete report allows end users and organizations to review it. The user interface should display a link to the report.</p>
+				<p>Providing a link to the complete report allows end users and organizations to review the specifics of its conformance or failure to standards. The user interface should display a link to the report.</p>
                 <h4>Implementation</h4>
                 <ul>
                      <li><a href="../techniques/epub-metadata.html#certifier-report">EPUB Accessibility: Certifier Report</a></li>
@@ -351,7 +358,7 @@
 				<h3>All Accessibility Metadata</h3>
 				<p><b>Value</b>: Link to complete list of all metadata fields</p>
 				<h4>Definition</h4>
-				<p>It is a pointer to show the listing of all the accessibility metadata of the publication. It can be a hyperlink to another page or can be listed in HTML summary/details element. It should include metadata for <i>accessibilityFeature</i>, <i>accessibilityHazard</i>, <i>accessMode</i>, <i>accessModeSufficient</i> and all the accessibility metadata and conformance metadata listed above.</p>
+				<p>This field provides the listing of all accessibility metadata for the publication. It can be a hyperlink to another page or can be listed in HTML summary/details element. It should include metadata for <i>accessibilityFeature</i>, <i>accessibilityHazard</i>, <i>accessMode</i>, <i>accessModeSufficient</i> and all the accessibility metadata and conformance metadata listed above.</p>
 				<h4>Rationale</h4>
 				<p>A complete list of accessibility metadata is important for advanced users who would like to know about the presence of specific accessibility features in the publication. This listing is also important for verification of the interpretation of the accessibility metadata provided according to this user experience guide.</p>
                 <h4>Implementation</h4>
@@ -391,7 +398,7 @@
 			<section id="ipr">
 				<h3>Intellectual Property Rights</h3>
 				<ul>
-					<li>The accessibility icon used in <a href="#ex-bookFeatures">Example Book Features</a> is from <a href="https://www.w3.org/WAI/teach-advocate/accessibility-icon-set">Accessibility Icon Set from W3C WAI</a> Status:Draft</li>
+					<li>The accessibility icon used in <a href="#ex-bookFeatures">Example Book Features</a> is from <a href="https://www.w3.org/WAI/teach-advocate/accessibility-icon-set">Accessibility Icon Set from W3C WAI</a> Status: Draft.</li>
 				</ul>
 			</section>
             

--- a/UX-Guide-Metadata/principles/index.html
+++ b/UX-Guide-Metadata/principles/index.html
@@ -89,7 +89,7 @@
 		<section id="abstract">
 			<p>Finding, buying, and finally reading a publication is a very personal experience. For most of us this is routine. We go to a bookstore, search for the title we are interested in or perhaps browse the best sellers list, then purchase and start reading the publication.</p>
 			<p>Now consider you are blind and rely on an assistive technology to read the publication. You wonder: will my screen reader work with this title; are there image descriptions that will be spoken to describe these images; are there page numbers which are accessible; is the reading order correct so I don't hear a <q>caution</q> after reading a paragraph which could be dangerous? These are just a few of the accessibility concerns consumers have when trying to purchase and ultimately read a digital publication.</p>
-			<p>The good news is more and more publishers are creating publications that are <q>Born Accessible</q> (i.e., accessible from the outset, not fixed later) and getting the accessibility validation or audit done by independent organizations.</p>
+			<p>The good news is more and more publishers are creating publications that are Born Accessible (i.e., accessible from the outset, not fixed later) and getting the accessibility validation or audit done by independent organizations.</p>
 			<p>This document proposes a shared framework for presenting publication accessibility metadata in a user-friendly manner.</p>
 		</section>
 		<section id="sotd"></section>

--- a/UX-Guide-Metadata/principles/index.html
+++ b/UX-Guide-Metadata/principles/index.html
@@ -158,7 +158,7 @@
 				will then provide the information that is discussed below.</p>
             
 			<div class="note">
-				<p>When there is no accessibility metadata for this EPUB a statement should be displayed informing that there was no accessibility information provided.</p>
+				<p>When there is no accessibility metadata for this publication a statement should be displayed informing that there was no accessibility information provided.</p>
 			</div>
             
 			<p>In this example, a link to the accessibility information is provided with a traditional textual link.</p>


### PR DESCRIPTION
Mostly minor rewording suggestions in the earlier talkative sections of the guide.

The document jumped back and forth from "publication" to "book", so I standardized the language on "publication" since that's typically what we do to avoid book bias.

The only other slightly substantive change I've made is to move up the list of links in the section that describes the ordering. I find it helps to place it between the explanation of why there is ordering and the snippets that introduce the fields (e.g., so if you're in a hurry you can skim the list and move on).

But have a review and let me know if you disagree with any of it.