### PR TITLE
Updated acknowledgements

### DIFF
--- a/UX-Guide-Metadata/draft/common/acknowledgements.html
+++ b/UX-Guide-Metadata/draft/common/acknowledgements.html
@@ -1,0 +1,36 @@
+<section id="app-acknowledgements" class="appendix informative">
+	<h2 id="acknowledgements">Acknowledgements</h2>
+	
+	<p>The leadership and editing contributions of the following individuals were central to producing this guide:</p>
+	
+	<ul>
+		<li>Avneesh Singh</li>
+		<li>Charles LaPierre</li>
+		<li>George Kerscher</li>
+		<li>Gregorio Pellegrino</li>
+		<li>Madeleine Rothberg</li>
+		<li>Matt Garrish</li>
+		<li>Gautier Chomel</li>
+		<li>Chris Saynor</li>
+	</ul>
+	
+	<p>The following members of the Publishing Community Group contributed to the development of this document:</p>
+	
+	<ul>
+		<li>Dave Cramer</li>
+		<li>Jason White</li>
+		<li>Rachel Comerford</li>
+		<li>Rick Johnson</li>
+		<li>Chris Oliver</li>
+		<li>Jonas Lillqvist</li>
+		<li>Hadrien Gardeur</li>
+		<li>Naomi Kennedy</li>
+		<li>Miia Kirsi</li>
+		<li>Simon Mellins</li>
+		<li>James Yanchak</li>
+	</ul>
+	
+	<p>The group would also like to thank Erin Kirchner-Lucas and Luc Audrain for their invaluable help
+		reviewing the documents.</p>
+</section>
+	

--- a/UX-Guide-Metadata/draft/common/acknowledgements.html
+++ b/UX-Guide-Metadata/draft/common/acknowledgements.html
@@ -17,15 +17,14 @@
 	<p>The following members of the Publishing Community Group contributed to the development of this document:</p>
 	
 	<ul>
+		<li>Christopher Carr</li>
 		<li>Chris Oliver</li>
-		<li>Dave Cramer</li>
 		<li>Hadrien Gardeur</li>
 		<li>James Yanchak</li>
 		<li>Jason White</li>
 		<li>Jonas Lillqvist</li>
 		<li>Miia Kirsi</li>
 		<li>Naomi Kennedy</li>
-		<li>Rachel Comerford</li>
 		<li>Rick Johnson</li>
 		<li>Simon Mellins</li>
 	</ul>

--- a/UX-Guide-Metadata/draft/common/acknowledgements.html
+++ b/UX-Guide-Metadata/draft/common/acknowledgements.html
@@ -17,8 +17,8 @@
 	<p>The following members of the Publishing Community Group contributed to the development of this document:</p>
 	
 	<ul>
-		<li>Christopher Carr</li>
 		<li>Chris Oliver</li>
+		<li>Christopher Carr</li>
 		<li>Hadrien Gardeur</li>
 		<li>James Yanchak</li>
 		<li>Jason White</li>

--- a/UX-Guide-Metadata/draft/common/acknowledgements.html
+++ b/UX-Guide-Metadata/draft/common/acknowledgements.html
@@ -6,28 +6,28 @@
 	<ul>
 		<li>Avneesh Singh</li>
 		<li>Charles LaPierre</li>
+		<li>Chris Saynor</li>
+		<li>Gautier Chomel</li>
 		<li>George Kerscher</li>
 		<li>Gregorio Pellegrino</li>
 		<li>Madeleine Rothberg</li>
 		<li>Matt Garrish</li>
-		<li>Gautier Chomel</li>
-		<li>Chris Saynor</li>
 	</ul>
 	
 	<p>The following members of the Publishing Community Group contributed to the development of this document:</p>
 	
 	<ul>
+		<li>Chris Oliver</li>
 		<li>Dave Cramer</li>
+		<li>Hadrien Gardeur</li>
+		<li>James Yanchak</li>
 		<li>Jason White</li>
+		<li>Jonas Lillqvist</li>
+		<li>Miia Kirsi</li>
+		<li>Naomi Kennedy</li>
 		<li>Rachel Comerford</li>
 		<li>Rick Johnson</li>
-		<li>Chris Oliver</li>
-		<li>Jonas Lillqvist</li>
-		<li>Hadrien Gardeur</li>
-		<li>Naomi Kennedy</li>
-		<li>Miia Kirsi</li>
 		<li>Simon Mellins</li>
-		<li>James Yanchak</li>
 	</ul>
 	
 	<p>The group would also like to thank Erin Kirchner-Lucas and Luc Audrain for their invaluable help

--- a/UX-Guide-Metadata/draft/common/acknowledgements.html
+++ b/UX-Guide-Metadata/draft/common/acknowledgements.html
@@ -29,8 +29,5 @@
 		<li>Rick Johnson</li>
 		<li>Simon Mellins</li>
 	</ul>
-	
-	<p>The group would also like to thank Erin Kirchner-Lucas and Luc Audrain for their invaluable help
-		reviewing the documents.</p>
 </section>
 	

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -1013,36 +1013,6 @@ Always get legal advice from in-house or your retained counsel to assess legal c
 
 			<p>Links TBD</p>
 		</section>
-
-
-		<section id="app-acknowledgements" class="appendix informative">
-			<h2 id="acknowledgements">Acknowledgements</h2>
-
-			<section id="contributors">
-				<h3>Contributors</h3>
-
-				<ul>
-					<li>Avneesh Singh</li>
-					<li>Charles LaPierre</li>
-					<li>Dave Cramer</li>
-					<li>George Kerscher</li>
-					<li>Gregorio Pellegrino</li>
-					<li>Jason White</li>
-					<li>Madeleine Rothberg</li>
-					<li>Matt Garrish</li>
-					<li>Rachel Comerford</li>
-					<li>Rick Johnson</li>
-					<li>Gautier Chomel</li>
-					<li>Chris Oliver</li>
-					<li>Jonas Lillqvist</li>
-					<li>Hadrien Gardeur</li>
-					<li>Chris Saynor</li>
-					<li>Naomi Kennedy</li>
-					<li>Miia Kirsi</li>
-					<li>Simon Mellins</li>
-					<li>James Yanchak</li>
-				</ul>
-			</section>
-		</section>
+		<div data-include="../common/acknowledgements.html" data-include-replace="true"></div>
 	</body>
 </html>

--- a/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
+++ b/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
@@ -1210,31 +1210,6 @@
 			</section>
 			
 		</section>
-
-        <section id="app-acknowledgements" class="appendix informative">
-			<h2 id="acknowledgements">Acknowledgements</h2>
-			<section id="contributors">
-				<h3>Contributors</h3>
-				<ul>
-					<li>Avneesh Singh</li>
-                    <li>Charles LaPierre</li>
-					<li>Dave Cramer</li>
-                    <li>George Kerscher</li>
-                    <li>Gregorio Pellegrino</li>
-					<li>Jason White</li>
-					<li>Madeleine Rothberg</li>
-                    <li>Matt Garrish</li>
-					<li>Rachel Comerford</li>
-					<li>Rick Johnson</li>
-				</ul>
-			</section>
-			<section id="reviewers">
-				<h3>Reviewers</h3>
-				<ul>
-					<li>Erin Kirchner-Lucas</li>
-					<li>Luc Audrain</li>
-				</ul>
-			</section>
-		</section>
+		<div data-include="../common/acknowledgements.html" data-include-replace="true"></div>
 	</body>
 </html>

--- a/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
+++ b/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
@@ -1210,6 +1210,6 @@
 			</section>
 			
 		</section>
-		<div data-include="../common/acknowledgements.html" data-include-replace="true"></div>
+		<div data-include="../../common/acknowledgements.html" data-include-replace="true"></div>
 	</body>
 </html>

--- a/UX-Guide-Metadata/draft/techniques/onix-metadata/index.html
+++ b/UX-Guide-Metadata/draft/techniques/onix-metadata/index.html
@@ -1186,6 +1186,6 @@
 				</section>
 			</section>
 		</section>
-		<div data-include="../common/acknowledgements.html" data-include-replace="true"></div>
+		<div data-include="../../common/acknowledgements.html" data-include-replace="true"></div>
 	</body>
 </html>

--- a/UX-Guide-Metadata/draft/techniques/onix-metadata/index.html
+++ b/UX-Guide-Metadata/draft/techniques/onix-metadata/index.html
@@ -1186,30 +1186,6 @@
 				</section>
 			</section>
 		</section>
-		<section id="app-acknowledgements" class="appendix informative">
-			<h2 id="acknowledgements">Acknowledgements</h2>
-			<section id="contributors">
-				<h3>Contributors</h3>
-				<ul>
-					<li>Avneesh Singh</li>
-                    <li>Charles LaPierre</li>
-					<li>Dave Cramer</li>
-                    <li>George Kerscher</li>
-                    <li>Gregorio Pellegrino</li>
-					<li>Jason White</li>
-					<li>Madeleine Rothberg</li>
-                    <li>Matt Garrish</li>
-					<li>Rachel Comerford</li>
-					<li>Rick Johnson</li>
-				</ul>
-			</section>
-			<section id="reviewers">
-				<h3>Reviewers</h3>
-				<ul>
-					<li>Erin Kirchner-Lucas</li>
-					<li>Luc Audrain</li>
-				</ul>
-			</section>
-		</section>
+		<div data-include="../common/acknowledgements.html" data-include-replace="true"></div>
 	</body>
 </html>


### PR DESCRIPTION
This pull request modifies the acknowledgements section as follows:

- it adds a new list for leadership/editors
- it re-alphabetizes the contributor lists by first name (to match the 1.0 version)
- it removes the reviewers as they only worked on the 1.0 release
- it shares the contributor file across all three documents so we aren't maintaining the lists separately

Let me know if any other fixes are necessary, or if anyone else should be listed.

The following preview and diff are only for the principles as the techniques will get the same section.

- [Preview](https://raw.githack.com/w3c/publ-a11y/ux/update-ack/UX-Guide-Metadata/draft/principles/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/principles/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/publ-a11y/ux/update-ack/UX-Guide-Metadata/draft/principles/index.html)
