### PR TITLE
Added two list items about no markup and jargon

### DIFF
--- a/drafts/schema-a11y-summary/index.html
+++ b/drafts/schema-a11y-summary/index.html
@@ -95,13 +95,13 @@
 					For example, a publication intended to teach Spanish to English speaking students would have the
 					primary language as English.</li>
 				<li>Ensure the language of the accessibility summary is declared in the metadata.</li>
-				<li>It should be noted that markup in metadata is commonly not allowed. While it may be tempting to use headings, bullets, bold, or  other markup, this should not be used.</li>
+				<li>It should be noted that markup in metadata is commonly not allowed. While it may be tempting to use headings, bullets, bold, or  other markup, this must not be used.</li>
 
 				<li>Use simple language that communicates effectively to a non-technical and a non-accessibility aware
 					community.</li>
 				<li>Avoid terms that are only known in a specific knowledge domain, or explain the term in a simple
 					way.</li>
-					<li>The use of jargon or language that is not commonly understood should be avoided. It is better to explain  what is meant . For example, the term "reflow" may not be understood by most people. Saying, "This publication is in EPUB 3 and supports the selection of font size which will enlarge the text and then wrap to fit the screen" is better than saying this publication supports reflowable text.</li>
+					<li>The use of jargon or language that is not commonly understood should be avoided. It is better to explain what is meant. For example, the term "reflow" may not be understood by most people. Saying, "This publication is in EPUB 3 and supports the selection of font size which will enlarge the text and then wrap to fit the screen" is better than saying this publication supports reflowable text.</li>
 
 					
 				<li>Write out the words of the acronym before using the abbreviation, e.g. Web Content Accessibility

--- a/drafts/schema-a11y-summary/index.html
+++ b/drafts/schema-a11y-summary/index.html
@@ -89,16 +89,21 @@
 			<ul>
 				<li>There should only be one accessibility summary. Do not include multiple accessibility summaries in
 					different languages.</li>
-				<li>The language of the accessibility summary should be in the primary language of publication. For
+				<li>The language of the accessibility summary should be in the primary language of the publication. For
 					example, a publication in French should have the accessibility summary also in French. While some
 					publications may have many passages in another language, the primary language should be determined.
 					For example, a publication intended to teach Spanish to English speaking students would have the
 					primary language as English.</li>
 				<li>Ensure the language of the accessibility summary is declared in the metadata.</li>
+				<li>It should be noted that markup in metadata is commonly not allowed. While it may be tempting to use headings, bullets, bold, or  other markup, this should not be used.</li>
+
 				<li>Use simple language that communicates effectively to a non-technical and a non-accessibility aware
 					community.</li>
 				<li>Avoid terms that are only known in a specific knowledge domain, or explain the term in a simple
 					way.</li>
+					<li>The use of jargon or language that is not commonly understood should be avoided. It is better to explain  what is meant . For example, the term "reflow" may not be understood by most people. Saying, "This publication is in EPUB 3 and supports the selection of font size which will enlarge the text and then wrap to fit the screen" is better than saying this publication supports reflowable text.</li>
+
+					
 				<li>Write out the words of the acronym before using the abbreviation, e.g. Web Content Accessibility
 					Guidelines (WCAG).</li>
 				<li>Include all accessibility features, even those detailed in another schema.org metadata item;


### PR DESCRIPTION
This commit addes two list items in section 3. The no markup is one and the no jargon is the other. The no jargon is similar to the use plain language list item, but I think it works.
