### PR TITLE
Distinguishing conformity / Legal provision / Accessibility (for editor call discussion)

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -472,12 +472,6 @@
 						<dt>Certifier's Report</dt>
 						<dd>If a link to a report is provided, this may be of interest.</dd>
 
-						<dt>Reason why the publication does not claim to meet the standards</dt>
-						<dd>For some jurisdictions, it may be important to indicate why a publication is not compliant
-							with the standards, such as if the company is too small and therefore not required to, or if
-							the cost to produce the accessible version is too high. Showing this information may be
-							important if required by local legislation, otherwise it can be omitted.</dd>
-					</dl>
 				</section>
 
 				<section id="conf-examples">

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -404,14 +404,6 @@
 					publication. The certifying organization should be identified along with their credentials and
 					placed immediately after the conformance statement.</p>
 
-				<aside class="note">
-					<p>In cases where the publication's compliance with accessibility standards is unknown, or it has
-						known accessibility problems, it may be important for local legislation (e.g., the European
-						Accessibility Act) to indicate why the publication is not accessible. This information could be
-						contained in the Accessibility Summary, or as machine readable metadata, in which case the
-						information may be given in the detailed accessibility information section.</p>
-				</aside>
-
 				<section id="conf-statements">
 					<h4>Conformance statements</h4>
 

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -514,18 +514,6 @@
 
 					</aside>
 
-					<aside class="example"
-						title="Unknown accessibility conformance statement with detailed conformance Information">
-<p class="note">In cases    where the publisher is claiming an exemption, as in the example below, it is up to  implementors to decide what to present to end users. It is not mandatory that the detailed conformance information  be displayed. Publishers may not want their exemption information to be made public, and have the option to express their conformance information in the accessibility summary.  It may be advisable for implementors to instead provide guidance to the end user by including a user-friendly statement such as, "This title may not yet be fully accessible to all readers. Check the list of accessibility features to determine  if this title is suitable for your way of reading."
-</p>
-						<p>Conformance to accepted standards for accessibility of this publication cannot be
-							determined.</p>
-						<p>Detailed Conformance Information:</p>
-						<p>The creator of the publication is not required to publish in an accessible format because it
-							is a micro-enterprise (e.g., enterprises employing fewer than 10 people and with annual
-							turnover or balance sheet total not exceeding €2 million).</p>
-
-					</aside>
 <aside class="example"
 						title="Unknown accessibility conformance statement with missing detailed conformance Information">
 						<p>Conformance to accepted standards for accessibility of this publication cannot be

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -515,11 +515,11 @@
 					</aside>
 
 <aside class="example"
-						title="Unknown accessibility conformance statement with missing detailed conformance Information">
+						title="Unknown accessibility conformance statement">
 						<p>Conformance to accepted standards for accessibility of this publication cannot be
 							determined.</p>
 						<p>Detailed Conformance Information:</p>
-<p> The conformance metadata was not found.</p>
+<p>The conformance metadata was not found. The creator of the publication may have provided more information in the Accessibility summary.</p>
 						
 
 					</aside>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -438,12 +438,6 @@
 								standard.</p>
 						</dd>
 
-						<dt>This publication is known to have accessibility limitations.</dt>
-						<dd>
-							<p>The publication does not claim to meet the requirements of EPUB Accessibility or WCAG 2
-								Level A.</p>
-						</dd>
-
 						<dt>The publication does not include a conformance claim.</dt>
 						<dd>
 							<p>The conformity to a standard of this publication is unknown.</p>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -444,9 +444,9 @@
 								Level A.</p>
 						</dd>
 
-						<dt>The accessibility of this publication is unknown.</dt>
+						<dt>The publication does not include a conformance claim.</dt>
 						<dd>
-							<p>The publication does not include a conformance claim.</p>
+							<p>The conformity to a standard of this publication is unknown.</p>
 						</dd>
 					</dl>
 				</section>


### PR DESCRIPTION
This is a follow-up to the discussion that started with the display of exemptions. It proposes to keep the conformance section straight about Conformance. Aside from this, we can open separate issues to discuss:

1. What and how legal information may be displayed?
2. What and how known accessibility limitations can be informed and displayed?

Regarding the different options for Displaying the reason for the exemption:

1. If we do not suggest displaying it, publishers who want to give users exemption information can use the Summary to do so.
2. If we suggest displaying it, publishers who don’t want it to be displayed must not use that metadata, which has other consequences for control, filtering, and data collection.

Option one is less likely to disturb or create a threat, so I feel it is the most convenient one for consensus.

Also, an attention point was raised regarding the confusion between "Conformity to a standard", "exemption to legal obligations", and "user needs for information on accessibility features".

To address that, my proposal is:

1. We keep the conformity section for conformance only (ONIX 196, 01 to 05 and 80 to 99; EPUB conformsTo and affiliated),
2. The value “The publication does not include a conformance claim” is triggered when no conformity code is provided.
3. The wording “The accessibility of this publication is unknown” Is changed to "The conformity of this publication to a standard is unknown".
4. We delete the values “This publication is known to have accessibility limitations” as both ONIX 09 and Schema Accessibility Feature None are not about conformity. The absence of feature is already available to the end user as Non Visual Reading and Display Transformability are to be informed if Not possible or Unknown.
5. We include nothing that needs a check related to exemption.