### PR TITLE
Changed to Has transcript 

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1313,7 +1313,7 @@ Videos included in publications have closed
 <li><span data-localization-id="additional-accessibility-information-adaptation-open-captions" data-localization-mode="descriptive">
 Videos included in publications have open captions </span></li>
 <li><span data-localization-id="additional-accessibility-information-adaptation-full-transcript" data-localization-mode="descriptive">
-Prerecorded audio has a full transcript</span></li>
+Has a transcript</span></li>
 <li><span data-localization-id="rich-content-unknown" data-localization-mode="descriptive">No information is available</span></li>
 					</ul>
 				</aside>
@@ -1349,7 +1349,7 @@ Videos have closed
 <span data-localization-id="additional-accessibility-information-adaptation-open-captions" data-localization-mode="compact">
 Videos have open captions </span></li>
 <li><span data-localization-id="additional-accessibility-information-adaptation-full-transcript" data-localization-mode="compact">
-Prerecorded audio has transcript</span></li>
+Has transcript</span></li>
 <li><span data-localization-id="rich-content-unknown" data-localization-mode="compact">No information is available</span></li>
 					</ul>
 				</aside>


### PR DESCRIPTION
Removed Prerecordig audio full transcript. to Has a transcript and in compact to Has transcript

It seems we do not know if the transcript is of everything and if it is associated with audio or vieeo. This simply reports that there is a transcript, which is I think whatwhat we do know.