### PR TITLE
Correct lang declaration on html element as per core specifications

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -1,5 +1,5 @@
 	<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 
 	<head>
 		<meta charset="utf-8" />

--- a/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
+++ b/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>Display Techniques for EPUB Accessibility Metadata 2.0</title>

--- a/UX-Guide-Metadata/draft/techniques/onix-metadata/index.html
+++ b/UX-Guide-Metadata/draft/techniques/onix-metadata/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
 		<title>Display Techniques for ONIX Accessibility Metadata 2.0</title>


### PR DESCRIPTION
As per #291 originaly discussed in #283 (comment)

Applies only to Display Guide and Techniques drafts.