### PR TITLE
Changes made that Gregorio, Charles, and George agreed on

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -551,8 +551,7 @@
 			<div class="note">
 				<p>This document does not define the order in which to
 					show the key accessibility information; each
-					implementer can decide the preferred order for
-					showing the accessibility information that
+					implementer can decide the preferred order and appropriate headings to use to show the accessibility information that
 					follows.</p>
 				<p>In this document are examples of important metadata
 					that is expected to be in a wide range of
@@ -1233,21 +1232,19 @@
 
 					<ul>
 						<li><span data-localization-id="navigation-toc"
-								data-localization-mode="compact">table
-								of
-								contents</span></li>
+								data-localization-mode="compact">Table
+								of contents</span></li>
 						<li><span
 								data-localization-id="navigation-index"
-								data-localization-mode="compact">index</span>
+								data-localization-mode="compact">Index</span>
 						</li>
 						<li><span
 								data-localization-id="navigation-structural"
-								data-localization-mode="compact">headings</span>
+								data-localization-mode="compact">Headings</span>
 						</li>
 						<li><span
 								data-localization-id="navigation-page-navigation"
-								data-localization-mode="compact">go to
-								page </span></li>
+								data-localization-mode="compact">Go to page </span></li>
 <li>No information is available</li>
 					</ul>
 				</aside>
@@ -1316,7 +1313,7 @@
 						<li>
 							<span
 								data-localization-id="charts-diagrams-formulas-extended"
-								data-localization-mode="descriptive">Charts, diagrams, figures, and graphs have extended descriptions</span>
+								data-localization-mode="descriptive">Complex images are described by extended descriptions</span>
 						</li>
 <li><span data-localization-id="additional-accessibility-information-adaptation-closed-captions" data-localization-mode="descriptive">
 Videos included in publications have closed
@@ -1328,11 +1325,6 @@ Videos included in publications have open captions </span></li>
 Prerecorded audio is present in the publication</span></li>
 <li><span data-localization-id="additional-accessibility-information-adaptation-full-transcript" data-localization-mode="descriptive">
 Prerecorded audio has a full transcript</span></li>
-<li>
-							<span data-localization-id="charts-diagrams-formulas-unknown"
-								data-localization-mode="descriptive">
-								Math, chemical formulas, charts, diagrams, figures, graphs, videos, or audio content  not identified as being accessible</span>
-						</li>
 <li>No information is available</li>
 					</ul>
 				</aside>
@@ -1371,11 +1363,6 @@ Videos have open captions </span></li>
 Prerecorded audio is present</span></li>
 <li><span data-localization-id="additional-accessibility-information-adaptation-full-transcript" data-localization-mode="compact">
 Prerecorded audio has transcript</span></li>
-
-						<li> <span
-								data-localization-id="charts-diagrams-formulas-unknown"
-								data-localization-mode="compact">Rich content not identified as being accessible</span>
-						</li>
 <li>No information is available</li>
 					</ul>
 				</aside>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1279,10 +1279,10 @@
 				</p>
 			</div>
 
-			<p>Indicates the presence of math, chemical formulas, charts, diagrams, figures or graphs within the title and whether these are in an accessible format or available in an alternative form, e.g., whether math and chemical formulas are navigable with assistive technologies, or whether extended descriptions are available for information-rich images. In addition, it indicates the presence of videos and prerecorded audio, and if closed captions, open captions, or transcripts are available.</p>
+			<p>Indicates the presence of math, chemical formulas, charts, diagrams, figures or graphs within the title and whether these are in an accessible format or available in an alternative form, e.g., whether math and chemical formulas are navigable with assistive technologies, or whether extended descriptions are available for information-rich images. In addition, it indicates the presence of videos and if closed captions, open captions, or transcripts for prerecorded audio are available.</p>
 
 			<p>This group should be displayed only if the metadata
-				indicates the presence of math, chemical formulas, charts, diagrams, figures, graphs, videos, or audio within the title, otherwise it can be hidden.</p>
+				indicates the presence of math, chemical formulas, charts, diagrams, figures, graphs, videos, or transcripts of audio within the title, otherwise it can be hidden.</p>
 
 			<section id="cdf-examples">
 				<h4>Examples</h4>
@@ -1321,8 +1321,6 @@ Videos included in publications have closed
 
 <li><span data-localization-id="additional-accessibility-information-adaptation-open-captions" data-localization-mode="descriptive">
 Videos included in publications have open captions </span></li>
-<li><span data-localization-id="pre-recorded-audio-complementary" data-localization-mode="descriptive">
-Prerecorded audio is present in the publication</span></li>
 <li><span data-localization-id="additional-accessibility-information-adaptation-full-transcript" data-localization-mode="descriptive">
 Prerecorded audio has a full transcript</span></li>
 <li>No information is available</li>
@@ -1359,8 +1357,6 @@ Videos have closed
 						<li>
 <span data-localization-id="additional-accessibility-information-adaptation-open-captions" data-localization-mode="compact">
 Videos have open captions </span></li>
-<li><span data-localization-id="pre-recorded-audio-complementary" data-localization-mode="compact">
-Prerecorded audio is present</span></li>
 <li><span data-localization-id="additional-accessibility-information-adaptation-full-transcript" data-localization-mode="compact">
 Prerecorded audio has transcript</span></li>
 <li>No information is available</li>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1279,7 +1279,7 @@
 				</p>
 			</div>
 
-			<p>Indicates the presence of math, chemical formulas, charts, diagrams, figures or graphs within the title and whether these are in an accessible format or available in an alternative form, e.g., whether math and chemical formulas are navigable with assistive technologies, or whether extended descriptions are available for complex images. In addition, it indicates the presence of videos and prerecorded audio, and if closed captions, open captions, or transcripts are available.</p>
+			<p>Indicates the presence of math, chemical formulas, charts, diagrams, figures or graphs within the title and whether these are in an accessible format or available in an alternative form, e.g., whether math and chemical formulas are navigable with assistive technologies, or whether extended descriptions are available for information-rich images. In addition, it indicates the presence of videos and prerecorded audio, and if closed captions, open captions, or transcripts are available.</p>
 
 			<p>This group should be displayed only if the metadata
 				indicates the presence of math, chemical formulas, charts, diagrams, figures, graphs, videos, or audio within the title, otherwise it can be hidden.</p>
@@ -1313,7 +1313,7 @@
 						<li>
 							<span
 								data-localization-id="charts-diagrams-formulas-extended"
-								data-localization-mode="descriptive">Complex images are described by extended descriptions</span>
+								data-localization-mode="descriptive">Information-rich images are described by extended descriptions</span>
 						</li>
 <li><span data-localization-id="additional-accessibility-information-adaptation-closed-captions" data-localization-mode="descriptive">
 Videos included in publications have closed
@@ -1351,7 +1351,7 @@ Prerecorded audio has a full transcript</span></li>
 <li>
 							<span
 								data-localization-id="charts-diagrams-formulas-extended"
-								data-localization-mode="compact">Complex images are described by extended descriptions</span>
+								data-localization-mode="compact">Information-rich images are described by extended descriptions</span>
 </li>
 <li><span data-localization-id="additional-accessibility-information-adaptation-closed-captions" data-localization-mode="compact">
 Videos have closed


### PR DESCRIPTION
Gregorio, Charles, and George met today. We discussed several items covered in this PR
1. In the navigation compact examples, the first letter was made uper case.
2.  In the Rich content section, the one statement was removed that said that charts, diagrams, figures, and graphs werenot identified as being accessible.
3. Added to the introduction of key information that the order and the heading used to show is up to the implementation. The headings is the key item here, because we expect implementers to have several groups under a single heading, such as "Reading Modes."