### PR TITLE
added more to principles based on Matt's suggestions

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -542,9 +542,9 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 
 					<ul>
-						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Conformance</a></li>
+						<li><a href="../techniques/epub-metadata/index.html#conformance-group">EPUB Accessibility: Conformance</a></li>
 						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Certification</a></li>
-						<li><a href="../techniques/onix-metadata/index.html">ONIX: Conformance</a></li>
+						<li><a href="../techniques/onix-metadata/index.html#conformance-group">ONIX: Conformance</a></li>
 						<li><a href="../techniques/onix-metadata/index.html">ONIX: Certification</a></li>
 					</ul>
 				</section>
@@ -791,7 +791,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				</section>
 
 				<section id="sum-techniques">
-					<h4>Display techniques for accessibility summarysupport</h4>
+					<h4>Display techniques for accessibility summary support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Accessibility

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -311,7 +311,7 @@
 				</section>
 
 				<section id="va-techniques">
-					<h4>Visual adjustments metadata techniques</h4>
+					<h4>Display techniques for Visual adjustments support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Visual
@@ -374,7 +374,7 @@
 				</section>
 
 				<section id="nv-techniques">
-					<h4>Supports nonvisual reading metadata techniques</h4>
+					<h4>Display techniques  for nonvisual reading support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html#screen-reader-friendly">EPUB Accessibility:
@@ -538,7 +538,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				</section>
 
 				<section id="conf-techniques">
-					<h4>Conformance metadata techniques</h4>
+					<h4>Display techniques for conformance support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 
 					<ul>
@@ -596,7 +596,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				</section>
 
 				<section id="pra-techniques">
-					<h4>Pre-recorded audio metadata techniques</h4>
+					<h4>Display techniques for pre-recorded audio support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html#full-audio">EPUB Accessibility: Full
@@ -649,7 +649,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				</section>
 
 				<section id="nav-techniques">
-					<h4>Navigation metadata techniques</h4>
+					<h4>Display techniques for navigation support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Navigation</a></li>
@@ -697,7 +697,8 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				</section>
 
 				<section id="cdf-techniques">
-					<h4>Charts, diagrams, and formulas metadata techniques</h4>
+					<h4>Display techniques for charts, diagrams, and formulas support</h4>
+					
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Graphics and
@@ -750,7 +751,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				</section>
 
 				<section id="hazards-techniques">
-					<h4>Hazards metadata techniques</h4>
+					<h4>Display techniques for hazards reporting</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html#hazards">EPUB Accessibility:
@@ -790,7 +791,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				</section>
 
 				<section id="sum-techniques">
-					<h4>Accessibility summary metadata techniques</h4>
+					<h4>Display techniques for accessibility summarysupport</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Accessibility
@@ -833,7 +834,7 @@ Always get legal advice from in-house or your retained counsel to assess legal c
 
 						
 <section id="legal-techniques">
-					<h4> Legal considerations metadata techniques</h4>
+					<h4> Display techniques for legal considerations support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html#legal-considerations">EPUB Accessibility: legal considerations</a></li>
@@ -924,7 +925,7 @@ Always get legal advice from in-house or your retained counsel to assess legal c
 				</section>
 
 				<section id="add-info-techniques">
-					<h4>Additional accessibility information metadata techniques</h4>
+					<h4>Display techniques for additional accessibility information support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Book Features</a></li>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -541,6 +541,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 					<h4>Display techniques for conformance support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 
+
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html#conformance-group">EPUB Accessibility: Conformance</a></li>
 						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Certification</a></li>


### PR DESCRIPTION
I added the words display techniques for to the heading of the headings to the techniques.

It did not sound right to say support for hazards, so that one I listed as reporting.

I added the links in conformance to the conformance in the teniques, i.e. added the id.

I was using VS code and the push seemed to go worng.

I hope this is looking OK.

