### PR TITLE
Reference to techniques updated and some other changes

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -783,9 +783,7 @@
 				WCAG levels are identified.</p>
 
 			<p>If the publication does not include a conformance claim,
-				the statement should indicate that the
-				publication does not include a conformance statement.
-			</p>
+				the statement should indicate that no information is available.</p>
 
 			<p>In most cases, people will want to know more about the
 				conformance and certification of the
@@ -835,11 +833,8 @@
 					<!--To be Confirmed (see https://github.com/w3c/publ-a11y/issues/368)-->
 
 					<dt data-localization-id="conformance-no"
-						data-localization-mode="compact">The publication
-						does
-						not include a conformance statement</dt>
-					<dd data-localization-id="conformance-no"
-						data-localization-mode="descriptive">
+						data-localization-mode="compact">No information is available</dt>
+					<dd >
 						<p>The conformance metadata is missing and
 							conformity to a standard of this publication
 							is
@@ -957,7 +952,7 @@
 								href="http://www.example.com/a11y/report/9780000000001">certifier's
 								report</a></span>
 					</p>
-<p>No information is available</p>
+
 
 				</aside>
 
@@ -1011,7 +1006,7 @@
 								href="http://www.example.com/a11y/report/9780000000001">certifier's
 								report</a></span>
 					</p>
-<p>No information is available</p>
+
 				</aside>
 
 
@@ -1045,15 +1040,18 @@
 <p>For more information refer to the <a
 							href="http://www.example.com/a11y/report/9780000000001">certifier's
 							report.</a></p>
-<p>No information is available</p>
+
 				</aside>
 
 				<aside class="example"
 					title="Missing a conformance statement">
 					<p data-localization-id="conformance-no"
 						data-localization-mode="compact">No information is available</p>
+
+<!-- It does not make sense to have detailed information when we already know that no conformance information was provided.
+
 					<p>Detailed conformance information:</p>
-					<p>No information is available</p>
+					<p>No information is available</p> -->
 
 
 				</aside>
@@ -1540,7 +1538,7 @@ Prerecorded audio has transcript</span></li>
 			<p>The accessibility summary was intended (in EPUB
 				Accessibility 1.0) to describe in human-readable
 				prose the accessibility features present in the
-				publication as well as any shortcomings. From EPUB
+				publication as well as any shortcomings. Starting with  EPUB
 				Accessibility version 1.1 the accessibility summary
 				became a human-readable summary of the
 				accessibility that complements, but does not duplicate,

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -744,7 +744,7 @@
 			</section>
 
 			<section id="nv-techniques">
-				<h4>Display techniques for nonvisual reading support
+				<h4>Display techniques for support for nonvisual reading support
 				</h4>
 
 				<p>Specific techniques for meeting this principle are
@@ -1390,8 +1390,8 @@ Prerecorded audio has transcript</span></li>
 			</section>
 
 			<section id="cdf-techniques">
-				<h4>Display techniques for charts, diagrams, and
-					formulas support</h4>
+				<h4>Display techniques for rich content support</h4>
+
 
 				<p>Specific techniques for meeting this principle are
 					defined in the following documents:</p>
@@ -1399,12 +1399,11 @@ Prerecorded audio has transcript</span></li>
 				<ul>
 					<li><a
 							href="../techniques/epub-metadata/index.html#charts-diagrams-and-formulas">EPUB
-							Accessibility: Graphics and Formulas</a>
+							Accessibility: Rich content</a>
 					</li>
 					<li><a
 							href="../techniques/onix-metadata/index.html#charts-diagrams-and-formulas">ONIX:
-							Graphics
-							and Formulas</a></li>
+							Rich content</a></li>
 				</ul>
 			</section>
 		</section>


### PR DESCRIPTION
In the links to the techniques, the headings had the old text in the rich content section and in nonvisual reading. These have been now fixed.

Fixes #534 
fixes #533 
I went through all of key information sectiond and made several changes. There were several places where  No information is available seemed incorrect. I also removed the No information is available for detailed information, because it did not make sense to repeate it. I commented it out in the file.
