### PR TITLE
#280 proposal: The exemption reason should not be displayed unless the publisher opts in for it.

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -400,11 +400,7 @@
 					placed immediately after the conformance statement.</p>
 
 				<aside class="note">
-					<p>In cases where the publication's compliance with accessibility standards is unknown, or it has
-						known accessibility problems, it may be important for local legislation (e.g., the European
-						Accessibility Act) to indicate why the publication is not accessible. This information could be
-						contained in the Accessibility Summary, or as machine readable metadata, in which case the
-						information should be given in the detailed accessibility information section.</p>
+					<p>Because it may reveal private information related to the publishing company, reasons of exemptions to legislation should not be displayed unless a local law obliges to do so. A publisher willing to have this information provided to the end user can provide it thru the accessibility addendum or summary</p>
 				</aside>
 
 				<section id="conf-statements">
@@ -475,11 +471,6 @@
 						<dt>Certifier's Report</dt>
 						<dd>If a link to a report is provided, this may be of interest.</dd>
 
-						<dt>Reason why the publication does not claim to meet the standards</dt>
-						<dd>For some jurisdictions, it may be important to indicate why a publication is not compliant
-							with the standards, such as if the company is too small and therefore not required to, or if
-							the cost to produce the accessible version is too high. Showing this information may be
-							important if required by local legislation, otherwise it can be omitted.</dd>
 					</dl>
 				</section>
 


### PR DESCRIPTION
The exemption reason should not be displayed unless the publisher opts in for it.

This is a proposal to resolve #280 by clarifying that the machine-readable exemption metadata is for authority control and eventually filtering options but should never be displayed as it exposes publishing house privacy (like annual turnover).