### PR TITLE
Changes Supports nonvisual to Support for

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -378,7 +378,7 @@
 
 				<ol>
 					<li>Visual adjustments</li>
-					<li>Supports nonvisual reading</li>
+					<li>Support for nonvisual reading</li>
 					<li>Conformance</li>
 				</ol>
 
@@ -468,7 +468,7 @@
 
 
 			<section id="supports-nonvisual-reading">
-				<h3 data-localization-id="nonvisual-reading-title">Supports nonvisual reading</h3>
+				<h3 data-localization-id="nonvisual-reading-title">Support for nonvisual reading</h3>
 
 				<div class="note">
 					<p>This key information should always be displayed, even if there is no metadata (See the examples
@@ -524,9 +524,9 @@
 
 					<ul>
 						<li><a href="../techniques/epub-metadata/index.html#supports-nonvisual-reading">EPUB
-								Accessibility: Supports nonvisual reading</a></li>
-						<li><a href="../techniques/onix-metadata/index.html#supports-nonvisual-reading">ONIX: Supports
-								nonvisual reading</a></li>
+								Accessibility: Support for nonvisual reading</a></li>
+						<li><a href="../techniques/onix-metadata/index.html#supports-nonvisual-reading">ONIX: Support
+								for nonvisual reading</a></li>
 					</ul>
 				</section>
 			</section>
@@ -1269,7 +1269,7 @@
 
 				<aside class="example" title="Minimum filtering options">
 					<ul>
-						<li>Supports Nonvisual Reading</li>
+						<li>Support for Nonvisual Reading</li>
 						<li>Supports Visual Adjustments</li>
 					</ul>
 				</aside>


### PR DESCRIPTION
This changes the title from Supports nonvisual reading to Support for nonvisual reading. This is is explained in #483.

It is a subtile change, but important. It will impact the techniques, so it cannot be closed with the changes to the guidelines alone.

I did not change any of the IDs, which also use this construct. I think we are OK there.