### PR TITLE
Add to principles deep links to techniques and page breaks

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -864,7 +864,8 @@ Always get legal advice from in-house or your retained counsel to assess legal c
 					<dd>
 						<p>For information on any structuring aids that facilitate use of a resource (e.g., ARIA).</p>
 					</dd>
-
+<dt>Page breaks</dt>
+<dd>The inclusion of page break markers from a print source allows users to identify where they are in a digital publication relative to its print equivalent. </dd>
 					<dt>Adaptation</dt>
 					<dd>
 						<p>For information on provisions in the content that enable reading in alternative access modes
@@ -905,6 +906,7 @@ Always get legal advice from in-house or your retained counsel to assess legal c
 						<ul>
 							<li>Content is enhanced with ARIA roles to optimize organization and facilitate
 								navigation.</li>
+<li>Page breaks   included  from the original print source.</li>
 							<li>Videos included in publications have closed captions and sign language representation. </li>
 							<li>Tactile graphics have been integrated to facilitate access to visual elements by blind
 								people.</li>
@@ -917,6 +919,7 @@ Always get legal advice from in-house or your retained counsel to assess legal c
 					<aside class="example" title="Compact explanations">
 						<ul>
 							<li>ARIA roles included.</li>
+<li>Page breaks</li>
 							<li>Closed captions and sign language interpretation for videos.</li>
 							<li>Tactile graphics attached.</li>
 							<li>Music scores visually presented.</li>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -314,9 +314,9 @@
 					<h4>Display techniques for Visual adjustments support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
-						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Visual
+						<li><a href="../techniques/epub-metadata/index.html#visual-adjustments">EPUB Accessibility: Visual
 							Adjustments</a></li>
-						<li><a href="../techniques/onix-metadata/index.html">ONIX: Visual Adjustments</a></li>
+						<li><a href="../techniques/onix-metadata/index.html#visual-adjustments">ONIX: Visual Adjustments</a></li>
 					</ul>
 				</section>
 			</section>
@@ -377,9 +377,9 @@
 					<h4>Display techniques  for nonvisual reading support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
-						<li><a href="../techniques/epub-metadata/index.html#screen-reader-friendly">EPUB Accessibility:
+						<li><a href="../techniques/epub-metadata/index.html#supports-nonvisual-reading">EPUB Accessibility:
 								Supports nonvisual reading</a></li>
-						<li><a href="../techniques/onix-metadata/index.html#screen-reader-friendly">ONIX: Supports
+						<li><a href="../techniques/onix-metadata/index.html#supports-nonvisual-reading">ONIX: Supports
 								nonvisual reading</a></li>
 					</ul>
 				</section>
@@ -600,9 +600,9 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 					<h4>Display techniques for pre-recorded audio support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
-						<li><a href="../techniques/epub-metadata/index.html#full-audio">EPUB Accessibility: Full
+						<li><a href="../techniques/epub-metadata/index.html#pre-recorded-audio">EPUB Accessibility: Full
 								audio</a></li>
-						<li><a href="../techniques/onix-metadata/index.html#full-audio">ONIX: Full audio</a></li>
+						<li><a href="../techniques/onix-metadata/index.html#pre-recorded-audio">ONIX: Full audio</a></li>
 					</ul>
 				</section>
 			</section>
@@ -653,8 +653,8 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 					<h4>Display techniques for navigation support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
-						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Navigation</a></li>
-						<li><a href="../techniques/onix-metadata/index.html">ONIX: Navigation</a></li>
+						<li><a href="../techniques/epub-metadata/index.html#navigation">EPUB Accessibility: Navigation</a></li>
+						<li><a href="../techniques/onix-metadata/index.html#navigation">ONIX: Navigation</a></li>
 					</ul>
 				</section>
 			</section>
@@ -702,9 +702,9 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 					
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
-						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Graphics and
+						<li><a href="../techniques/epub-metadata/index.html#charts-diagrams-and-formulas">EPUB Accessibility: Graphics and
 								Formulas</a></li>
-						<li><a href="../techniques/onix-metadata/index.html">ONIX: Graphics and Formulas</a></li>
+						<li><a href="../techniques/onix-metadata/index.html#charts-diagrams-and-formulas">ONIX: Graphics and Formulas</a></li>
 					</ul>
 				</section>
 			</section>
@@ -795,9 +795,9 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 					<h4>Display techniques for accessibility summary support</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
-						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Accessibility
+						<li><a href="../techniques/epub-metadata/index.html#accessibility-summary">EPUB Accessibility: Accessibility
 								Summary</a></li>
-						<li><a href="../techniques/onix-metadata/index.html">ONIX: Accessibility Summary</a></li>
+						<li><a href="../techniques/onix-metadata/index.html#accessibility-summary">ONIX: Accessibility Summary</a></li>
 					</ul>
 				</section>
 			</section>
@@ -835,7 +835,7 @@ Always get legal advice from in-house or your retained counsel to assess legal c
 
 						
 <section id="legal-techniques">
-					<h4> Display techniques for legal considerations support</h4>
+					<h4> Display techniques for legal considerations</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html#legal-considerations">EPUB Accessibility: legal considerations</a></li>
@@ -926,11 +926,11 @@ Always get legal advice from in-house or your retained counsel to assess legal c
 				</section>
 
 				<section id="add-info-techniques">
-					<h4>Display techniques for additional accessibility information support</h4>
+					<h4>Display techniques for additional accessibility information</h4>
 <p>Specific techniques for meeting this principle are defined in the following documents:</p>
 					<ul>
-						<li><a href="../techniques/epub-metadata/index.html">EPUB Accessibility: Book Features</a></li>
-						<li><a href="../techniques/onix-metadata/index.html">ONIX: Book Features</a></li>
+						<li><a href="../techniques/epub-metadata/index.html#additional-accessibility-information">EPUB Accessibility: Book Features</a></li>
+						<li><a href="../techniques/onix-metadata/index.html#additional-accessibility-information">ONIX: Book Features</a></li>
 					</ul>
 				</section>
 			</section>


### PR DESCRIPTION
Changed the wording of some of the Display techniques headings  based on Matt's guidance. Add deep links to the correct sections inboth techniques. Added the Page breaks information in the Additional information section.

With the changes to the names of the Display techniques, the heading titles in the techniques are different from the principles. Also, the text in the links does not match exactly. 