### PR TITLE
Detailed conformance information fixed and checked theIDs

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -629,7 +629,7 @@
 								data-localization-mode="compact">with a credential of</span> "Enterprise
 							Accessibility Rating." </p>
 
-						<p data-localization-id="conformance-details">Detailed Conformance Information</p>
+						<p data-localization-id="conformance-details">Detailed conformance information</p>
 						<p>
 							<span data-localization-id="conformance-claim">This publication claims to meet</span>
 							<span data-localization-id="conformance-epub-accessibility-1-1">EPUB Accessibility
@@ -664,7 +664,7 @@
 							<span data-localization-id="conformance-certifier-credentials-prefix"
 								data-localization-mode="compact">with a credential of</span> "Enterprise
 							Accessibility Rating."</p>
-						<p data-localization-id="conformance-details">Detailed Conformance Information</p>
+						<p data-localization-id="conformance-details">Detailed conformance information</p>
 						<p>
 							<span data-localization-id="conformance-claim">This publication claims to meet</span>
 							<span data-localization-id="conformance-epub-accessibility-1-0"> EPUB Accessibility 1.0 </span>
@@ -694,7 +694,7 @@
 						<p><span data-localization-id="conformance-certifier-credentials">The certifier's credential is</span>"Enterprise Accessibility Rating."</p>
 
 						
-<p data-localization-id="conformance-details">Detailed Conformance Information</p>
+<p data-localization-id="conformance-details">Detailed conformance information</p>
 						<p>This publication reports (Publisher's in-house specification.)</p>
 <p> The publication was certified
 							on 2021-09-07 by Foo's Accessibility Testing with a credential of "Enterprise Accessibility
@@ -705,7 +705,7 @@
 
 					<aside class="example" title="Missing a conformance statement">
 						<p data-localization-id="conformance-no" data-localization-mode="compact">The publication does not include a conformance statement</p>
-						<p>Detailed Conformance Information:</p>
+						<p>Detailed conformance information:</p>
 						<p>The conformance metadata was not found</p>
 
 

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -455,7 +455,7 @@
 						</ul>
 					</li>
 					<li>
-						<span>display <code id="conformance-details">"Detailed Conformance Information"</code> as heading.</span>
+						<span>display <code id="conformance-details">"Detailed conformance information"</code> as heading.</span>
 					</li>
 					<li>
 						<span><b>IF</b> <var>epub_accessibility_10</var> <b>OR</b> <var>epub_accessibility_11</var> <b>OR</b> <var>wcag_20</var> <b>OR</b> <var>wcag_21</var> <b>OR</b> <var>wcag_22</var> <b>OR</b> <var>level_aaa</var> <b>OR</b> <var>level_aa</var> <b>OR</b> <var>level_a</var>:</span>


### PR DESCRIPTION
In the Guidelines I made the headings consistent. Only the first letter of a heading is capatlized. I also checked the IDs. I did not find any with cammel case. It must have been in the JSON file only. 