### PR TITLE
changed title to Accessibility Metadata Display Guide for ...

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -3,7 +3,7 @@
 
 	<head>
 		<meta charset="utf-8" />
-		<title>User Experience Guide for Displaying Accessibility Metadata 2.0</title>
+		<title>Accessibility Metadata Display Guide for Digital Publications 2.0</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script class="remove">
 		// <![CDATA[
@@ -185,7 +185,7 @@
                         <p>
                             From here both flow down into the "Metadata Processing" layer where the EPUB metadata gets processed through the "Display Techniques for EPUB Accessibility Metadata", and the "ONIX accessibility metadata" is processed through the "Display Techniques for ONIX Accessibility Metadata."</p>
                         <p>
-                            Finally from the "Metadata Processing" layer both the Display Techniques for EPUB and ONIX flow into the "Resulting Statements" layer "User Experience Guide for Displaying Accessibility Metadata"</p>
+                            Finally from the "Metadata Processing" layer both the Display Techniques for EPUB and ONIX flow into the "Resulting Statements" layer "Accessibility Metadata Display Guide for Digital Publications"</p>
                     </details>
 
             </section>
@@ -213,7 +213,7 @@
 		</section>
 		<section id="general-info">
 			<h2>General information</h2>
-			<p>To solve the problem of displaying the accessibility metadata in a human readable form, vendors will determine their correct statement to display (from the User Experience Guide) by parsing the metadata and using the appropriate Display Techniques document. </p>
+			<p>To solve the problem of displaying the accessibility metadata in a human readable form, vendors will determine their correct statement to display (from the Accessibility Metadata Display Guide for Digital Publications) by parsing the metadata and using the appropriate Display Techniques document. </p>
 
 			<p>The product details provide precious information about the usability of the book in relation to specific user needs. The following information should always be displayed:</p>
 


### PR DESCRIPTION
Changed the title  of principles to: "Accessibility Metadata Display Guide for Digital Publications 2.0"

Also  found the reference to the title in a few places in the document and changed them as well. The words user experience still appear in several places and these seem to be appropriate.

Closes #403