### PR TITLE
Edits discussed in editors' call

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -153,29 +153,9 @@
 		<section id="ui-technical-details">
 			<h2>UI Technical Details</h2>
 			<p>When you have accessibility metadata about a digital publication, it is important to share this information in as user-friendly a way as possible. At a very high level, when displaying information about a digital publication, you may only want to acknowledge that <q>Accessibility Features</q> or <q>Accessibility Information</q> is available. If the user would like to get at this information, they can click a text or image link which will then provide the information that is discussed below.</p>
-            
 			<div class="note">
 				<p>When a publisher does not provide any accessibility metadata for a publication, a statement should be displayed to the user informing them that no information was supplied.</p>
 			</div>
-            
-			<p>In this example, a link to the accessibility information is provided with a traditional textual link.</p>
-			<aside class="example">
-				<p>Title: Huckleberry Finn</p>
-				<p>Author: Mark Twain</p>
-				<p>Copyright: 1999</p>
-				<p>ISBN: 9780486110035</p>
-				<p>Publisher: Dover Publications</p>
-				<p>Book Features: <u>Accessibility Information</u>
-					<i>(textual link to accessibility information below)</i></p>
-			</aside>
-			<p>Alternatively, this link to the accessibility information could be provided with a clickable image.</p>
-			<aside id="ex-bookFeatures" class="example">
-				<p>Book Features:</p>
-				<p><img  src="./media/accessibility.svg" alt="Accessibility Information" width="75" /></p>
-				<p><i>(clickable image to accessibility information below)</i></p>
-				<p><i>Suggested Alt-text for image <q>Accessibility Information</q></i></p>
-			</aside>
-            
             <section id="techniques">
                 <h3>Techniques</h3>
                 <p>To assist developers in implementing these guidelines, in-depth notes are available to explain how to extract information from publishing industry metadata standards.</p>
@@ -185,8 +165,6 @@
 					<li><p><a href="../techniques/onix-metadata/index.html">ONIX Accessibility Metadata</a></p></li>
 				</ul>
             </section>
-            
-            
 		</section>
         
 		<section id="order-of-key-information">
@@ -336,6 +314,27 @@
 
 			</section>
 			
+		</section>
+		
+		<section id="examples">
+			<h2>Examples</h2>
+			<p>In this example, a link to the accessibility information is provided with a traditional textual link.</p>
+			<aside class="example">
+				<p>Title: Huckleberry Finn</p>
+				<p>Author: Mark Twain</p>
+				<p>Copyright: 1999</p>
+				<p>ISBN: 9780486110035</p>
+				<p>Publisher: Dover Publications</p>
+				<p>Book Features: <u>Accessibility Information</u>
+					<i>(textual link to accessibility information below)</i></p>
+			</aside>
+			<p>Alternatively, this link to the accessibility information could be provided with a clickable image.</p>
+			<aside id="ex-bookFeatures" class="example">
+				<p>Book Features:</p>
+				<p><img  src="./media/accessibility.svg" alt="Accessibility Information" width="75" /></p>
+				<p><i>(clickable image to accessibility information below)</i></p>
+				<p><i>Suggested Alt-text for image <q>Accessibility Information</q></i></p>
+			</aside>
 		</section>
 
 		<section id="app-acknowledgements" class="appendix informative">


### PR DESCRIPTION
I made these two changes:

- Move examples in section 3 to the bottom of the document.
- Remove a part of section 4 that states about order of key information.