### PR TITLE
Fix conformance statement definitions and modify example titles

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -562,25 +562,25 @@
 						<dt>This publication meets accepted accessibility standards.</dt>
 						<dd>
 							<p>The publication contains a conformance claim that it meets WCAG 2 Level AA, but no
-								evaluator information is provided.</p>
+								evaluator information is provided or conformance is self-certified by the publisher.</p>
 						</dd>
 
 						<dt>This publication meets minimum accessibility standards.</dt>
 						<dd>
 							<p>The publication contains a conformance claim that it meets WCAG 2 Level A, but no
-								evaluator information is provided.</p>
+								evaluator information is provided or conformance is self-certified by the publisher.</p>
 						</dd>
 
 						<dt>This publication is certified to meet accepted accessibility standards.</dt>
 						<dd>
-							<p>The publication contains a conformance claim that it meets WCAG 2 Level AA, and the
-								evaluator's information is provided.</p>
+							<p>The publication contains a conformance claim that it meets WCAG 2 Level AA, and
+								conformance is certified by a third-party evaluator.</p>
 						</dd>
 
 						<dt>This publication is certified to meet minimum accessibility standards.</dt>
 						<dd>
-							<p>The publication contains a conformance claim that it meets WCAG 2 Level A, and the
-								evaluator's information is provided.</p>
+							<p>The publication contains a conformance claim that it meets WCAG 2 Level A, and
+								conformance is certified by a third-party evaluator.</p>
 						</dd>
 
 						<dt>This publication's accessibility conformance has not been associated with accepted
@@ -654,7 +654,7 @@
 						compact statement that covers the whole conformance group. Either the descriptive or compact
 						style is appropriate, but do not provide both approaches.</p>
 
-					<aside class="example" title="Additional Accessibility Information shown as individual statements">
+					<aside class="example" title="Additional Accessibility Information with descriptive statements">
 						<p>This publication is certified to meet accepted accessibility standards.</p>
 
 						<details><summary>Additional Accessibility Information</summary>
@@ -672,7 +672,7 @@
 						</details>
 					</aside>
 
-					<aside class="example" title="Additional Accessibility Information statements shown as a paragraph">
+					<aside class="example" title="Additional Accessibility Information with a compact statement">
 						<p>This publication meets accepted accessibility standards.</p>
 						<details><summary>Additional Accessibility Information</summary>
 							<p>This publication meets accepted accessibility recommendations and reports (EPUB
@@ -683,7 +683,8 @@
 						</details>
 					</aside>
 
-					<aside class="example" title="Unknown accessibility conformance">
+					<aside class="example"
+						title="Unknown accessibility conformance with a compact Additional Accessibility Information statement">
 						<p>Conformance to accepted standards for accessibility of this publication cannot be
 							determined.</p>
 						<details><summary>Additional Accessibility Information</summary>


### PR DESCRIPTION
These fixes are based on what I heard on the call, but let me know if you want something else.

[Preview](https://raw.githack.com/w3c/publ-a11y/principles/conf-fixes/UX-Guide-Metadata/draft/principles/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/principles/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/publ-a11y/principles/conf-fixes/UX-Guide-Metadata/draft/principles/index.html)
