### PR TITLE
Aligned the guidelines with what is in ONIX techniques 

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1,4 +1,4 @@
-	<!DOCTYPE html>
+		<!DOCTYPE html>
 
 
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US"
@@ -1443,9 +1443,7 @@ Prerecorded audio has transcript</span></li>
 				unknown, which means the content creator of the
 				metadata explicitly acknowledges that the resource has
 				not been checked for hazards. This is
-				different than providing no metadata for this property
-				which does not carry any meaning. In either case, the
-				information to the end user is"not known."</p>
+				different than providing no metadata for this property.</p>
 
 			<section id="hazards-examples">
 				<h4>Examples</h4>
@@ -1465,18 +1463,20 @@ Prerecorded audio has transcript</span></li>
 								publication contains flashing content
 								which can cause photosensitive
 								seizures</span></li>
+<li><span data-localization-id="hazards-motion"
+								data-localization-mode="descriptive">The
+								publication contains motion simulations
+								that can cause motion sickness</span></li>
 						<li><span data-localization-id="hazards-sound"
 								data-localization-mode="descriptive">The
 								publication contains loud sounds which
 								can be uncomfortable</span></li>
-						<li><span data-localization-id="hazards-motion"
-								data-localization-mode="descriptive">The
-								publication contains motion simulations
-								that can cause motion sickness</span>
-						</li>
 						<li><span data-localization-id="hazards-unknown"
-								data-localization-mode="descriptive">Presents
-								of hazards is not known</span></li>
+								data-localization-mode="descriptive">The presents
+								of hazards is unknown</span></li>
+						<li><span data-localization-id="hazards-no-metadata]."
+								data-localization-mode="descriptive">No information about possible hazards is available</span></li>
+
 					</ul>
 				</aside>
 
@@ -1491,16 +1491,18 @@ Prerecorded audio has transcript</span></li>
 								data-localization-id="hazards-flashing"
 								data-localization-mode="compact">Flashing
 								content</span></li>
-						<li><span data-localization-id="hazards-sound"
-								data-localization-mode="compact">Loud
-								sounds</span></li>
 						<li><span data-localization-id="hazards-motion"
 								data-localization-mode="compact">Motion
 								simulation</span></li>
+<li><span data-localization-id="hazards-sound"
+								data-localization-mode="compact">Loud
+								sounds</span></li>
+<li><span
+								data-localization-id="hazards-unknown"
+								data-localization-mode="compact"></span>The presence of hazards is unknown</li>
 						<li><span
 								data-localization-id="hazards-no-metadata"
-								data-localization-mode="compact">Not
-								known</span></li>
+								data-localization-mode="compact">No information about possible hazards is available</span></li>
 					</ul>
 				</aside>
 			</section>


### PR DESCRIPTION
I used the content from PR 526, the ONIX hazard refactoring to adjust the balues in the guidelines.

I made the order in the guidelines the same as in the ONIX.
In the introduction where we talk about hazard metadata being different do we want to explain the difference between:
• The presents of hazards is unknown
• No information about possible hazards is available
The second one is where there is no metadata.

I noticed that we are inconsistent about the use of headings before the examples. I will create an issue about this.

