### PR TITLE
Conformance section fixed

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -292,6 +292,7 @@
 							<li>Text and page layout cannot be modified. The reading experience is close to a print
 								version. Reading systems can still provide zooming options.</li>
 							<li>Ability to modify the appearance is not known.</li>
+<li>The appearance cannot be modified.</li>
 						</ul>
 					</aside>
 
@@ -301,6 +302,7 @@
 							<!--if Display transformability is present-->
 							<li>Appearance cannot be modified.</li>
 							<!--if display transformability is not present and text on visual is present-->
+<!-- or if accessibility features are none or if ONIX code 09 -->
 							<li>Ability to modify the appearance is not known.</li>
 							<!--if neither display transformability nor text on visual are presents-->
 						</ul>
@@ -357,6 +359,7 @@
 								braille.</li>
 <li>It is not known if the content will be available in generated read aloud speech and electronic
 								braille.</li>
+<li>Content will not be available in generated read aloud speech and electronic braille.</li>
 						</ul>
 					</aside>
 
@@ -366,6 +369,7 @@
 							<li>May not be fully readable in read aloud and braille.</li>
 							<li>Not fully readable in read aloud and braille.</li>
 <li>Not known if readable in read aloud and braille</li>
+<li>Not readable in read aloud and braille.</li>
 						</ul>
 					</aside>
 				</section>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -471,9 +471,9 @@
 				<section id="conf-examples">
 					<h4>Examples</h4>
 
-					<p>Four  examples are provided for the conformance statement, one shows a statement that claims to
+					<p>Three examples are provided for the conformance statement, one shows a statement that claims to
 						meet recommended accessibility standards and a second that claims to meet the minimum level. The
-						third and fourth show a publication with unknown accessibility.</p>
+						third   shows a publication with unknown accessibility.</p>
 
 					<p>The examples present the conformance statement, the certifier, the certifiers credentials and is
 						followed by the detailed conformance information section </p>
@@ -513,7 +513,7 @@
 						<p>Conformance to accepted standards for accessibility of this publication cannot be
 							determined.</p>
 						<p>Detailed Conformance Information:</p>
-<p>The conformance metadata was not found. The creator of the publication may have provided more information in the Accessibility summary.</p>
+<p>The conformance metadata was not found.</p>
 						
 
 					</aside>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -469,7 +469,7 @@
 
 						<dt>Certifier's Report</dt>
 						<dd>If a link to a report is provided, this may be of interest.</dd>
-
+</dl>
 				</section>
 
 				<section id="conf-examples">
@@ -513,7 +513,7 @@
 					</aside>
 
 <aside class="example"
-						title="Unknown accessibility conformance statement">
+						title="Unknown  conformance statement">
 						<p>Conformance to accepted standards for accessibility of this publication cannot be
 							determined.</p>
 						<p>Detailed Conformance Information:</p>


### PR DESCRIPTION
This pr changes the statement in conformance from four to three. It also adds the possibility of including the following statements:
• The appearance cannot be modified. This statement was already in the compact.
• Content will not be available in generated read aloud speech and electronic braille.
• Not readable in read aloud and braille.

The above would be triggered by ONIX 09 or if accessibilityFeatures is set to none.

