### PR TITLE
Updated the Audio playback section 

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1078,7 +1078,7 @@
 
 
 		<section id="pre-recorded-audio">
-			<h3 data-localization-id="pre-recorded-audio-title">Audio playback</h3>
+			<h3 data-localization-id="pre-recorded-audio-title">Prerecorded audio</h3>
 
 			<div class="note">
 				<p>This key information can be hidden if metadata is
@@ -1120,7 +1120,7 @@
 					<ul>
 						<li data-localization-id="pre-recorded-audio-only"
 							data-localization-mode="descriptive">
-							Prerecorded audiobook with no text alternative</li>
+							audiobook with no text alternative</li>
 						<!-- <li data-localization-id="pre-recorded-audio-complementary"
 							data-localization-mode="descriptive">
 							Contents available as complementary audio
@@ -1139,9 +1139,9 @@
 				<aside class="example" title="Compact explanations">
 					<ul>
 						<li data-localization-id="pre-recorded-audio-only"
-							data-localization-mode="compact">Prerecorded audiobook only</li>
+							data-localization-mode="compact">Audiobook</li>
 						<li data-localization-id="pre-recorded-audio-synchronized"
-							data-localization-mode="compact">Prerecorded synchronized audio and text</li>
+							data-localization-mode="compact">Prerecorded audio synchronized with text</li>
 <li data-localization-id="pre-recorded-audio-no-metadata"
 							data-localization-mode="compact">
 							Prerecorded audio not provided</li>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1078,8 +1078,7 @@
 
 
 		<section id="pre-recorded-audio">
-			<h3 data-localization-id="pre-recorded-audio-title">
-				Prerecorded audio</h3>
+			<h3 data-localization-id="pre-recorded-audio-title">Audio playback</h3>
 
 			<div class="note">
 				<p>This key information can be hidden if metadata is
@@ -1092,11 +1091,7 @@
 				</p>
 			</div>
 
-			<p>Indicates the presence of prerecorded audio and specifies
-				if this audio is standalone (an
-				audiobook), accompanies text (embedded audio and video
-				clips), or represents an alternative to the
-				text (synchronized text-audio playback).</p>
+			<p>Indicates the presence of prerecorded audio and specifies if this audio is standalone (an audiobook), or is an alternative to the text (synchronized text with audio playback).</p>
 
 			<p>Audiobooks created for mainstream use provide important
 				access for many users with disabilities even
@@ -1104,10 +1099,10 @@
 				popularity, audiobooks may provide more
 				accessibility options in the future.</p>
 
-			<p>Some publications provide audio (including audio in
+			<!-- <p>Some publications provide audio (including audio in
 				video) in addition to text. In this case, it is
 				important that the user is informed that they may not be
-				able to access all content in the book. </p>
+				able to access all content in the book. </p> -->
 
 			<p>Some publications provide prerecorded audio with text
 				synchronization. Users with hearing
@@ -1125,30 +1120,31 @@
 					<ul>
 						<li data-localization-id="pre-recorded-audio-only"
 							data-localization-mode="descriptive">
-							Audiobook with no text alternative</li>
-						<li data-localization-id="pre-recorded-audio-complementary"
+							Prerecorded audiobook with no text alternative</li>
+						<!-- <li data-localization-id="pre-recorded-audio-complementary"
 							data-localization-mode="descriptive">
 							Contents available as complementary audio
 							and
-							text</li>
+							text</li> -->
 						<li data-localization-id="pre-recorded-audio-synchronized"
 							data-localization-mode="descriptive">All the
 							content is available as prerecorded audio
 							synchronized with text</li>
+<li data-localization-id="pre-recorded-audio-no-metadata"
+							data-localization-mode="descriptive">
+							Prerecorded audio not provided</li>
 					</ul>
 				</aside>
 
 				<aside class="example" title="Compact explanations">
 					<ul>
 						<li data-localization-id="pre-recorded-audio-only"
-							data-localization-mode="compact">Audio
-							only</li>
-						<li data-localization-id="pre-recorded-audio-complementary"
-							data-localization-mode="compact">
-							Complementary audio and text</li>
+							data-localization-mode="compact">Prerecorded audiobook only</li>
 						<li data-localization-id="pre-recorded-audio-synchronized"
+							data-localization-mode="compact">Prerecorded synchronized audio and text</li>
+<li data-localization-id="pre-recorded-audio-no-metadata"
 							data-localization-mode="compact">
-							Synchronized audio and text</li>
+							Prerecorded audio not provided</li>
 					</ul>
 				</aside>
 			</section>


### PR DESCRIPTION
The audio section is simplified. This fixes #528. It has the prerecorded audiobook, the audio synced with text, and prerecorded audio not provided.

In the Rich content section, there is the audio and transcript, which the audio is complementary.

This will require changes in the techniques.