### PR TITLE
Add blank template for writing notes

### DIFF
--- a/templates/cg-note.html
+++ b/templates/cg-note.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+	<head>
+		<meta charset="utf-8" />
+		<title>Title</title>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
+		<script class="remove">
+			var respecConfig = {
+				group: "publishingcg",
+				edDraftURI: "https://w3c.github.io/publ-a11y/drafts/shortname/",
+				specStatus: "CG-DRAFT",
+				noRecTrack: true,
+				copyrightStart: "2022",
+				latestVersion: "https://w3c.github.io/publ-a11y/shortname",
+				editors: [
+					{
+						name: "",
+						company: "",
+						companyURL: "",
+						w3cid: 0
+					}
+				],
+				processVersion: 2020,
+				includePermalinks: true,
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				github:			 {
+					repoURL: "https://github.com/w3c/publ-a11y",
+					branch: "main"
+				}
+			};
+		</script>
+	</head>
+	<body>
+		<section id="abstract">
+			<p></p>
+		</section>
+		<section id="sotd"></section>
+	</body>
+</html>


### PR DESCRIPTION
This pull request just adds a stripped down template file to use when writing new notes. It's a nuisance to take old notes and remove all the unwanted parts each time, plus it often results in stale and unused metadata.