### PR TITLE
Removed redundant info in details

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -497,7 +497,7 @@
 						<p>The certifier's credential is "Enterprise Accessibility Rating."</p>
 
 						<p>Detailed Conformance Information:</p>
-						<p>This publication claims to meet accepted accessibility standards and reports (EPUB
+						<p>This publication reports (EPUB
 								Accessibility 1.1 and Web Accessibility Content Guidelines (WCAG) 2.1 Level AA.) This publication was certified on 2021-09-07by Foo's Accessibility Testing with a credential of
 							"Enterprise Accessibility Rating." For more information, refer to the <a
 									href="http://www.example.com/a11y/report/9780000000001">certifier's report.</a></p>
@@ -512,7 +512,7 @@
 						<p>The certifier's credential is "Enterprise Accessibility Rating."</p>
 
 						<p>Detailed Conformance Information:</p>
-						<p>This publication claims to meet minimum accessibility standards and reports (EPUB
+						<p>This publication reports (EPUB
 							Accessibility 1.1 and the Web Content Accessibility Guidelines (WCAG) 2.1 Level A). The
 							publication was certified on 2021-09-07 by Foo's Accessibility Testing with a credential of
 							"Enterprise Accessibility Rating." For more information refer to the <a


### PR DESCRIPTION
I agree with Gregorio that the repeating of the meets accepted or minimum is not needed in the details. It now says "This publication reports..." This is in the two details.