### PR TITLE
Update README.md

### DIFF
--- a/UX-Guide-Metadata/techniques/README.md
+++ b/UX-Guide-Metadata/techniques/README.md
@@ -1,5 +1,5 @@
  # Display Techniques for Displaying Accessibility Metadata
-- [Display Techniques for EPUB Accessibility Metadata](https://w3c.github.io/publ-a11y/UX-Guide-Metadata/techniques/epub-metadata.html)
-- [Display Techniques for ONIX Accessibility Metadata](https://w3c.github.io/publ-a11y/UX-Guide-Metadata/techniques/onix.html)
+- [Display Techniques for EPUB Accessibility Metadata](https://w3c.github.io/publ-a11y/UX-Guide-Metadata/techniques/epub-metadata/)
+- [Display Techniques for ONIX Accessibility Metadata](https://w3c.github.io/publ-a11y/UX-Guide-Metadata/techniques/onix/)
 
  


### PR DESCRIPTION
The references went to 404.

Actually, I wonder whether the target should be the github.io addresses or the `https://www.w3.org/publishing/...` addresses. I'd suspect the latter.