### PR TITLE
Updated hazard and fixed typo

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -293,7 +293,7 @@
 							<!--if Display transformability is present-->
 							<li>Appearance cannot be modified.</li>
 							<!--if display transformability is not present and text on visual is present-->
-							<li>Appearance Modifiability not known.</li>
+							<li>Ability to modify the appearance is not known.</li>
 							<!--if neither display transformability nor text on visual are presents-->
 						</ul>
 					</aside>
@@ -714,7 +714,8 @@
 					negatively. This is because users search for content that is safe for them as well as want to know
 					when content is potentially dangerous to them.</p>
 
-				<p>This group should always be displayed. Indicate that no metadata is provided if that is the case.</p>
+				<p>The hazards property vocabulary includes a value of unknown, which means the content creater  of the metadata explicitly acknowledges that the resource has not been checked for hazards. This is different than providing no metadata for this property which does not carry any meaning.
+</p>
 
 				<section id="hazards-examples">
 					<h4>Examples</h4>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -714,7 +714,7 @@
 					negatively. This is because users search for content that is safe for them as well as want to know
 					when content is potentially dangerous to them.</p>
 
-				<p>The hazards property vocabulary includes a value of unknown, which means the content creater  of the metadata explicitly acknowledges that the resource has not been checked for hazards. This is different than providing no metadata for this property which does not carry any meaning.
+				<p>The hazards property vocabulary includes a value of unknown, which means the content creator of the metadata explicitly acknowledges that the resource has not been checked for hazards. This is different than providing no metadata for this property which does not carry any meaning.
 </p>
 
 				<section id="hazards-examples">


### PR DESCRIPTION
I made one change where Charles said: Shouldn't modifiability be lower case?
I changed that whole line to read:
Ability to modify the appearance is not known.

This change makes localization easier because people do not need a way to express modifyability.

The second change is based on the suggestion from Madeleine which is:
If we aren't including this line for any other optional metadata group, we should probably remove the whole paragraph as it was part of the previous decision, now overridden.
We may want a new paragraph that teases out "unknown" vs "no metadata". Here's a draft for comments:
The hazards property vocabulary includes a value of unknown, which means the author of the metadata explicitly acknowledges that the resource has not been checked for hazards. This is different than providing no metadata for this property which does not carry any meaning.

I changed author to content creator.
In the hazards section 
