### PR TITLE
Rewrite of Complex content was Charts diagrams etc

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1302,31 +1302,21 @@
 			</section>
 		</section>
 		<section id="charts-diagrams-and-formulas">
-			<h3 data-localization-id="charts-diagrams-formulas-title">
-				Charts, diagrams, math, and formulas</h3>
+			<h3 data-localization-id="charts-diagrams-formulas-title">Complex content</h3>
 
 			<div class="note">
 				<p>This key information can be hidden if metadata is
 					missing. Alternatively it can be stated that
 					<span
 						data-localization-id="charts-diagrams-formulas-unknown"
-						data-localization-mode="descriptive">accessibility
-						of formulas, charts, math, and diagrams not
-						identified as being accessible</span>
+						data-localization-mode="descriptive">accessibility of complex content not identified as being accessible</span>
 				</p>
 			</div>
 
-			<p>Indicates the presence of formulas (including math,
-				chemistry, etc.), graphs, charts, and diagrams
-				within the title and whether these are in an accessible
-				format or available in an alternative form
-				(e.g., whether formulas are navigable with assistive
-				technologies, or whether extended descriptions
-				are available for complex images).</p>
+			<p>Indicates the presence of math, chemistry, charts, diagrams, figures or graphs within the title and whether these are in an accessible format or available in an alternative form, e.g., whether math and chemistry is navigable with assistive technologies, or whether extended descriptions are available for complex images.</p>
 
 			<p>This group should be displayed only if the metadata
-				indicates the presence of formulas, math, charts, or
-				graphs within the title, otherwise it can be hidden.</p>
+				indicates the presence of math, chemistry, charts, diagrams, figures, or graphs within the title, otherwise it can be hidden.</p>
 
 			<section id="cdf-examples">
 				<h4>Examples</h4>
@@ -1337,31 +1327,32 @@
 
 				<aside class="example" title="Descriptive explanations">
 					<ul>
+<li><span data-localization-id="charts-diagrams-formulas-accessible-math-as-mathml"
+								data-localization-mode="descriptive">Math as MathML</span>
+						</li>
+<li><span data-localization-id="charts-diagrams-formulas-accessible-math-as-latex"
+								data-localization-mode="descriptive">Math as Latex</span>
+						</li>
+						<li><span
+								data-localization-id="charts-diagrams-formulas-accessible-math-described"
+								data-localization-mode="descriptive">Math as images with text description</span>
+						</li>
+<li><span data-localization-id="charts-diagrams-formulas-accessible-chemistry-as-mathml"
+								data-localization-mode="descriptive">Chemistry is in MathML</span>
+						</li>
+<li><span data-localization-id="charts-diagrams-formulas-accessible-chemistry-as-latex"
+								data-localization-mode="descriptive">Chemistry is in LaTex</span>
+						</li>
 						<li>
 							<span
 								data-localization-id="charts-diagrams-formulas-extended"
-								data-localization-mode="descriptive">Charts
-								and diagrams are present and described
-								by extended descriptions</span>
-						</li>
-						<li><span
-								data-localization-id="charts-diagrams-formulas-accessible-math"
-								data-localization-mode="descriptive">Contains
-								math formulas in accessible
-								format</span>
-						</li>
-						<li><span
-								data-localization-id="charts-diagrams-formulas-accessible-chemistry"
-								data-localization-mode="descriptive">Chemistry
-								is in an accessible format</span>
+								data-localization-mode="descriptive">Charts and diagrams are present and have extended descriptions</span>
 						</li>
 						<li>
-							<span
-								data-localization-id="charts-diagrams-formulas-unknown"
+							<span data-localization-id="charts-diagrams-formulas-unknown"
 								data-localization-mode="descriptive">
 								accessibility of formulas, charts, math,
-								and diagrams not identified as being
-								accessible</span>
+								and diagrams not identified as being accessible</span>
 						</li>
 					</ul>
 				</aside>
@@ -1369,22 +1360,28 @@
 				<aside class="example" title="Compact explanations">
 					<ul>
 						<li>
+<span  data-localization-id="charts-diagrams-formulas-accessible-math-as-mathml"
+								data-localization-mode="compact">Math as MathML</span></li>
+<li>
+<span data-localization-id="charts-diagrams-formulas-accessible-math-as-latex"
+								data-localization-mode="compact">Math as LaTex</span></li>
+<li>
+<span data-localization-id="charts-diagrams-formulas-accessible-math-described"
+								data-localization-mode="compact">Math as images with text description</span></li>
+<li><span data-localization-id="charts-diagrams-formulas-accessible-chemistry-as-mathml"
+								data-localization-mode="compact">Chemistry in MathML</span>
+						</li>
+<li><span data-localization-id="charts-diagrams-formulas-accessible-chemistry-as-latex"
+								data-localization-mode="compact">Chemistry in LaTex</span>
+						</li>
+
+<li>
 							<span
 								data-localization-id="charts-diagrams-formulas-extended"
-								data-localization-mode="compact">Charts
-								and diagrams have extended
-								descriptions</span>
-							<span
-								data-localization-id="charts-diagrams-formulas-accessible-math"
-								data-localization-mode="compact">
-								Accessible math content</span>
-							<span
-								data-localization-id="charts-diagrams-formulas-accessible-chemistry"
-								data-localization-mode="compact">Accessible
-								chemistry content</span>
-						</li>
-						<li>
-							<span
+								data-localization-mode="compact">Charts, diagrams, figures, and graphs have extended descriptions</span>
+</li>
+
+						<li> <span
 								data-localization-id="charts-diagrams-formulas-unknown"
 								data-localization-mode="compact">accessibility
 								of formulas, charts, math, and diagrams


### PR DESCRIPTION
I could not find in the issues a new name for this section. From my memory of the discussion, we said "Complex content" so that is what I went with.

I have math chemistry, charts, diagrams, figures, and graphs as the list of items in addition to math and chemistry.

In the examples, I have appended to the IDs we use

For the math:
-as-mathml
-as-latex
-as-descriptive
For chemistry:
-as-mathml
-as-latex


Question:

Should we use the word "mathematics" in the normal text and in the descriptive  text? Some places use maths and others math, but mathematics is the formal usage.
 
-