### PR TITLE
Made changes as discussed on October 29

### DIFF
--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -1102,13 +1102,10 @@
 
 				<section id="legal-examples">
 					<h4>Example</h4>
-
-					
-<p>In many cases no legal exception or exemption information will be presented. Where it it is provided, the example is  provided as   a possible descriptive   explanation.</p>
- 
-					<aside class="example" title="Descriptive explanation">
+		<aside class="example" title="In many cases no legal exception or exemption information will be presented. The following example is provided as a possible descriptive explanation when legal exception or exemption information needs to be presented.">
 
 <p data-localization-id="legal-considerations-exempt"
+
 								data-localization-mode="descriptive">This publication claims an accessibility exemption in some jurisdictions</p>
 </aside>
 

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -1102,7 +1102,7 @@
 
 				<section id="legal-examples">
 					<h4>Example</h4>
-		<aside class="example" title="Exception or exception ">
+		<aside class="example" title="Exception or exemption ">
 <p> In many cases no legal exception or exemption information will be presented. The following example is provided as a possible descriptive explanation when legal exception or exemption information needs to be presented.</p>
 <p data-localization-id="legal-considerations-exempt"
 

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -1109,7 +1109,7 @@
 					<aside class="example" title="Descriptive explanation">
 
 <p data-localization-id="legal-considerations-exempt"
-								data-localization-mode="descriptive">This publication claims an accessibility exemption in some jurisdictions.</p>
+								data-localization-mode="descriptive">This publication claims an accessibility exemption in some jurisdictions</p>
 </aside>
 
 				</section>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -1102,8 +1102,8 @@
 
 				<section id="legal-examples">
 					<h4>Example</h4>
-		<aside class="example" title="In many cases no legal exception or exemption information will be presented. The following example is provided as a possible descriptive explanation when legal exception or exemption information needs to be presented.">
-
+		<aside class="example" title="Exception or exception ">
+<p> In many cases no legal exception or exemption information will be presented. The following example is provided as a possible descriptive explanation when legal exception or exemption information needs to be presented.</p>
 <p data-localization-id="legal-considerations-exempt"
 
 								data-localization-mode="descriptive">This publication claims an accessibility exemption in some jurisdictions</p>

--- a/UX-Guide-Metadata/draft/principles/index.html
+++ b/UX-Guide-Metadata/draft/principles/index.html
@@ -1101,17 +1101,17 @@
 					is to provide as much accessibility information as is possible.</p>
 
 				<section id="legal-examples">
-					<h4>Examples</h4>
-					<p>TBD</p>
-					<!--
+					<h4>Example</h4>
+
+					
+<p>In many cases no legal exception or exemption information will be presented. Where it it is provided, the example is  provided as   a possible descriptive   explanation.</p>
+ 
 					<aside class="example" title="Descriptive explanation">
 
-<p>This title may not yet be fully accessible to all readers. Check the list of accessibility features to determine  if this title is suitable for your way of reading.</p>
+<p data-localization-id="legal-considerations-exempt"
+								data-localization-mode="descriptive">This publication claims an accessibility exemption in some jurisdictions.</p>
 </aside>
-<aside class="example" title="Compact explanation">
-<p>May not  be fully accessible. Check features for suitability.</p>
-</aside>
--->
+
 				</section>
 
 


### PR DESCRIPTION
One descriptive example was provided. I made it singular. Where it talks about what was provided, I say that in most cases this will not be displayed, but where it is, we use the string: "This publication claims an accessibility exemption in some jurisdictions"

I will comment in issue 350 about this approach.