### PR TITLE
Added the logo or badge option

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -578,7 +578,7 @@ George asks why is details used here?</detail>
 
 						<dt>Certifier's Credentials </dt>
 						<dd>If the certifier has a badge or a credential, then the text is provided. If there is a link
-							to their credential, then this can be provided as a link.</dd>
+							to their credential, then this can be provided as a link.If the certifier has a logo or badge, this can be displayed. The display of the logo or badge can be arranged between the certifier and the distributor showing the accessibility metadata.</dd>
 
 						<dt>This publication's accessibility conformance has not been associated with accepted
 							standards.</dt>


### PR DESCRIPTION
I added "If the certifier has a logo or badge, this can be displayed. The display of the logo or badge can be arranged between the certifier and the distributor showing the accessibility metadata. "

This is only in one place. I did not add it to the examples. If we want to add it to the examples, we would need to find a logo to use and then we get into styling the image and all of that.