### PR TITLE
Conformance section examples are now single items in each statement

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -915,18 +915,14 @@
 						<span
 							data-localization-id="conformance-certification-info"
 							data-localization-mode="compact">The
-							publication was certified</span>
-						<span
-							data-localization-id="conformance-certifier-prefix"
-							data-localization-mode="compact">by</span>
+							publication was certified by</span>
 						Foo's Accessibility Testing
 					</p>
 					<p>
 						<span
 							data-localization-id="conformance-certifier-credentials-prefix"
-							data-localization-mode="compact">with a
-							credential of</span> "Enterprise
-						Accessibility Rating."
+							data-localization-mode="compact">The certifier 's credential is</span> "Enterprise
+						Accessibility Rating"
 					</p>
 
 					<p data-localization-id="conformance-details">
@@ -950,18 +946,9 @@
 					</p>
 					<p><span data-localization-id="conformance-certification-info"
 							data-localization-mode="descriptive">The
-							publication was certified</span>
-						<span
-							data-localization-id="conformance-certification-date-prefix">on</span>
-						2021-09-07
-						<span
-							data-localization-id="conformance-certifier-prefix"
-							data-localization-mode="descriptive">by</span>
-						Foo's Accessibility Testing <span
-							data-localization-id="conformance-certifier-credentials-prefix">with
-							a credential
-							of</span> "Enterprise Accessibility Rating"
-						<span
+							publication was certified on</span>
+						2021-09-07</p>
+						<p><span
 							data-localization-id="conformance-certifier-report">For
 							more information refer to the
 							<a
@@ -981,18 +968,14 @@
 						<span
 							data-localization-id="conformance-certification-info"
 							data-localization-mode="compact">The
-							publication was certified</span>
-						<span
-							data-localization-id="conformance-certifier-prefix"
-							data-localization-mode="compact">by</span>
+							publication was certified by</span>
 						Foo's Accessibility Testing
 					</p>
 					<p>
 						<span
 							data-localization-id="conformance-certifier-credentials-prefix"
-							data-localization-mode="compact">with a
-							credential of</span> "Enterprise
-						Accessibility Rating."
+							data-localization-mode="compact">The certifier 's credential is</span> "Enterprise
+						Accessibility Rating"
 					</p>
 					<p data-localization-id="conformance-details">
 						Detailed conformance information</p>
@@ -1014,17 +997,11 @@
 					</p>
 					<p><span data-localization-id="conformance-certification-info"
 							data-localization-mode="descriptive">The
-							publication was certified</span>
-						<span
-							data-localization-id="conformance-certification-date-prefix">on</span>
-						2021-09-07
-						<span
-							data-localization-id="conformance-certifier-prefix"
-							data-localization-mode="descriptive">by</span>
-						Foo's Accessibility Testing <span
-							data-localization-id="conformance-certifier-credentials-prefix">with
-							a credential of</span> "Enterprise
-						Accessibility Rating" <span
+							publication was certified on</span>
+					2021-09-07</p>
+						<p><span data-localization-id="conformance-certifier-credentials-prefix">The certifier 's credential is</span> "Enterprise
+						Accessibility Rating" </p>
+<p><span
 							data-localization-id="conformance-certifier-report">For
 							more information refer to the
 							<a
@@ -1049,17 +1026,19 @@
 					<p><span
 							data-localization-id="conformance-certifier-credentials">The
 							certifier's credential is</span>"Enterprise
-						Accessibility Rating."</p>
+						Accessibility Rating</p>
 
 
 					<p data-localization-id="conformance-details">
 						Detailed conformance information</p>
 					<p>This publication reports (Publisher's in-house
-						specification.)</p>
+						specification</p>
 					<p> The publication was certified
-						on 2021-09-07 by Foo's Accessibility Testing
-						with a credential of "Enterprise Accessibility
-						Rating." For more information refer to the <a
+						on 2021-09-07 </p>
+<p>
+						The certifier 's credential is"Enterprise Accessibility
+						Rating" </p>
+<p>For more information refer to the <a
 							href="http://www.example.com/a11y/report/9780000000001">certifier's
 							report.</a></p>
 

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1432,7 +1432,7 @@
 				not been checked for hazards. This is
 				different than providing no metadata for this property
 				which does not carry any meaning. In either case, the
-				information to the end user is "not known."</p>
+				information to the end user is"not known."</p>
 
 			<section id="hazards-examples">
 				<h4>Examples</h4>
@@ -1581,7 +1581,7 @@
 				considerations</h3>
 
 			<div class="issue" data-number="350">We are actively seeking
-				comments on this "legal consideration"
+				comments on this"legal consideration"
 				section. If you are a publisher, we want your feedback!
 				Please visit the GitHub Issue tracking
 				linked above to leave a comment.</div>


### PR DESCRIPTION
The changes makes the conformance much cleaner.

In the conformance section, each statement is in a paragraph with a single entry. This assumes a placeholder will be used to extract the metadata, such as the date into the item.

I expect conformance to EPUB 1.0 or 1.1, the WCAG number, and the level will be modified in the techniques. This will require changes in this section after the techniques are finished.
