### PR TITLE
Correct Heading orders for Localization and Implementations

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -542,7 +542,6 @@
 						
 
 					</aside>
-				</se
 				</section>
 
 				<section id="conf-techniques">
@@ -897,7 +896,6 @@
 				</section>
 			</section>
 		</section>
-</section>
 		<section id="discovering-accessible-content">
 			<h2>Discovering accessible content</h2>
 
@@ -962,69 +960,68 @@
 					</ul>
 				</aside>
 			</section>
-</section>
-			<section id="localization">
-				<h2>Localization</h2>
-				<p>In these guidelines, we have used simple language to communicate the meaning of the metadata values.
-					Many people have contributed to development of the words and phrases we have selected. We intend to
-					provide a mechanism for the publishing community to provide translations that localizes the strings
-					for equally effective communication in many languages. We understand that simply translating the
-					strings is not enough; the subtle meaning of the words and phrases of accessibility concepts must be
-					localized for maximum understanding. </p>
-				<p>For users seeking books, a seamless user experience is essential to avoid adding cognitive load to
-					the already complex task of understanding the included features and accessing the book.</p>
-				<p>The wording is part of the UX and similarities of wordings in language areas are as crucial as the
-					organization and categorization of the information.</p>
-				<p>The wording proposed in this guide has been widely discussed by a large group representing different
-					actors of the English speaking geographies. It has been improved after proof of concept
-					implementations and panel testers.</p>
-				<p>To agree on linguistic areas wordings the actors should follow a localization framework. The UX guide
-					translation webpage will propose such framework and list translations with contextualization of the
-					localization process.</p>
-			</section>
+		</section>
+		<section id="localization">
+			<h2>Localization</h2>
+			<p>In these guidelines, we have used simple language to communicate the meaning of the metadata values.
+				Many people have contributed to development of the words and phrases we have selected. We intend to
+				provide a mechanism for the publishing community to provide translations that localizes the strings
+				for equally effective communication in many languages. We understand that simply translating the
+				strings is not enough; the subtle meaning of the words and phrases of accessibility concepts must be
+				localized for maximum understanding. </p>
+			<p>For users seeking books, a seamless user experience is essential to avoid adding cognitive load to
+				the already complex task of understanding the included features and accessing the book.</p>
+			<p>The wording is part of the UX and similarities of wordings in language areas are as crucial as the
+				organization and categorization of the information.</p>
+			<p>The wording proposed in this guide has been widely discussed by a large group representing different
+				actors of the English speaking geographies. It has been improved after proof of concept
+				implementations and panel testers.</p>
+			<p>To agree on linguistic areas wordings the actors should follow a localization framework. The UX guide
+				translation webpage will propose such framework and list translations with contextualization of the
+				localization process.</p>
+		</section>
 
-			<section id="implementations">
-				<h2>Implementations</h2>
-				<p>These guidelines provide a general framework and makes suggestions on the display of accessibility
-					metadata. It is not a normative description of what must be done. It is instructive to provide
-					examples of implementations from the community. </p>
+		<section id="implementations">
+			<h2>Implementations</h2>
+			<p>These guidelines provide a general framework and makes suggestions on the display of accessibility
+				metadata. It is not a normative description of what must be done. It is instructive to provide
+				examples of implementations from the community. </p>
 
-				<p>Linked below are static pages that show real-life implementations. We have captured these examples
-					from organization's websites that have agreed to allow us to showcase the work they have done to
-					display accessibility metadata.</p>
+			<p>Linked below are static pages that show real-life implementations. We have captured these examples
+				from organization's websites that have agreed to allow us to showcase the work they have done to
+				display accessibility metadata.</p>
 
-				<p>Links TBD</p>
-			</section>
+			<p>Links TBD</p>
+		</section>
 
 
-			<section id="app-acknowledgements" class="appendix informative">
-				<h2 id="acknowledgements">Acknowledgements</h2>
+		<section id="app-acknowledgements" class="appendix informative">
+			<h2 id="acknowledgements">Acknowledgements</h2>
 
-				<section id="contributors">
-					<h3>Contributors</h3>
+			<section id="contributors">
+				<h3>Contributors</h3>
 
-					<ul>
-						<li>Avneesh Singh</li>
-						<li>Charles LaPierre</li>
-						<li>Dave Cramer</li>
-						<li>George Kerscher</li>
-						<li>Gregorio Pellegrino</li>
-						<li>Jason White</li>
-						<li>Madeleine Rothberg</li>
-						<li>Matt Garrish</li>
-						<li>Rachel Comerford</li>
-						<li>Rick Johnson</li>
-						<li>Gautier Chomel</li>
-						<li>Chris Oliver</li>
-						<li>Jonas Lillqvist</li>
-						<li>Hadrien Gardeur</li>
-						<li>Chris Saynor</li>
-						<li>Naomi Kennedy</li>
-						<li>Miia Kirsi</li>
-						<li>Simon Mellins</li>
-						<li>James Yanchak</li>
-					</ul>
-				</section>
+				<ul>
+					<li>Avneesh Singh</li>
+					<li>Charles LaPierre</li>
+					<li>Dave Cramer</li>
+					<li>George Kerscher</li>
+					<li>Gregorio Pellegrino</li>
+					<li>Jason White</li>
+					<li>Madeleine Rothberg</li>
+					<li>Matt Garrish</li>
+					<li>Rachel Comerford</li>
+					<li>Rick Johnson</li>
+					<li>Gautier Chomel</li>
+					<li>Chris Oliver</li>
+					<li>Jonas Lillqvist</li>
+					<li>Hadrien Gardeur</li>
+					<li>Chris Saynor</li>
+					<li>Naomi Kennedy</li>
+					<li>Miia Kirsi</li>
+					<li>Simon Mellins</li>
+					<li>James Yanchak</li>
+				</ul>
 			</section>
 		</section>
 	</body>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -897,6 +897,7 @@
 				</section>
 			</section>
 		</section>
+</section>
 		<section id="discovering-accessible-content">
 			<h2>Discovering accessible content</h2>
 
@@ -961,7 +962,7 @@
 					</ul>
 				</aside>
 			</section>
-
+</section>
 			<section id="localization">
 				<h2>Localization</h2>
 				<p>In these guidelines, we have used simple language to communicate the meaning of the metadata values.

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -963,7 +963,7 @@
 			</section>
 
 			<section id="localization">
-				<h3>Localization</h3>
+				<h2>Localization</h2>
 				<p>In these guidelines, we have used simple language to communicate the meaning of the metadata values.
 					Many people have contributed to development of the words and phrases we have selected. We intend to
 					provide a mechanism for the publishing community to provide translations that localizes the strings
@@ -983,7 +983,7 @@
 			</section>
 
 			<section id="implementations">
-				<h3>Implementations</h3>
+				<h2>Implementations</h2>
 				<p>These guidelines provide a general framework and makes suggestions on the display of accessibility
 					metadata. It is not a normative description of what must be done. It is instructive to provide
 					examples of implementations from the community. </p>


### PR DESCRIPTION
Those titles where h3, so under <h2>Discovering accessible content</h2>. This change makes them independant.