### PR TITLE
Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,44 @@
 
 ![W3C Logo](https://www.w3.org/Icons/w3c_home)
 
-# Accessibility Discussions of the Publishing@W3C Groups
+# Accessibility Task Force
 
-This is the repository for the Accessibility related discussions of the [Publishing@W3C Groups](https://www.w3.org/publishing/). 
+This is the repository for the Accessibility Task Force of the Publishing Community Group.
 
 [Minutes of the task force meetings](https://github.com/w3c/publ-a11y/wiki/Minutes-of-Publishing-CG-Accessibility-Task-Force-Meetings)
+
+## Participation
+
+To join the task force, please first become a member of the [Publishing Community Group](https://www.w3.org/community/publishingcg/).
+
+Task force meetings are announced on the community group's public mailing list. All members are welcome to join.
+
+## Documents
+
+The Accessibility Task Force maintains the following documents in this repository:
+
+- Accessibility Metadata Display Guide for Digital Publications
+  - [Editor's Draft](https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/principles/)
+  - [Latest Version](https://www.w3.org/2021/09/UX-Guide-metadata-1.0/principles/)
+  - EPUB Techniques
+    - [Editor's Draft](https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/techniques/epub-metadata/)
+    - [Latest Version](https://www.w3.org/publishing/a11y/UX-Guide-metadata/techniques/epub-metadata/)
+  - ONIX Techniques
+    - [Editor's Draft](https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/techniques/onix-metadata/)
+    - [Latest Version](https://www.w3.org/publishing/a11y/UX-Guide-metadata/techniques/onix-metadata/)
+- Accessibility Properties Crosswalk
+  - [Editor's Draft](https://w3c.github.io/publ-a11y/drafts/a11y-crosswalk-MARC/)
+- Publishing Guide to Audio Playback and Text-To-Speech
+  - [Editor's Draft](https://w3c.github.io/publ-a11y/drafts/audio-playback/)
+  - [Latest Version](https://www.w3.org/publishing/a11y/audio-playback/)
+- Page Source Identification
+  - [Editor's Draft](https://w3c.github.io/publ-a11y/drafts/page-source-id/)
+  - [Latest Version](https://www.w3.org/publishing/a11y/page-source-id/)
+- Accessibility Summary Authoring Guidelines for EPUB Publications
+  - [Editor's Draft](https://w3c.github.io/publ-a11y/drafts/schema-a11y-summary/)
+  - [Latest Version](https://www.w3.org/publishing/a11y/schema-a11y-summary/)
+- Zero-Tolerance Accessibility Conformance Approaches for Publishing
+  - [Editor's Draft](https://w3c.github.io/publ-a11y/drafts/zero-tolerance-conformance/)
 
 ## Contributing to the Repository
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ![W3C Logo](https://www.w3.org/Icons/w3c_home)
 
-# Accessibility Task Force
+# Publishing Accessibility Task Force
 
 This is the repository for the Accessibility Task Force of the Publishing Community Group.
 


### PR DESCRIPTION
This beefs up the readme for the repository by focusing it on the task force and the documents we produce rather than as a generic repository for discussions in the publishing activity. I added a section on participating in the task force and listed all the documents we host here.

This will also gives us a better reference point for the rechartering, as we may move things like pageBreakSource into the spec in a new revision.