### PR TITLE
Added a note about the page break source to navigation before examples

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1198,6 +1198,8 @@
 						href="https://www.w3.org/TR/WCAG21/#multiple-ways">Success
 						Criterion 2.4.5 Multiple
 						Ways</a></cite>).</p>
+<div class="note"><p>While not required if available, it may be helpful to identify the bibliographic information about the page break source identified in metadata of the digital publication. Having sufficient information to identify the print source would assure students and educators that the digital version they are using is correctly associated with the print version used in the classroom. The goal is to have the go to page function take the digital user to the same page as the print version user.
+</p></div>
 
 			<section id="nav-examples">
 				<h4>Examples</h4>


### PR DESCRIPTION
Added this note about the page break source. Several problems here. First, the pageBreakSource is only an identifier. It would require advanced processing to retreive and present the bibliographic information about the print source.

Second, the system presenting the accessibility metadata may not be able to resolve and retrieve information about the other title referenced by the identifier .

So, it says while not required and if possible...

Iin the example, it does not show the bibliographic information.

This fixes #484 