### PR TITLE
added new EPUB Charts, Diagrams, and Formulas Technique

### DIFF
--- a/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
+++ b/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
@@ -361,6 +361,84 @@
 			<section id="charts-diagrams-and-formulas">
 				<h3>Charts, diagrams, and formulas</h3>
 				<p>This technique relates to <a href="https://www.w3.org/2021/09/UX-Guide-metadata-2.0/principles/#charts-diagrams-and-formulas">Charts, diagrams, and formulas key information</a>.</p>
+                
+                <p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
+				<h4>Understanding the variables</h4>
+				<dl>
+					<dt><var>contains_charts_diagrams</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityFeature="chartOnVisual"</i> (charts encoded in visual form) is present in the OPF file, otherwise if false it means that the metadata is not present.</p>                   
+						<p>This means that there is a positive indication that the product has some information conveyed via some form of illustration, such as a graph, a chart, a diagram, a figure, etc).</p>
+					</dd>
+					<dt><var>long_text_descriptions</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityFeature="longDescriptions"</i> (Full alternative textual description) is present in the OPF file, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that a full alternative textual description has been supplied for all of the graphs, charts, diagrams, or figures necessary to understand the content.</p>
+					</dd>
+					<dt><var>contains_chemical_formula</var></dt>
+					<dd>              
+						<p>If true it indicates that the <i>accessibilityFeature="chemOnVisual"</i> (Chemical content) is present in the OPF file, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that the publication contains chemical notations, formulae.</p>
+					</dd>
+					<dt><var>chemical_formula_as_chemml</var></dt>
+					<dd>
+						<p>If true it indicates that the <i>accessibilityFeature="ChemML"</i> (Accessible chemistry content as ChemML) is present in the OPF file, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that the chemical formulae are presented using ChemML and works with compatible assistive technology.</p>
+					</dd>
+					<dt><var>contains_math_formula</var></dt>
+					<dd>
+						<p>If true it indicates that the <i>accessibilityFeature="describedMath"</i> (Mathematical content) is present in the OPF file, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that the publication contains mathematical notation, equations, formulae.</p>
+					</dd>
+					<dt><var>math_formula_as_latex</var></dt>
+					<dd>
+						<p>If true it indicates that the <i>accessibilityFeature="latex"</i> (Accessible math content as LaTeX) is present in the OPF file, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that the chemical formulae are presented using LaTeX and works with compatible assistive technology.</p>
+					</dd>
+					<dt><var>math_formula_as_mathml</var></dt>
+					<dd>
+						<p>If true it indicates that the <i>accessibilityFeature="MathML"</i> (Accessible math content as MathML) is present in the OPF file, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that all mathematical content is presented using MathML and works with compatible assistive technology.</p>
+					</dd>
+				</dl>
+				<h4>Variables setup</h4>
+				<ol class="condition">
+					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">pre processing</a> given <var>package_document_as_text</var>.</li>
+                    
+                    <li><b>LET</b> <var>contains_charts_diagrams</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>chartOnVisual</i>"]</code>.</li>
+					
+                    <li><b>LET</b> <var>long_text_descriptions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>longDescriptions</i>"]</code>.</li>
+					
+                    <li><b>LET</b> <var>contains_chemical_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>chemOnVisual</i>"]</code>.</li>
+					
+                    <li><b>LET</b> <var>chemical_formula_as_chemml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>ChemML</i>"]</code>.</li>
+					
+                    
+	                <li><b>LET</b> <var>contains_math_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>describedMath</i>"]</code>.</li>
+				
+	                <li><b>LET</b> <var>math_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>latex</i>"]</code>.</li>
+
+	                <li><b>LET</b> <var>math_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>MathML</i>"]</code>.</li>
+				</ol>
+				<h4>Instructions</h4>
+				<ol class="condition">
+					<li>
+						<span><b>IF</b> (<var>contains_charts_diagrams</var> <b>AND</b> <var>long_text_descriptions</var>):</span>
+						<span><b>THEN</b> display <code id="charts-diagrams-formulas-extended">"Charts and diagrams have extended descriptions"</code>.</span>
+					</li>
+					<li>
+						<span><b>IF</b> <var>chemical_formula_as_chemml</var>:</span>
+						<span><b>THEN</b> display <code id="charts-diagrams-formulas-accessible-chemistry">"Accessible chemistry content"</code>.</span>
+					</li>
+					<li>
+						<span><b>IF</b> <var>math_formula_as_latex</var> <b>OR</b> <var>math_formula_as_mathml</var>:</span>
+						<span><b>THEN</b> display <code id="charts-diagrams-formulas-accessible-math">"Accessible math content"</code>.</span>
+					</li>
+					<li>
+						<span><b>IF</b> (<var>contains_charts_diagrams</var> <b>OR</b> <var>contains_chemical_formula</var> <b>OR</b> <var>contains_math_formula</var>) <b>AND</b> <b>NOT</b> (<var>long_text_descriptions</var> <b>OR</b> <var>chemical_formula_as_chemml</var> <b>OR</b> <var>math_formula_as_latex</var> <b>OR</b> <var>math_formula_as_mathml</var>):</span>
+						<span><b>THEN</b> display <code id="charts-diagrams-formulas-accessible-math">"Accessibility of formulas, charts, and diagrams unknown"</code>.</span>
+					</li>
+				</ol>
 
 			</section>
 			


### PR DESCRIPTION
I approve this PR. However, I do see an issue that I do not how to address with our current metadata. Chem on visual indicates that there is Chemistry present as a visual. It could be made accessible through ChemML, but I do not know how widely it is used. It could also be made accessible with a long description and now that MathML supports Chemistry, that could also make it accessible. So, for now I think we are good, but should I submit an issue about this. There is also the Community Group Chemistry on the Web and in Publishing we could turn to for guidance.