### PR TITLE
Corrected description from chemistry to math

### DIFF
--- a/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
+++ b/UX-Guide-Metadata/draft/techniques/epub-metadata/index.html
@@ -713,7 +713,7 @@
 					<dt><var>math_formula_as_latex</var></dt>
 					<dd>
 						<p>If true it indicates that the <i>accessibilityFeature="latex"</i> (Accessible math content as LaTeX) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that the chemical formulae are presented using LaTeX and works with compatible assistive technology.</p>
+						<p>This means that there is a positive indication that the  math  is  presented using LaTeX and works with compatible assistive technology.</p>
 					</dd>
 					<dt><var>math_formula_as_mathml</var></dt>
 					<dd>


### PR DESCRIPTION
In the techniques under chartes, formulae section, the description said chemestry but it was supposed to be math. I think that was only a typo and I did not see the problem anywhere else.