### PR TITLE
Removed headings in examples for nav, rich, additional info

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1209,25 +1209,22 @@
 					adoption.</p>
 
 				<aside class="example" title="Descriptive explanations">
-					<p><span data-localization-id="navigation-intro"
+					<!-- <p><span data-localization-id="navigation-intro"
 							data-localization-mode="descriptive">Navigation
-							features contain:</span></p>
+							features contain:</span></p> -->
 					<ul>
 						<li data-localization-id="navigation-toc"
-							data-localization-mode="descriptive">A table
+							data-localization-mode="descriptive">Table
 							of contents to all chapters of the text via
 							links</li>
 						<li data-localization-id="navigation-index"
-							data-localization-mode="descriptive">An
-							index
-							to links to referenced entries</li>
+							data-localization-mode="descriptive">Index
+							with links to referenced entries</li>
 						<li data-localization-id="navigation-structural"
-							data-localization-mode="descriptive">Book
-							elements such as headings, tables, etc for
+							data-localization-mode="descriptive">Elements such as headings, tables, etc for
 							structured navigation</li>
 						<li data-localization-id="navigation-page-navigation"
-							data-localization-mode="descriptive">A
-							page list to go to pages from the print
+							data-localization-mode="descriptive">Page list to go to pages from the print
 							source
 							version</li>
 <li>No information is available</li>
@@ -1235,9 +1232,7 @@
 				</aside>
 
 				<aside class="example" title="Compact explanation">
-					<p><span data-localization-id="navigation-intro"
-							data-localization-mode="compact">Navigation
-							by:</span></p>
+
 					<ul>
 						<li><span data-localization-id="navigation-toc"
 								data-localization-mode="compact">table
@@ -1303,7 +1298,6 @@
 
 				<aside class="example" title="Descriptive explanations">
 
-<p>Rich content contains:</p>
 					<ul>
 <li><span data-localization-id="charts-diagrams-formulas-accessible-math-as-mathml"
 								data-localization-mode="descriptive">Math formulas in accessible format (MathML)</span>
@@ -1346,7 +1340,7 @@ Prerecorded audio has a full transcript</span></li>
 				</aside>
 
 				<aside class="example" title="Compact explanations">
-<p>Contains:</p>
+
 					<ul>
 						<li>
 <span  data-localization-id="charts-diagrams-formulas-accessible-math-as-mathml"
@@ -1373,7 +1367,7 @@ Prerecorded audio has a full transcript</span></li>
 Videos have closed
 							captions </span></li>
 						<li>
-<span data-localization-id="additional-accessibility-information-adaptation-open-captions" data-localization-mode="descriptive">
+<span data-localization-id="additional-accessibility-information-adaptation-open-captions" data-localization-mode="compact">
 Videos have open captions </span></li>
 <li><span data-localization-id="pre-recorded-audio-complementary" data-localization-mode="compact">
 Prerecorded audio is present</span></li>
@@ -1702,7 +1696,7 @@ Prerecorded audio has transcript</span></li>
 				range of information related to the
 				publication's content. Therefore, the features are
 				grouped so that the presentation is more
-				understandable to end users.</p>
+				understandable.</p>
 
 <p>The categories are:</p>
 			<dl>
@@ -1767,23 +1761,13 @@ Prerecorded audio has transcript</span></li>
 					techniques. </div>
 
 				<aside class="example" title="Descriptive explanations">
-<p>Structure:</p>
+
 					<ul>
 						<li>Content is enhanced with ARIA roles to
 							optimize organization and facilitate
 							navigation</li>
 						<li>Page breaks included from the original print
 							source</li>
-</ul>
-
-<p>Adaptation:</p>
-<ul>
-						<li>Videos included in publications have closed
-							captions </li>
-</ul>
-
-<p>Tactile:</p>
-<ul>
 						<li>Tactile graphics have been integrated to
 							facilitate access to visual elements for
 							blind
@@ -1794,20 +1778,10 @@ Prerecorded audio has transcript</span></li>
 				</aside>
 
 				<aside class="example" title="Compact explanations">
-<p>Structure:</p>
+
 					<ul>
 						<li>ARIA roles included</li>
 						<li>Visible page numbering</li>
-<li>No information is available</li>
-
-					</ul>
-
-<p>Adaptation:</p>
-<ul>
-						<li>Closed captions for videos</li>
-</ul>
-<p>Tactile:</p>
-<ul>
 						<li>Tactile graphics attached</li>
 <li>No information is available</li>
 </ul>


### PR DESCRIPTION
Removed the headings before examples in Navigation, Rich content, and in Additional information. Some of the wording needed to change. I left the headings in the definition list explaining the additional information categories.

Also removed the cosed caption example in Additional information because it was covered in Rich content. 