### PR TITLE
Proposal for pageSource property

### DIFF
--- a/drafts/page-source-id/css/common.css
+++ b/drafts/page-source-id/css/common.css
@@ -1,0 +1,45 @@
+
+/****************************************************/
+/*  property tables                                 */
+/****************************************************/
+
+/* ensure confomity of width for property tables */
+table.tabledef {
+	border-spacing: 0px;
+	border: none;
+	font-size: 1em;
+	width: 100%
+}
+
+table.tabledef td, table.tabledef th {
+	border: none;
+	background-color: rgb(236,246,255);
+	color: rgb(0,0,0);
+	padding: 0.3em;
+	vertical-align: top;
+}
+
+table.tabledef th {
+    text-align: left;
+	vertical-align: top;
+    width: 8em;
+    padding-left: 1em;
+}
+
+table.tabledef th {
+    border-left: 5px solid rgb(145,200,255);
+}
+
+table.tabledef td {
+    padding: 3px 3px 3px 10px;
+}
+
+table.tabledef td > p:first-child {
+	padding: 0em;
+	margin: 0em
+}
+
+a code
+{
+    color: rgb(3,69,117) !important;
+}

--- a/drafts/page-source-id/index.html
+++ b/drafts/page-source-id/index.html
@@ -42,8 +42,8 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This proposal defines the <code>a11y:pageSource</code> property to identify the source of page markers
-				and the page list in EPUB publications.</p>
+			<p>This proposal defines the <code>a11y:pageBreakSource</code> property to identify the source of page
+				markers and the page list in EPUB publications.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="introduction">
@@ -89,8 +89,8 @@
 						source.</li>
 				</ol>
 
-				<p>The <code>pageSource</code> property proposed in this document is intended to provide a simple and
-					reliable solution to these problems moving forward.</p>
+				<p>The <code>pageBreakSource</code> property proposed in this document is intended to provide a simple
+					and reliable solution to these problems moving forward.</p>
 			</section>
 
 			<section id="sec-terminology">
@@ -106,17 +106,17 @@
 
 			<section id="conformance"></section>
 		</section>
-		<section id="pageSource">
-			<h2>The <code>pageSource</code> property</h2>
+		<section id="pageBreakSource">
+			<h2>The <code>pageBreakSource</code> property</h2>
 
-			<section id="pageSource-definition">
+			<section id="pageBreakSource-definition">
 				<h3>Definition</h3>
 
 				<table class="tabledef">
 					<tr>
 						<th>Name:</th>
 						<td>
-							<code>pageSource</code>
+							<code>pageBreakSource</code>
 						</td>
 					</tr>
 					<tr>
@@ -154,7 +154,7 @@
 					<p>In this example, the pagination corresponds to a print edition with an ISBN number. A URN is used
 						to identify the scheme the number conforms to.</p>
 					<pre>&lt;meta
-    property="a11y:pageSource">
+    property="a11y:pageBreakSource">
    urn:isbn:9780010010001
 &lt;/meta></pre>
 				</aside>
@@ -164,7 +164,7 @@
 						edition. The value <code>none</code> indicates that the pagination is not drawn from another
 						source.</p>
 					<pre>&lt;meta
-    property="a11y:pageSource">
+    property="a11y:pageBreakSource">
    none
 &lt;/meta></pre>
 				</aside>
@@ -173,7 +173,7 @@
 					<p>In this example, the name of the document and its format are used to identify the source of the
 						pagination.</p>
 					<pre>&lt;meta
-    property="a11y:pageSource">
+    property="a11y:pageBreakSource">
    Hobo eReader User Manual. PDF: https://example.org/manuals/hobo/
 &lt;/meta></pre>
 				</aside>

--- a/drafts/page-source-id/index.html
+++ b/drafts/page-source-id/index.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+	<head>
+		<meta charset="utf-8" />
+		<title>Page Source Identification</title>
+		<script src="js/css-inline.js" class="remove"></script>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
+		<script class="remove">
+			var respecConfig = {
+				group: "publishingcg",
+				edDraftURI: "https://w3c.github.io/publ-a11y/drafts/page-source-id/",
+				specStatus: "CG-DRAFT",
+				noRecTrack: true,
+				copyrightStart: "2022",
+				latestVersion: "https://w3c.github.io/publ-a11y/page-source-id",
+				editors: [
+					{
+						name: "Matt Garrish",
+						company: "DAISY Consortium",
+						companyURL: "http://daisy.org",
+						w3cid: 51655
+					}
+				],
+				processVersion: 2020,
+				includePermalinks: true,
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				github:			 {
+					repoURL: "https://github.com/w3c/publ-a11y",
+					branch: "main"
+				},
+				preProcess:[inlineCustomCSS],
+				localBiblio: {
+					"epub-3": {
+						"title": "EPUB 3",
+						"href": "https://www.w3.org/TR/epub/",
+						"publisher": "W3C"
+					}
+				}
+			};
+		</script>
+	</head>
+	<body>
+		<section id="abstract">
+			<p>This proposal defines the <code>a11y:pageSource</code> property to identify the source of page markers
+				and the page list in EPUB publications.</p>
+		</section>
+		<section id="sotd"></section>
+		<section id="introduction">
+			<h2>Introduction</h2>
+
+			<section id="background">
+				<h3>Background</h3>
+
+				<p>Providing navigation to static page break markers is a key accessibility feature for digital
+					publications that are used in both print and digital formats in the same environment (e.g.,
+					classrooms). But without a means of identifying what edition of a static work the page navigation
+					corresponds to, it is impossible for users to determine if the publication will be sufficient for
+					their needs. For example, if a class uses a softcover edition of a book and the EPUB publication
+					pagination corresponds to the hardcover, digital users will not be able to access the same page
+					break locations.</p>
+
+				<p>How to identify the source of pagination has been a continuing problem in the EPUB 3 metadata. The
+					original idea was to use a <a href="https://www.w3.org/TR/epub/#sec-opf-dcmes-optional-def"
+							><code>dc:source</code> element</a> [[epub-3]] to specify the pagination. This method proved
+					unreliable both for machine verification that the EPUB creator had set the method and to extract and
+					present the information to users. Publishers sometimes specify multiple sources for their
+					publications in multiple <code>dc:source</code> elements, making it impossible for a machine to
+					determine which identifies the source.</p>
+
+				<p>To address this problem, the specification then introduced a "<a
+						href="https://www.w3.org/TR/epub/#attrdef-refines">refinement</a>" [[epub-3]] property called <a
+						href="https://www.w3.org/TR/epub/#sec-source-of"><code>source-of</code></a> [[epub-3]] whose
+					only purpose was to indicate which <code>dc:source</code> property identified the source.</p>
+
+				<p>Since its addition, however, two additional problems have surfaced with this approach:</p>
+
+				<ol>
+					<li>It was defined in a way that makes it unique to EPUB 3's metadata format. When the
+							<code>refines</code> attribute was nearly dropped in EPUB 3.1, it exposed that there was
+						still no other way to express this information. Consequently, future formats cannot rely on the
+							<code>source-of</code> property.</li>
+					<li>Relying on <code>dc:source</code> makes it confusing how to state that a digital-only
+						publication does not have a source for its markers. EPUB creators have resorted to identifying
+						the current publication as the source of itself or saying that the publication has a source of
+						nothing for the pagination, neither of which makes much sense logically and are at best hacks of
+						the metadata. Omitting a <code>dc:source</code>, while accurate in this situation, makes
+						validation difficult as it cannot be determined whether the EPUB creator simply forgot to
+						specify the source.</li>
+				</ol>
+
+				<p>The <code>pageSource</code> property proposed in this document is intended to provide a simple and
+					reliable solution to these problems moving forward.</p>
+			</section>
+
+			<section id="sec-terminology">
+				<h3>Terminology</h3>
+
+				<p>This specification uses <a href="https://www.w3.org/TR/epub/#sec-terminology">terminology defined in
+						EPUB 3</a> [[epub-3]].</p>
+
+				<div class="note">
+					<p>Only the first instance of a term in a section links to its definition.</p>
+				</div>
+			</section>
+
+			<section id="conformance"></section>
+		</section>
+		<section id="pageSource">
+			<h2>The <code>pageSource</code> property</h2>
+
+			<section id="pageSource-definition">
+				<h3>Definition</h3>
+
+				<table class="tabledef">
+					<tr>
+						<th>Name:</th>
+						<td>
+							<code>pageSource</code>
+						</td>
+					</tr>
+					<tr>
+						<th>Description:</th>
+						<td>
+							<p>Provides a unique identifier for the source of the page break markers in an <a
+									href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a>.</p>
+							<p>The identifier should be expressed as a URN when the value conforms to a recognized
+								scheme such as an ISBN.</p>
+							<p>If a unique identifier does not exist for the source, EPUB creators should use a text
+								description that identifies the source as clearly as possible (e.g., the title of a word
+								processing document).</p>
+							<p>If the page break markers are unique to the EPUB publication (e.g., for a digital-only
+								edition), EPUB creators MUST specify the value "<code>none</code>".</p>
+						</td>
+					</tr>
+					<tr>
+						<th>Allowed value(s):</th>
+						<td>
+							<code>xsd:string</code>
+						</td>
+					</tr>
+					<tr>
+						<th>Cardinality:</th>
+						<td>Exactly one when the publication includes a page list and/or page break markers, otherwise
+							0.</td>
+					</tr>
+				</table>
+			</section>
+
+			<section id="examples">
+				<h3>Examples</h3>
+
+				<aside class="example" title="Pagination from a source with a unique identifier">
+					<p>In this example, the pagination correponds to a print edition with an ISBN number. A URN is used
+						to identify the scheme the number conforms to.</p>
+					<pre>&lt;meta
+    property="a11y:pageSource">
+   urn:isbn:9780010010001
+&lt;/meta></pre>
+				</aside>
+
+				<aside class="example" title="Pagination without a source">
+					<p>In this example, the publisher has added the page break markers and page list for a digital-only
+						edition. The value <code>none</code> indicates that the pagination is not drawn from another
+						source.</p>
+					<pre>&lt;meta
+    property="a11y:pageSource">
+   none
+&lt;/meta></pre>
+				</aside>
+
+				<aside class="example" title="Pagination from a source without a unique identifier">
+					<p>In this example, the name of the document and its format are used to identify the source of the
+						pagination.</p>
+					<pre>&lt;meta
+    property="a11y:pageSource">
+   Hobo eReader User Manual. PDF: https://example.org/manuals/hobo/
+&lt;/meta></pre>
+				</aside>
+			</section>
+		</section>
+	</body>
+</html>

--- a/drafts/page-source-id/index.html
+++ b/drafts/page-source-id/index.html
@@ -42,8 +42,8 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This proposal defines the <code>a11y:pageBreakSource</code> property to identify the source of page
-				markers and the page list in EPUB publications.</p>
+			<p>This proposal defines the <code>pageBreakSource</code> property to identify the source of page markers
+				and the page list in EPUB publications.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="introduction">
@@ -154,7 +154,7 @@
 					<p>In this example, the pagination corresponds to a print edition with an ISBN number. A URN is used
 						to identify the scheme the number conforms to.</p>
 					<pre>&lt;meta
-    property="a11y:pageBreakSource">
+    property="pageBreakSource">
    urn:isbn:9780010010001
 &lt;/meta></pre>
 				</aside>
@@ -164,7 +164,7 @@
 						edition. The value <code>none</code> indicates that the pagination is not drawn from another
 						source.</p>
 					<pre>&lt;meta
-    property="a11y:pageBreakSource">
+    property="pageBreakSource">
    none
 &lt;/meta></pre>
 				</aside>
@@ -173,7 +173,7 @@
 					<p>In this example, the name of the document and its format are used to identify the source of the
 						pagination.</p>
 					<pre>&lt;meta
-    property="a11y:pageBreakSource">
+    property="pageBreakSource">
    Hobo eReader User Manual. PDF: https://example.org/manuals/hobo/
 &lt;/meta></pre>
 				</aside>

--- a/drafts/page-source-id/index.html
+++ b/drafts/page-source-id/index.html
@@ -80,13 +80,13 @@
 							<code>refines</code> attribute was nearly dropped in EPUB 3.1, it exposed that there was
 						still no other way to express this information. Consequently, future formats cannot rely on the
 							<code>source-of</code> property.</li>
-					<li>Relying on <code>dc:source</code> makes it confusing how to state that a digital-only
-						publication does not have a source for its markers. EPUB creators have resorted to identifying
-						the current publication as the source of itself or saying that the publication has a source of
-						nothing for the pagination, neither of which makes much sense logically and are at best hacks of
-						the metadata. Omitting a <code>dc:source</code>, while accurate in this situation, makes
-						validation difficult as it cannot be determined whether the EPUB creator simply forgot to
-						specify the source.</li>
+					<li>Relying on <code>dc:source</code> confuses how to state that a digital-only publication does not
+						have a source for its markers. EPUB creators have resorted to identifying the current
+						publication as the source of itself or saying that the publication has a source of nothing for
+						the pagination, neither of which makes much sense logically and are at best hacks of the
+						metadata. Omitting a <code>dc:source</code>, while accurate in this situation, makes validation
+						difficult as it cannot be determined whether the EPUB creator simply forgot to specify the
+						source.</li>
 				</ol>
 
 				<p>The <code>pageSource</code> property proposed in this document is intended to provide a simple and
@@ -151,7 +151,7 @@
 				<h3>Examples</h3>
 
 				<aside class="example" title="Pagination from a source with a unique identifier">
-					<p>In this example, the pagination correponds to a print edition with an ISBN number. A URN is used
+					<p>In this example, the pagination corresponds to a print edition with an ISBN number. A URN is used
 						to identify the scheme the number conforms to.</p>
 					<pre>&lt;meta
     property="a11y:pageSource">

--- a/drafts/page-source-id/js/css-inline.js
+++ b/drafts/page-source-id/js/css-inline.js
@@ -1,0 +1,36 @@
+
+function inlineCustomCSS() {
+    
+    var customCSS = getCSS();
+    
+    if (customCSS == '') { return; }
+    
+    var style = document.createElement('style');
+    	style.textContent = customCSS;
+    
+    document.getElementsByTagName('head')[0].appendChild(style);
+    
+}
+
+function getCSS() {
+    
+    try {
+        var xmlhttp = new XMLHttpRequest();
+        
+        xmlhttp.open('GET', 'css/common.css', false);
+        xmlhttp.send();
+        
+        if (xmlhttp.status == 200) {
+           return xmlhttp.responseText;
+        }
+        else {
+           console.error('Failed to read CSS file css/common.css. Returned status: ' + xmlhttp.status);
+           return '';
+        }
+    }
+    
+    catch (e) {
+        console.error(e);
+        return '';
+    }
+}


### PR DESCRIPTION
The problems with our use of dc:source to identify the source of pagination has come up again in discussions around the accessibility metadata. The dc:source element is too generic, as we discovered between 3.0 and 3.0.1, and the hack of a "source-of" property is as doomed as the `refines` attribute. It also makes for confusion when there is no source, as you can't say that a source of something is nothing and that nothing is the source of the pagination. We're hacking on hacks.

This PR is a proposal to create an `a11y:pageSource` property to finally deal with this issue properly. It removes the ambiguity of dc:source and makes more sense when used with a value like "none" for digital-only editions.

The preview is available here: https://raw.githack.com/w3c/publ-a11y/feature/page-source-id/drafts/page-source-id/index.html