### PR TITLE
Changed the sequencquence and add unknown to nonvisual

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -238,8 +238,8 @@
 			<div class="note">
 				<p>When the content creator does not provide any accessibility metadata for a publication, the three
 					pieces of key information that should always be present can still be shown (with an indication that
-					the information is missing): <a href="#supports-nonvisual-reading">Supports nonvisual reading</a>,
-						<a href="#visual-adjustments">Visual adjustments</a> and <a href="#conformance-group"
+					the information is missing): <a href="#visual-adjustments">Visual adjustments</a>, <a href="#supports-nonvisual-reading">Supports nonvisual reading</a>,
+						and <a href="#conformance-group"
 						>Conformance</a>.</p>
 			</div>
 
@@ -347,6 +347,8 @@
 								electronic braille.</li>
 							<li>Not all of the content will be available in generated read aloud speech and electronic
 								braille.</li>
+<li>It is not known if thecontent will be available in generated read aloud speech and electronic
+								braille</li>
 						</ul>
 					</aside>
 
@@ -355,6 +357,7 @@
 							<li>Readable in read aloud and braille.</li>
 							<li>May not be fully readable in read aloud and braille.</li>
 							<li>Not fully readable in read aloud and braille.</li>
+<li>Not known ifReadable in read aloud and braille</li>
 						</ul>
 					</aside>
 				</section>


### PR DESCRIPTION
I changed the sequence in the first note in section 3. This just switching one item in that list in the paragraph.

In the nonvisual section, I added the unknown. I think this is the condition where there is no related accessibility metadata.

I am wondering if the logic we are using supports this in the techniques. If a variable is false, will we know if there is no medtadata for this or if the value indicates that it is not accessible.

We will need to talk about this on the editors call.