### PR TITLE
Added note with text from comment in 271

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -196,6 +196,9 @@
 						<p><a href="../techniques/onix-metadata/index.html">ONIX Accessibility Metadata</a></p>
 					</li>
 				</ul>
+<div class="note">
+<p>Publishers update their ONIX records as needed. We expect unknown accessibility metadata will be provided as more information becomes known. For this reason, implementors should be prepared to update the accessibility metadata as new ONIX feeds are made available.</p>
+</div>
 			</section>
 
 		</section>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -197,7 +197,7 @@
 					</li>
 				</ul>
 <div class="note">
-<p>Publishers update their ONIX records as needed. We expect unknown accessibility metadata will be provided as more information becomes known. For this reason, implementors should be prepared to update the accessibility metadata as new ONIX feeds are made available.</p>
+<p>Publishers update their ONIX records as needed. We expect "unknown" accessibility metadata may be initially provided but may change as more information becomes available. For this reason, implementors should be prepared to update the accessibility metadata as new ONIX feeds are made available.</p>
 </div>
 			</section>
 


### PR DESCRIPTION
I took the text from the comment in 271. I put it at the end of the section that links to the techniques. The text says:
Publishers update their ONIX records as needed. We expect unknown accessibility metadata will be provided as more information becomes known. For this reason, implementors should be prepared to update the accessibility metadata as new ONIX feeds are made available.