### PR TITLE
Added to the note about when not available

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -366,8 +366,8 @@
 						<ul>
 							<li data-localization-id="nonvisual-reading-readable" data-localization-mode="compact">Readable in read aloud and braille.</li>
 							<li data-localization-id="nonvisual-reading-may-not-fully" data-localization-mode="compact">May not be fully readable in read aloud and braille.</li>
-							<!-- <li data-localization-id="nonvisual-reading-not-fully" data-localization-mode="compact">Not fully readable in read aloud and braille.</li> -->
-							<!--To be Confirmed (see https://github.com/w3c/publ-a11y/issues/367)--><li data-localization-id="nonvisual-reading-unknown" data-localization-mode="compact">Not known if readable in read aloud and braille</li>
+							 <li data-localization-id="nonvisual-reading-not-fully" data-localization-mode="compact">Not fully readable in read aloud and braille.</li> 
+							<!--To be Confirmed (see https://github.com/w3c/publ-a11y/issues/367)<li data-localization-id="nonvisual-reading-unknown" data-localization-mode="compact">Not known if readable in read aloud and braille</li>-->
 						</ul>
 					</aside>
 				</section>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -576,7 +576,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				<h3 data-localization-id="pre-recorded-audio-title">Pre-recorded audio</h3>
 
 				<div class="note">
-					<p>This key information can be hidden if metadata is missing.</p>
+					<p>This key information can be hidden if metadata is missing. Alternatively it can be stated that  <span data-localization-id="pre-recorded-audio-no-metadata" data-localization-mode="descriptive">No information about pre-recorded audio is available.</span></p>
 				</div>
 
 				<p>Indicates the presence of pre-recorded audio and specifies if this audio is standalone (an
@@ -631,7 +631,8 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				<h3 data-localization-id="navigation-title">Navigation</h3>
 
 				<div class="note">
-					<p>This key information can be hidden if metadata is missing.</p>
+					<p>This key information can be hidden if metadata is missing. Alternatively it can be stated that  <span data-localization-id="navigation-no-metadata" data-localization-mode="descriptive">No information about navigation is available.</span>
+</p>
 				</div>
 
 				<p>Identifies the navigation features included in the publication.</p>
@@ -687,7 +688,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				<h3 data-localization-id="charts-diagrams-formulas-title">Charts, diagrams, and formulas</h3>
 
 				<div class="note">
-					<p>This key information can be hidden if metadata is missing.</p>
+					<p>This key information can be hidden if metadata is missing. Alternatively it can be stated that  <span data-localization-id="charts-diagrams-formulas-unknown" data-localization-mode="descriptive">The accessibility of formulas, charts, and diagrams is not available.</span></p>
 				</div>
 
 				<p>Indicates the presence of formulas (including math, chemistry, etc.), graphs, charts, and diagrams
@@ -750,7 +751,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				<h3 data-localization-id="hazards-title">Hazards</h3>
 
 				<div class="note">
-					<p>This key information can be hidden if metadata is missing.</p>
+					<p>This key information can be hidden if metadata is missing. Alternatively it can be stated that  <span data-localization-id="hazards-no-metadata" data-localization-mode="descriptive">No information about possible hazards is available.</span></p>
 				</div>
 
 				<p>Identifies any potential hazards (e.g., flashing elements, background sounds, and motion simulation)
@@ -809,7 +810,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 				<h3 data-localization-id="accessibility-summary-title">Accessibility summary</h3>
 
 				<div class="note">
-					<p>This key information can be hidden if metadata is missing.</p>
+					<p>This key information can be hidden if metadata is missing. Alternatively it can be stated that  <span data-localization-id="accessibility-summary-no-metadata" data-localization-mode="descriptive">No accessibility summary is available.</span></p>
 				</div>
 
 				<p>The accessibility summary was intended (in EPUB Accessibility 1.0) to describe in human-readable

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -257,6 +257,8 @@
 				<p>This document does not define the order in which to show the key accessibility information; each
 					implementer can decide the preferred order for showing the accessibility information that
 					follows.</p>
+<p>In this document  are   examples of       important metadata  that is expected  to be in a wide range of publications. However, we do not have examples of all possible features that the metadata can express. The techniques have more values than are shown in the examples.
+</p>
 			</div>
 			<section id="visual-adjustments">
 				<h3 data-localization-id="visual-adjustments-title">Visual adjustments</h3>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -779,7 +779,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 								<span data-localization-id="hazards-sound" data-localization-mode="descriptive">rapidly changing lights,</span>
 								<span data-localization-id="hazards-motion" data-localization-mode="descriptive">visual stimuli or simulated movements, </span>
 								<span data-localization-id="hasards-explanatory" data-localization-mode="descriptive">which can cause discomfort, distraction, photosensitive seizures, or motion sickness.</span></li>
-							<li><span data-localization-id="hazards-unknown" data-localization-mode="descriptive">No information about possible hazards.</span></li>
+							<li><span data-localization-id="hazards-unknown" data-localization-mode="descriptive">The presence of hazards is unknown.</span></li>
 						</ul>
 					</aside>
 
@@ -792,7 +792,7 @@ The publication was certified on 2021-09-07 by Foo's Accessibility Testing with 
 								<span data-localization-id="join-array-and">, and </span>
 								<span data-localization-id="hazards-motion" data-localization-mode="compact">motion simulation hazards.</span></li>
 							<li>
-								<span data-localization-id="hazards-unknown" data-localization-mode="compact">No information about hazards.</span></li>		
+								<span data-localization-id="hazards-unknown" data-localization-mode="compact">The presence of hazards is unknown.</span></li>		
 						</ul>
 					</aside>
 				</section>


### PR DESCRIPTION
This is what it looks like now.

NOTE
This key information can be hidden if metadata is missing. Alternatively it can be stated that No information about pre-recorded audio is available.

This was added to five sections. The strings that are in the techniques seemed inappropriate.

I will make the changes to the strings in the ONIX techniques and in the EPUB techniques. This will be in separate PR to keep the three documents in separate PRs.