### PR TITLE
Visual adjustments updates for ONIX techniques

### DIFF
--- a/UX-Guide-Metadata/draft/techniques/onix-metadata/index.html
+++ b/UX-Guide-Metadata/draft/techniques/onix-metadata/index.html
@@ -217,13 +217,13 @@
 				<ol class="condition">
 					<li>
 						<span><b>IF</b> <var>all_textual_content_can_be_modified</var>:</span>
-						<span><b>THEN</b> display "<code id="visual-adjustments-1">Appearance can be modified</code>".</span>
+						<span><b>THEN</b> display <code id="visual-adjustments-1">"Appearance can be modified"</code>.</span>
 					</li>
 					<li>
 						<span><b>ELSE IF</b> <var>is_fixed_layout</var>:</span>
-						<span><b>THEN</b> display "<code id="visual-adjustments-2">Appearance cannot be modified</code>".</span>
+						<span><b>THEN</b> display <code id="visual-adjustments-2">"Appearance cannot be modified"</code>.</span>
 					</li>
-					<li><b>ELSE</b> display "<code id="visual-adjustments-3">Appearance modifiability not known</code>".</li>
+					<li><b>ELSE</b> display <code id="visual-adjustments-3">"Appearance modifiability not known"</code>.</li>
 				</ol>
 			</section>
 			

--- a/UX-Guide-Metadata/draft/techniques/onix-metadata/index.html
+++ b/UX-Guide-Metadata/draft/techniques/onix-metadata/index.html
@@ -51,6 +51,17 @@
 	  	code.xpath {
 	  		word-break: keep-all;
 	  	}
+	  	code[id]::before, code[id]::after {
+			background: #faa;
+			border-radius: 3px;
+			font: normal normal 400 1em/1.2 monospace;
+			margin-left: 0.2em;
+			padding: 0.1em;
+		}
+		code[id]::after {
+			content: "[ID: " attr(id) "]";
+		}
+		/*html::before { content: "<html>"; }*/
 	  </style>
 	</head>
 	<body>
@@ -190,29 +201,17 @@
 						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/36">code 36 of codelist 196</a> (All textual content can be modified) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
 						<p><i>All textual content can be modified</i> means that the digital publication does not restrict the ability of users to modify and reflow the display of any textual content to the full extent allowed by the reading system (i.e. to change the text size or typeface, line height and word spacing, colors).</p>
 					</dd>
-					<dt><var>real_text</var></dt>
+					<dt><var>is_fixed_layout</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/81/10">code 10 of codelist 81</a> (Text) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
-						<p><i>Text</i> means that digital publication contains "real" text (user-selectable) as its main content (or as secondary content).</p>
-					</dd>
-					<dt><var>text_within_images</var></dt>
-					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/81/45">code 45 of codelist 81</a> (Text within images) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
-						<p><i>Text within images</i> means that digital publication contains text within images (i.e. text in diagrams, charts or balloons on which the user will not be able to change the display settings) as its main content (or as secondary content).</p>
-					</dd>
-					<dt><var>images_of_text</var></dt>
-					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/81/49">code 49 of codelist 81</a> (Images of text) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
-						<p><i>Images of text</i> means that digital publication contains images of text (i.e. pictures of text on which the user will not be able to change the display settings) as its main content (or as secondary content).</p>
+						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/175/E201">code E201 of codelist 175</a> (Fixed format) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p><i>Fixed format</i> means that digital publication is in fixed format (e.g. EPUB Fixed Layout).</p>
 					</dd>
 				</dl>
 				<h4>Variables setup</h4>
 				<ol class="condition">
 					<li><b>LET</b> <var>onix</var> be the result of calling <a href="#pre-processing">pre processing</a> given <var>onix_record_as_text</var>.</li>
 					<li><b>LET</b> <var>all_textual_content_can_be_modified</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "36"]</code>.</li>
-					<li><b>LET</b> <var>real_text</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/PrimaryContentType[text() = "10"]</code> <b>OR</b> the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductContentType[text() = "10"]</code>.</li>
-					<li><b>LET</b> <var>text_within_images</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/PrimaryContentType[text() = "45"]</code> <b>OR</b> the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductContentType[text() = "45"]</code>.</li>
-					<li><b>LET</b> <var>images_of_text</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/PrimaryContentType[text() = "49"]</code> <b>OR</b> the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductContentType[text() = "49"]</code>.</li>
+					<li><b>LET</b> <var>is_fixed_layout</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormDetail[text() = "E201"]</code> <b>AND</b> <b>NOT</b> the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormDetail[text() = "E200"]</code>.</li>
 				</ol>
 				<h4>Instructions</h4>
 				<ol class="condition">
@@ -221,14 +220,10 @@
 						<span><b>THEN</b> display "<code id="visual-adjustments-1">Appearance can be modified</code>".</span>
 					</li>
 					<li>
-						<span><b>ELSE IF</b> <var>real_text</var> <b>AND</b> <b>NOT</b> <var>all_textual_content_can_be_modified</var>:</span>
+						<span><b>ELSE IF</b> <var>is_fixed_layout</var>:</span>
 						<span><b>THEN</b> display "<code id="visual-adjustments-2">Appearance cannot be modified</code>".</span>
 					</li>
-					<li>
-						<span><b>ELSE IF</b> <var>text_within_images</var> <b>OR</b> <var>images_of_text</var>:</span>
-						<span><b>THEN</b> display "<code id="visual-adjustments-3">Appearance cannot be modified for all textual content</code>".</span>
-					</li>
-					<li><b>ELSE</b> display "<code id="visual-adjustments-4">Appearance modifiability not known</code>".</li>
+					<li><b>ELSE</b> display "<code id="visual-adjustments-3">Appearance modifiability not known</code>".</li>
 				</ol>
 			</section>
 			


### PR DESCRIPTION
Here are the changes made:

- simplified the technique by removing the per infer calculations, leaving only the all_textual_content_can_be_modified and is_fixed_layout options
- visually showed IDs bound to strings to be shown on screen: created red labels (formatting can be changed); they are created automatically via CSS

Can you check that assistive technologies read the labels with IDs? With VoiveOver and Chrome on Mac they seem to work.