### PR TITLE
Fix swapped Code IDs on WCAG 2.x instructions

### DIFF
--- a/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
+++ b/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
@@ -450,7 +450,7 @@
 					</li>
 					<li>
 						<span><b>IF</b> <var>wcag_2_2</var>:</span>
-						<span><b>THEN</b> display <code id="conformance-wcag-2-0">" WCAG 2.2 "</code>.</span>
+						<span><b>THEN</b> display <code id="conformance-wcag-2-2">" WCAG 2.2 "</code>.</span>
 					</li>
 					<li>
 						<span><b>ELSE IF</b> <var>wcag_2_1</var>:</span>
@@ -458,7 +458,7 @@
 					</li>
 					<li>
 						<span><b>ELSE IF</b> <var>wcag_2_0</var>:</span>
-						<span><b>THEN</b> display <code id="conformance-wcag-2-2">" WCAG 2.0 "</code>.</span>
+						<span><b>THEN</b> display <code id="conformance-wcag-2-0">" WCAG 2.0 "</code>.</span>
 					</li>
 					<li>
 						<span><b>IF</b> <var>level_aaa</var>:</span>


### PR DESCRIPTION
The technique code IDs are swapped on these instructions such that 2.2 specifies 2.0 and vice versa