### PR TITLE
ONIX Rich content refactor - first draft

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -730,6 +730,21 @@
 						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/14">code 14 of codelist 196</a> (Short alternative textual descriptions) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that all or substantially all non-text content has short alternative (textual) descriptions, usually provided via alt attributes.</p>
 					</dd>
+					<dt><var>closed_captions</var></dt>
+					<dd>
+						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/175/V210">code V210 of codelist 175</a> (Closed captions) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that the publication contains videos with closed captions or subtitles.</p>
+					</dd>
+					<dt><var>open_captions</var></dt>
+					<dd>
+						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/175/V211">code V211 of codelist 175</a> (Open captions) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that the publication contains videos with ‘burnt-in’ or hard captions or subtitles.</p>
+					</dd>
+					<dt><var>transcript</var></dt>
+					<dd>
+						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/175/V212">code V212 of codelist 175</a> (Transcript) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that the publication contains full transcript of audio and audiovisual content.</p>
+					</dd>
 				</dl>
 				<h4>Variables setup</h4>
 				<ol class="condition">
@@ -741,6 +756,9 @@
 					<li><b>LET</b> <var>math_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "17"]</code>.</li>
 					<li><b>LET</b> <var>contains_math_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/DescriptiveDetail[PrimaryContentType = "48" or ContentType = "48"] </code>.</li>
 					<li><b>LET</b> <var>short_textual_alternative_images</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "14"]</code>.</li>
+					<li><b>LET</b> <var>closed_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail[ProductFormDetail = "V210"]</code>.</li>
+					<li><b>LET</b> <var>open_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail[ProductFormDetail = "V211"]</code>.</li>
+					<li><b>LET</b> <var>transcript</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail[ProductFormDetail = "V212"]</code>.</li>
 				</ol>
 				<h4>Instructions</h4>
 				<ol class="condition">
@@ -768,12 +786,20 @@
 						<span><b>IF</b> <var>charts_diagrams_as_non_graphical_data</var> <b>OR</b> <var>full_alternative_textual_descriptions</var>:</span>
 						<span><b>THEN</b> display <code id="rich-content-extended">"Complex images are described by extended descriptions"</code>.</span>
 					</li>
-					<!-- Videos have closed captions -->
-					<!-- Videos have open captions -->
-					<!-- Prerecorded audio is present -->
-					<!-- Prerecorded audio has transcript -->
 					<li>
-						<span><b>IF</b> <b>NOT</b> (<var>math_formula_as_mathml</var> <b>OR</b> <var>math_formula_as_latex</var> <b>OR</b> (<var>contains_math_formula</var> <b>AND</b> <var>short_textual_alternative_images</var>) <b>OR</b> <var>chemical_formula_as_mathml</var> <b>OR</b> <var>charts_diagrams_as_non_graphical_data</var> <b>OR</b> <var>full_alternative_textual_descriptions</var>):</span>
+						<span><b>IF</b> <var>closed_captions</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-closed-captions">"Videos have closed captions"</code>.</span>
+					</li>
+					<li>
+						<span><b>IF</b> <var>open_captions</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-open-captions">"Videos have open captions"</code>.</span>
+					</li>
+					<li>
+						<span><b>IF</b> <var>transcript</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-transcript">"Prerecorded audio has transcript"</code>.</span>
+					</li>
+					<li>
+						<span><b>IF</b> <b>NOT</b> (<var>math_formula_as_mathml</var> <b>OR</b> <var>math_formula_as_latex</var> <b>OR</b> (<var>contains_math_formula</var> <b>AND</b> <var>short_textual_alternative_images</var>) <b>OR</b> <var>chemical_formula_as_mathml</var> <b>OR</b> <var>charts_diagrams_as_non_graphical_data</var> <b>OR</b> <var>full_alternative_textual_descriptions</var> <b>OR</b> <var>closed_captions</var> <b>OR</b> <var>open_captions</var> <b>OR</b> <var>transcript</var>):</span>
 						<span><b>THEN</b> display <code id="rich-content-unknown">"No information is available"</code>.</span>
 					</li>
 				</ol>

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -796,7 +796,7 @@
 					</li>
 					<li>
 						<span><b>IF</b> <var>transcript</var>:</span>
-						<span><b>THEN</b> display <code id="rich-content-transcript">"Prerecorded audio has transcript"</code>.</span>
+						<span><b>THEN</b> display <code id="rich-content-transcript">"Has transcript"</code>.</span>
 					</li>
 					<li>
 						<span><b>IF</b> <b>NOT</b> (<var>math_formula_as_mathml</var> <b>OR</b> <var>math_formula_as_latex</var> <b>OR</b> (<var>contains_math_formula</var> <b>AND</b> <var>short_textual_alternative_images</var>) <b>OR</b> <var>chemical_formula_as_mathml</var> <b>OR</b> <var>charts_diagrams_as_non_graphical_data</var> <b>OR</b> <var>full_alternative_textual_descriptions</var> <b>OR</b> <var>closed_captions</var> <b>OR</b> <var>open_captions</var> <b>OR</b> <var>transcript</var>):</span>

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -684,31 +684,21 @@
 				</ol>
 			</section>
 			
-			<section id="charts-diagrams-and-formulas">
-				<h3>Charts, diagrams, math, and formulas</h3>
-				<p>This technique relates to <a href="../../guidelines/#charts-diagrams-and-formulas">Charts, diagrams, math, and formulas key information</a>.</p>
+			<section id="rich-content">
+				<h3>Rich content</h3>
+				<p>This technique relates to <a href="../../guidelines/#rich-content">Rich content key information</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
-					<dt><var>contains_charts_diagrams</var></dt>
-					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/81/19">code 19 of codelist 81</a> (Figures, diagrams, charts, graphs) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that the product has some information conveyed via some form of illustration, such as a graph, a chart, a diagram, a figure, etc).</p>
-					</dd>
 					<dt><var>charts_diagrams_as_non_graphical_data</var></dt>
 					<dd>
 						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/16">code 16 of codelist 196</a> (Visualized data also available as non-graphical datas) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that all data presented in a visual format (graph, chart, etc) has an alternative non-graphical presentation of the same data.</p>
 					</dd>
-					<dt><var>charts_diagrams_diagrams_as_long_text</var></dt>
+					<dt><var>full_alternative_textual_descriptions</var></dt>
 					<dd>
 						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/15">code 15 of codelist 196</a> (Full alternative textual description) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that a full alternative textual description has been supplied for all of the graphs, charts, diagrams, or figures necessary to understand the content.</p>
-					</dd>
-					<dt><var>contains_chemical_formula</var></dt>
-					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/81/47">code 47 of codelist 81</a> (Chemical content) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that the publication contains chemical notations, formulae.</p>
 					</dd>
 					<dt><var>chemical_formula_as_chemml</var></dt>
 					<dd>
@@ -720,11 +710,6 @@
 						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/34">code 34 of codelist 196</a> (Accessible chemistry content as MathML) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the chemical formulae are presented using MathML and works with compatible assistive technology.</p>
 					</dd>
-					<dt><var>contains_math_formula</var></dt>
-					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/81/48">code 48 of codelist 81</a> (Mathematical content) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that the publication contains mathematical notation, equations, formulae.</p>
-					</dd>
 					<dt><var>math_formula_as_latex</var></dt>
 					<dd>
 						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/35">code 35 of codelist 196</a> (Accessible math content as LaTeX) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
@@ -735,45 +720,61 @@
 						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/17">code 17 of codelist 196</a> (Accessible math content as MathML) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that all mathematical content is presented using MathML and works with compatible assistive technology.</p>
 					</dd>
+					<dt><var>contains_math_formula</var></dt>
+					<dd>
+						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/81/48">code 48 of codelist 81</a> (Mathematical content) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that the publication contains mathematical notation, equations, formulae.</p>
+					</dd>
+					<dt><var>short_textual_alternative_images</var></dt>
+					<dd>
+						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/14">code 14 of codelist 196</a> (Short alternative textual descriptions) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that all or substantially all non-text content has short alternative (textual) descriptions, usually provided via alt attributes.</p>
+					</dd>
 				</dl>
 				<h4>Variables setup</h4>
 				<ol class="condition">
 					<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
-					<li><b>LET</b> <var>contains_charts_diagrams</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/DescriptiveDetail[PrimaryContentType = "19" or ContentType = "19"] </code>.</li>
 					<li><b>LET</b> <var>charts_diagrams_as_non_graphical_data</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "16"]</code>.</li>
-					<li><b>LET</b> <var>charts_diagrams_diagrams_as_long_text</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "15"]</code>.</li>
-					<li><b>LET</b> <var>contains_chemical_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/DescriptiveDetail[PrimaryContentType = "47" or ContentType = "47"] </code>.</li>
-					<li><b>LET</b> <var>chemical_formula_as_chemml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "18"]</code>.</li>
+					<li><b>LET</b> <var>full_alternative_textual_descriptions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "15"]</code>.</li>
 					<li><b>LET</b> <var>chemical_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "34"]</code>.</li>
-					<li><b>LET</b> <var>contains_math_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/DescriptiveDetail[PrimaryContentType = "48" or ContentType = "48"] </code>.</li>
 					<li><b>LET</b> <var>math_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "35"]</code>.</li>
 					<li><b>LET</b> <var>math_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "17"]</code>.</li>
+					<li><b>LET</b> <var>contains_math_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/DescriptiveDetail[PrimaryContentType = "48" or ContentType = "48"] </code>.</li>
+					<li><b>LET</b> <var>short_textual_alternative_images</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "14"]</code>.</li>
 				</ol>
 				<h4>Instructions</h4>
 				<ol class="condition">
 					<li>
-						Display <code id="charts-diagrams-formulas-title">"Charts, diagrams, math, and formulas"</code> as heading.
+						Display <code id="rich-content-title">"Rich content"</code> as heading.
 						<p class="note">This heading can be hidden if metadata is missing.</p>
 					</li>
 					<li>
-						<span><b>IF</b> <var>contains_charts_diagrams</var> <b>AND</b>  <var>charts_diagrams_diagrams_as_long_text</var>:</span>
-						<span><b>THEN</b> display <code id="charts-diagrams-formulas-extended">"Charts and diagrams have extended descriptions"</code>.</span>
+						<span><b>IF</b> <var>math_formula_as_mathml</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-accessible-math-as-mathml">"Math as MathML"</code>.</span>
 					</li>
 					<li>
-						<span><b>IF</b> <var>contains_charts_diagrams</var> <b>AND</b>  <var>charts_diagrams_as_non_graphical_data</var>:</span>
-						<span><b>THEN</b> display <code id="charts-diagrams-formulas-non-graphical-data">"Visualized data also available as non-graphical data"</code>.</span>
+						<span><b>ELSE IF</b> <var>math_formula_as_latex</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-accessible-math-as-latex">"Math as LaTex"</code>.</span>
 					</li>
 					<li>
-						<span><b>IF</b> <var>chemical_formula_as_chemml</var> <b>OR</b> <var>chemical_formula_as_mathml</var>:</span>
-						<span><b>THEN</b> display <code id="charts-diagrams-formulas-accessible-chemistry">"Accessible chemistry content"</code>.</span>
+						<span><b>ELSE IF</b> <var>contains_math_formula</var> <b>AND</b> <var>short_textual_alternative_images</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-described-math">"Math as images with text description"</code>.</span>
 					</li>
 					<li>
-						<span><b>IF</b> <var>math_formula_as_latex</var> <b>OR</b> <var>math_formula_as_mathml</var>:</span>
-						<span><b>THEN</b> display <code id="charts-diagrams-formulas-accessible-math">"Accessible math content"</code>.</span>
+						<span><b>IF</b> <var>chemical_formula_as_mathml</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-accessible-chemistry-as-mathml">"Chemical formulas in MathML"</code>.</span>
 					</li>
 					<li>
-						<span><b>IF</b> (<var>contains_charts_diagrams</var> <b>OR</b> <var>contains_chemical_formula</var> <b>OR</b> <var>contains_math_formula</var>) <b>AND</b> <b>NOT</b> (<var>charts_diagrams_diagrams_as_long_text</var> <b>OR</b> <var>charts_diagrams_as_non_graphical_data</var> <b>OR</b> <var>chemical_formula_as_chemml</var> <b>OR</b> <var>chemical_formula_as_mathml</var> <b>OR</b> <var>math_formula_as_latex</var> <b>OR</b> <var>math_formula_as_mathml</var>):</span>
-						<span><b>THEN</b> display <code id="charts-diagrams-formulas-unknown">"accessibility of formulas, charts, math, and diagrams not identified as being accessible"</code>.</span>
+						<span><b>IF</b> <var>charts_diagrams_as_non_graphical_data</var> <b>OR</b> <var>full_alternative_textual_descriptions</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-extended">"Complex images are described by extended descriptions"</code>.</span>
+					</li>
+					<!-- Videos have closed captions -->
+					<!-- Videos have open captions -->
+					<!-- Prerecorded audio is present -->
+					<!-- Prerecorded audio has transcript -->
+					<li>
+						<span><b>IF</b> <b>NOT</b> (<var>math_formula_as_mathml</var> <b>OR</b> <var>math_formula_as_latex</var> <b>OR</b> (<var>contains_math_formula</var> <b>AND</b> <var>short_textual_alternative_images</var>) <b>OR</b> <var>chemical_formula_as_mathml</var> <b>OR</b> <var>charts_diagrams_as_non_graphical_data</var> <b>OR</b> <var>full_alternative_textual_descriptions</var>):</span>
+						<span><b>THEN</b> display <code id="rich-content-unknown">"No information is available"</code>.</span>
 					</li>
 				</ol>
 			</section>


### PR DESCRIPTION
In working on this PR, I realized a few things:

- @chrisONIX: can you help me figure out what ONIX code use to express "Videos have closed captions", "Videos have open captions", "Prerecorded audio has transcript"
- @GeorgeKerscher what does it mean "Prerecorded audio is present"? Maybe it should be in the "Pre-recorded audio" section?
- ONIX doesn't have code to express "Chemical formulas in LaTex," i seems like an edge case that maybe we don't need
- @GeorgeKerscher I changed all the IDs from "charts-diagrams-and-formulas" to "rich-content"