### PR TITLE
Removed the personal pronouns in background section

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -1,4 +1,4 @@
-	<!DOCTYPE html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 
 	<head>
@@ -117,15 +117,15 @@
    
    <section id="background" class="informative">
       <h3>Background</h3>
-      			<p>Reading a publication is a very personal experience. For most of us this is routine, and we give little
-				consideration to how we obtained the title before we read it. We may go to a bookstore, search for the
-				title to purchase online, or have the title selected for us by an instructor for a class.</p>
+      			<p>Reading a publication is a very personal experience. For most   people this is routine, and   little
+				consideration is given to how   the title was obtained before it is read. Users may go to a bookstore, search for the
+				title to purchase online, or have the title selected for them by an instructor for a class.</p>
 
-			<p>Now consider you are blind and rely on assistive technology. You need that technology to assist you in
-				the purchase process as well as to read the publication. You may wonder: will my screen reader work with
+			<p>Now consider that the person is blind and relies on assistive technology. The user  needs that technology to assist them in
+				the purchase process as well as to read the publication. The person  may wonder: will the screen reader work with
 				this title; are there image descriptions that will be spoken to describe these images; are there page
-				numbers which are accessible; is the reading order correct so I don't hear a caution after reading a
-				paragraph which could be dangerous? All of these, and more accessibility concerns are potential issues
+				numbers which are accessible; is the reading order correct so a caution after reading a
+				paragraph which could be dangerous will be announced? All of these, and more accessibility concerns are potential issues
 				consumers have when trying to purchase and ultimately read a digital publication.</p>
 
 			<p>The good news is more and more publishers are creating publications that are Born Accessible (i.e.,


### PR DESCRIPTION
Matt suggested that we remove the personal pronouns in the guidelines. While this is not a spec, it still should be avoided. This is in the background section.