### PR TITLE
Add note about potential ambiguity in naming of tts reading options

### DIFF
--- a/drafts/audio-playback/index.html
+++ b/drafts/audio-playback/index.html
@@ -122,9 +122,9 @@
 				full audio are never as simple to load and play as pure audiobooks are because there are control files
 				that a simple audio playback device does not understand.</p>
 
-			<p>Full audio publications are often referred to as "read aloud books" because publishers commonly use
-				synchronized text and audio playback in children's works. Children can follow the text as the Reading
-				System plays back the audio.</p>
+			<p>Full audio publications are often referred to as "<dfn>read aloud books</dfn>" because publishers
+				commonly use synchronized text and audio playback in children's works. Children can follow the text as
+				the Reading System plays back the audio.</p>
 		</section>
 		<section id="tts">
 			<h2>Text-To-Speech Synthesis</h2>
@@ -142,7 +142,14 @@
 
 			<p>Unlike audiobooks and publications with full audio, however, Text-To-Speech synthesis is not an audio
 				format. It is a way of listening to text content the reader has already obtained. Readers can use a TTS
-				application to read their EPUB publications, for example.</p>
+				application to read their EPUB publications.</p>
+
+			<div class="note">
+				<p>The names some reading systems give their Text-to-Speech playback feature can be confusingly similar
+					to "<a>read aloud books</a>". For example, a button named "Read Now" might initiate Text-to-Speech
+					playback. The distinguishing feature between the two is that Text-to-Speech playback employs
+					on-the-fly voice synthesizing.</p>
+			</div>
 
 			<p>The applications that provide Text-To-Speech synthesis for persons with disabilities are usually not
 				specifically designed for reading publications, however. They are general tools that aid navigation


### PR DESCRIPTION
This pull request adds a note to the TTS section to address the issue of a "read now" TTS option sounding similar to "read aloud books" full audio publication. The naming doesn't change the fundamental concepts of a full audio publication versus TTS synthesis.

This PR addresses the final issue that was raised when we resolved to publish the document, so merging will also gives us the green light to publish.