### PR TITLE
From dec 12 discussion

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1121,7 +1121,7 @@
 					<ul>
 						<li data-localization-id="pre-recorded-audio-only"
 							data-localization-mode="descriptive">
-							audiobook with no text alternative</li>
+							Audiobook with no text alternative</li>
 						<!-- <li data-localization-id="pre-recorded-audio-complementary"
 							data-localization-mode="descriptive">
 							Contents available as complementary audio
@@ -1216,7 +1216,7 @@
 							features contain:</span></p>
 					<ul>
 						<li data-localization-id="navigation-toc"
-							data-localization-mode="descriptive">a table
+							data-localization-mode="descriptive">A table
 							of contents to all chapters of the text via
 							links</li>
 						<li data-localization-id="navigation-index"
@@ -1224,7 +1224,7 @@
 							index
 							to links to referenced entries</li>
 						<li data-localization-id="navigation-structural"
-							data-localization-mode="descriptive">book
+							data-localization-mode="descriptive">Book
 							elements such as headings, tables, etc for
 							structured navigation</li>
 						<li data-localization-id="navigation-page-navigation"
@@ -1306,20 +1306,20 @@
 <p>Rich content contains:</p>
 					<ul>
 <li><span data-localization-id="charts-diagrams-formulas-accessible-math-as-mathml"
-								data-localization-mode="descriptive">math formulas in accessible format (MathML)</span>
+								data-localization-mode="descriptive">Math formulas in accessible format (MathML)</span>
 						</li>
 <li><span data-localization-id="charts-diagrams-formulas-accessible-math-as-latex"
-								data-localization-mode="descriptive">math formulas in accessible format (LaTex)</span>
+								data-localization-mode="descriptive">Math formulas in accessible format (LaTex)</span>
 						</li>
 						<li><span
 								data-localization-id="charts-diagrams-formulas-accessible-math-described"
-								data-localization-mode="descriptive">math formulas in accessible format (formulas as images with textual description)</span>
+								data-localization-mode="descriptive">Math formulas in accessible format (formulas as images with textual description)</span>
 						</li>
 <li><span data-localization-id="charts-diagrams-formulas-accessible-chemistry-as-mathml"
-								data-localization-mode="descriptive">chemical formulas in accessible format (MathML)</span>
+								data-localization-mode="descriptive">Chemical formulas in accessible format (MathML)</span>
 						</li>
 <li><span data-localization-id="charts-diagrams-formulas-accessible-chemistry-as-latex"
-								data-localization-mode="descriptive">chemical formulas in accessible format (LaTex)</span>
+								data-localization-mode="descriptive">Chemical formulas in accessible format (LaTex)</span>
 						</li>
 						<li>
 							<span
@@ -1339,7 +1339,7 @@ Prerecorded audio has a full transcript</span></li>
 <li>
 							<span data-localization-id="charts-diagrams-formulas-unknown"
 								data-localization-mode="descriptive">
-								math, chemical formulas, charts, diagrams, figures, graphs, videos, and audio content  not identified as being accessible</span>
+								Math, chemical formulas, charts, diagrams, figures, graphs, videos, and audio content  not identified as being accessible</span>
 						</li>
 					</ul>
 				</aside>
@@ -1357,16 +1357,16 @@ Prerecorded audio has a full transcript</span></li>
 <span data-localization-id="charts-diagrams-formulas-accessible-math-described"
 								data-localization-mode="compact">Math as images with text description</span></li>
 <li><span data-localization-id="charts-diagrams-formulas-accessible-chemistry-as-mathml"
-								data-localization-mode="compact">chemical formulas in MathML</span>
+								data-localization-mode="compact">Chemical formulas in MathML</span>
 						</li>
 <li><span data-localization-id="charts-diagrams-formulas-accessible-chemistry-as-latex"
-								data-localization-mode="compact">chemical formulas in LaTex</span>
+								data-localization-mode="compact">Chemical formulas in LaTex</span>
 						</li>
 
 <li>
 							<span
 								data-localization-id="charts-diagrams-formulas-extended"
-								data-localization-mode="compact">complex images are described by extended descriptions</span>
+								data-localization-mode="compact">Complex images are described by extended descriptions</span>
 </li>
 <li><span data-localization-id="additional-accessibility-information-adaptation-closed-captions" data-localization-mode="compact">
 Videos have closed
@@ -1795,7 +1795,7 @@ Prerecorded audio has transcript</span></li>
 <p>Structure:</p>
 					<ul>
 						<li>ARIA roles included</li>
-						<li>visible page numbering</li>
+						<li>Visible page numbering</li>
 
 
 					</ul>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -546,7 +546,7 @@
 				expected that these other areas of key information will
 				give people what they need to make an
 				informed choice to read a particular e-book.</p>
-<div class="note"><p>When no accessibility metadata is being provided by the publisher, making a statement that the item is "unknown" or "The metadata was not provided" creates a negative statement, which the publisher did not make. The distributer may not be allowed to show statements the publisher did not make. </p></div>
+<div class="note"><p>When no accessibility metadata is being provided by the publisher, it is best to avoid making a negative statement, which could be attributed to the publisher. The distributer may not be allowed to show statements the publisher did not make.  The neutral statement "No information is available" is shown in the examples for this case.</p></div>
 
 			<div class="note">
 				<p>This document does not define the order in which to
@@ -620,7 +620,7 @@
 							provide zooming options</li>
 						<li data-localization-id="visual-adjustments-unknown"
 							data-localization-mode="descriptive">
-							Appearance modifiability not known</li>
+							No information is available</li>
 					</ul>
 				</aside>
 
@@ -635,8 +635,7 @@
 							cannot be modified</li>
 						<!--if display transformability is not present and text on visual is present-->
 						<li data-localization-id="visual-adjustments-unknown"
-							data-localization-mode="compact">Appearance
-							modifiability not known</li>
+							data-localization-mode="compact">No information is available</li>
 						<!--if neither display transformability nor text on visual are presents-->
 					</ul>
 				</aside>
@@ -718,6 +717,7 @@
 							data-localization-mode="descriptive">Not all
 							of the content will be readable as read
 							aloud speech or dynamic braille</li>
+<li>No information is available</li>
 					</ul>
 				</aside>
 
@@ -738,7 +738,8 @@
 							fully readable in read aloud or dynamic
 							braille</li>
 						<!--To be Confirmed (see https://github.com/w3c/publ-a11y/issues/367)<li data-localization-id="nonvisual-reading-unknown" data-localization-mode="compact">Not known if readable in read aloud and braille</li>-->
-					</ul>
+<li>No information is available</li>
+</ul>
 				</aside>
 			</section>
 
@@ -956,6 +957,7 @@
 								href="http://www.example.com/a11y/report/9780000000001">certifier's
 								report</a></span>
 					</p>
+<p>No information is available</p>
 
 				</aside>
 
@@ -1009,6 +1011,7 @@
 								href="http://www.example.com/a11y/report/9780000000001">certifier's
 								report</a></span>
 					</p>
+<p>No information is available</p>
 				</aside>
 
 
@@ -1042,16 +1045,15 @@
 <p>For more information refer to the <a
 							href="http://www.example.com/a11y/report/9780000000001">certifier's
 							report.</a></p>
-
+<p>No information is available</p>
 				</aside>
 
 				<aside class="example"
 					title="Missing a conformance statement">
 					<p data-localization-id="conformance-no"
-						data-localization-mode="compact">The publication
-						does not include a conformance statement</p>
+						data-localization-mode="compact">No information is available</p>
 					<p>Detailed conformance information:</p>
-					<p>The conformance metadata was not found</p>
+					<p>No information is available</p>
 
 
 				</aside>
@@ -1133,7 +1135,7 @@
 							synchronized with text</li>
 <li data-localization-id="pre-recorded-audio-no-metadata"
 							data-localization-mode="descriptive">
-							Prerecorded audio not provided</li>
+							No information is available</li>
 					</ul>
 				</aside>
 
@@ -1145,7 +1147,7 @@
 							data-localization-mode="compact">Prerecorded audio synchronized with text</li>
 <li data-localization-id="pre-recorded-audio-no-metadata"
 							data-localization-mode="compact">
-							Prerecorded audio not provided</li>
+							No information is available</li>
 					</ul>
 				</aside>
 			</section>
@@ -1232,6 +1234,7 @@
 							page list to go to pages from the print
 							source
 							version</li>
+<li>No information is available</li>
 					</ul>
 				</aside>
 
@@ -1256,6 +1259,7 @@
 								data-localization-id="navigation-page-navigation"
 								data-localization-mode="compact">go to
 								page </span></li>
+<li>No information is available</li>
 					</ul>
 				</aside>
 			</section>
@@ -1339,8 +1343,9 @@ Prerecorded audio has a full transcript</span></li>
 <li>
 							<span data-localization-id="charts-diagrams-formulas-unknown"
 								data-localization-mode="descriptive">
-								Math, chemical formulas, charts, diagrams, figures, graphs, videos, and audio content  not identified as being accessible</span>
+								Math, chemical formulas, charts, diagrams, figures, graphs, videos, or audio content  not identified as being accessible</span>
 						</li>
+<li>No information is available</li>
 					</ul>
 				</aside>
 
@@ -1383,6 +1388,7 @@ Prerecorded audio has transcript</span></li>
 								data-localization-id="charts-diagrams-formulas-unknown"
 								data-localization-mode="compact">Rich content not identified as being accessible</span>
 						</li>
+<li>No information is available</li>
 					</ul>
 				</aside>
 			</section>
@@ -1475,7 +1481,7 @@ Prerecorded audio has transcript</span></li>
 								data-localization-mode="descriptive">The presents
 								of hazards is unknown</span></li>
 						<li><span data-localization-id="hazards-no-metadata]."
-								data-localization-mode="descriptive">No information about possible hazards is available</span></li>
+								data-localization-mode="descriptive">No information is available</span></li>
 
 					</ul>
 				</aside>
@@ -1502,7 +1508,7 @@ Prerecorded audio has transcript</span></li>
 								data-localization-mode="compact"></span>The presence of hazards is unknown</li>
 						<li><span
 								data-localization-id="hazards-no-metadata"
-								data-localization-mode="compact">No information about possible hazards is available</span></li>
+								data-localization-mode="compact">No information is available</span></li>
 					</ul>
 				</aside>
 			</section>
@@ -1568,6 +1574,7 @@ Prerecorded audio has transcript</span></li>
 						be expanded. There are several short videos in
 						American Sign Language that explains key
 						concepts.</p>
+<p>No information is available</p>
 				</aside>
 			</section>
 
@@ -1656,6 +1663,7 @@ Prerecorded audio has transcript</span></li>
 						data-localization-mode="descriptive">This
 						publication claims an accessibility exemption in
 						some jurisdictions</p>
+<p>No information is available</p>
 				</aside>
 
 			</section>
@@ -1787,6 +1795,7 @@ Prerecorded audio has transcript</span></li>
 							facilitate access to visual elements for
 							blind
 							people</li>
+<li>No information is available</li>
 </ul>
 
 				</aside>
@@ -1796,7 +1805,7 @@ Prerecorded audio has transcript</span></li>
 					<ul>
 						<li>ARIA roles included</li>
 						<li>Visible page numbering</li>
-
+<li>No information is available</li>
 
 					</ul>
 
@@ -1807,6 +1816,7 @@ Prerecorded audio has transcript</span></li>
 <p>Tactile:</p>
 <ul>
 						<li>Tactile graphics attached</li>
+<li>No information is available</li>
 </ul>
 
 				</aside>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -569,7 +569,7 @@
 			<div class="note">
 				<p>This key information should be displayed, even
 					if there is no metadata (See the examples
-					where the metadata is not known). </p>
+					where "No information is available"). </p>
 			</div>
 
 			<p>Indicates if users can modify the appearance of the text
@@ -669,7 +669,7 @@
 			<div class="note">
 				<p>This key information should be displayed, even
 					if there is no metadata (See the examples
-					where the metadata is not known). </p>
+					where "No information is available"). </p>
 			</div>
 
 			<p>Indicates whether all content required for comprehension
@@ -769,7 +769,7 @@
 			<div class="note">
 				<p>This key information should be displayed, even
 					if there is no metadata (See the examples
-					where the metadata is not known). </p>
+					where "No information is available"). </p>
 			</div>
 
 			<p>Identifies whether the digital publication claims to meet
@@ -1088,9 +1088,7 @@
 					missing. Alternatively it can be stated that
 					<span
 						data-localization-id="pre-recorded-audio-no-metadata"
-						data-localization-mode="descriptive">No
-						information about prerecorded audio is
-						available.</span>
+						data-localization-mode="descriptive">No information is available</span>
 				</p>
 			</div>
 
@@ -1177,9 +1175,7 @@
 				<p>This key information can be hidden if metadata is
 					missing. Alternatively it can be stated that
 					<span data-localization-id="navigation-no-metadata"
-						data-localization-mode="descriptive">No
-						information about navigation is
-						available</span>.
+						data-localization-mode="descriptive">No information is available</span>.
 				</p>
 			</div>
 
@@ -1289,7 +1285,7 @@
 					missing. Alternatively it can be stated that
 					<span
 						data-localization-id="charts-diagrams-formulas-unknown"
-						data-localization-mode="descriptive">accessibility of rich content not identified as being accessible</span>
+						data-localization-mode="descriptive">No information is available</span>
 				</p>
 			</div>
 
@@ -1420,9 +1416,7 @@ Prerecorded audio has transcript</span></li>
 				<p>This key information can be hidden if metadata is
 					missing. Alternatively it can be stated that
 					<span data-localization-id="hazards-no-metadata"
-						data-localization-mode="descriptive">No
-						information about possible hazards is
-						available.</span>
+						data-localization-mode="descriptive">No information is available</span>
 				</p>
 			</div>
 
@@ -1540,8 +1534,7 @@ Prerecorded audio has transcript</span></li>
 					missing. Alternatively it can be stated that
 					<span
 						data-localization-id="accessibility-summary-no-metadata"
-						data-localization-mode="descriptive">No
-						accessibility summary is available.</span>
+						data-localization-mode="descriptive">No information is available</span>
 				</p>
 			</div>
 


### PR DESCRIPTION
Oops, forgot pull before I made changes, sigh. May need to throw this away. I will see.

Made the capitilization changes Matt suggested.
Added No information is available to the end of the examples. Where the logic was there, just inserted. It was not there in several places. These do not have an ID in the paragraph or list item.

We need to take a close look at the logic in te techniques for the Rich content section. I see several problems.

