### PR TITLE
Additional information section updated

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -711,6 +711,21 @@ chemml</var></dt>
 						<p>If true it indicates that the <i>accessibilityFeature="MathML"</i> (Accessible math content as MathML) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that all mathematical content is presented using MathML and works with compatible assistive technology.</p>
 					</dd>
+						<dt><var>closed_captions</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="closedCaptions"</i> (Closed captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that the audio content of a video can be seen via closed captions that can be turned on or off  by the viewer and which will be a separate file from the video itself.</p>
+						</dd>
+						<dt><var>open_captions</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="openCaptions"</i> (Open captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that the audio content of a video can be seen via open captions, which means they cannot be turned off and are always visible when the video plays.</p>
+						</dd>
+<dt><var>transcript</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="transcript"</i> (transcript) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that a transcript of the audio content of the product is supplied with it.</p>
+						</dd>
 				</dl>
 				<h4>Variables setup</h4>
 				<ol class="condition">
@@ -1016,16 +1031,7 @@ chemml</var></dt>
 							<p>If true it indicates that the <i>accessibilityFeature="braille"</i> (Braille) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 							<p>This means that there is braille available within the publication.</p>
 						</dd>
-						<dt><var>closed_captions</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="closedCaptions"</i> (Closed captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that the audio content of a video can be seen via closed captions that can be turned on or off  by the viewer and which will be a separate file from the video itself.</p>
-						</dd>
-						<dt><var>open_captions</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="openCaptions"</i> (Open captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that the audio content of a video can be seen via open captions, which means they cannot be turned off and are always visible when the video plays.</p>
-						</dd>
+
 						<dt><var>tactile_graphic</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="tactileGraphic"</i> (tactile 2D graphic) is present in the package document, otherwise if false it means that the metadata is not present.</p>
@@ -1036,11 +1042,7 @@ chemml</var></dt>
 							<p>If true it indicates that the <i>accessibilityFeature="tactileObject"</i> (tactile 3D object) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 							<p>This means that there is tactile 3D object(s) contained within this publication.</p>
 						</dd>
-						<dt><var>transcript</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="transcript"</i> (transcript) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that a transcript of the audio content of the product is supplied with it.</p>
-						</dd>
+
 						<dt><var>sign_language</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="signLanguage"</i> (Sign language interpretation) is present in the package document, otherwise if false it means that the metadata is not present.</p>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -747,6 +747,10 @@ chemml</var></dt>
 	                <li><b>LET</b> <var>math_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>latex</i>"]</code>.</li>
 
 	                <li><b>LET</b> <var>math_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>MathML</i>"]</code>.</li>
+
+	                <li><b>LET</b> <var>closed_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>closedCaptions</i>"]</code>.</li>
+<li><b>LET</b> <var>open_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>openCaptions</i>"]</code>.</li>
+<li><b>LET</b> <var>transcript</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and text()="<i>transcript</i>"]</code>.</li>
 				</ol>
 				<h4>Instructions</h4>
 				<ol class="condition">

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -1066,37 +1066,24 @@ chemml</var></dt>
 
 					<h5>Instructions</h5>
 					<ol class="condition">
-						<li><b>LET</b> <var>adaptation</var> be  an empty array.</li>
 						<li>
 							<span><b>IF</b> <var>audio_descriptions</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-adaptation-audio-descriptions">"audio descriptions"</code> to <var>adaptation</var>.</span>
-						</li>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-adaptation-audio-descriptions">"Audio descriptions"</code>.</span></li>
 						<li>
 							<span><b>IF</b> <var>braille</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-adaptation-braille">"braille"</code> to <var>adaptation</var>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-adaptation-braille">"braille"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>tactile_graphic</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-adaptation-tactile_graphic">"tactile graphic"</code> to <var>adaptation</var>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-adaptation-tactile_graphic">"Tactile graphic"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>tactile_object</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-adaptation-tactile_object">"tactile 3D object"</code> to <var>adaptation</var>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-adaptation-tactile_object">"Tactile 3D object"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>sign_language</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-adaptation-sign-language">"sign language"</code> to <var>adaptation</var>.</span>
-						</li>
-						<li><b>IF</b> <var>adaptation</var> is <b>NOT</b> empty:
-							<ol class="condition">
-								<li><b>LET</b> <var>adaptation_string</var> be the result of:
-									<ul class="condition">
-										<li>calling <a href="#join-array-to-comma-list">join array to comma list</a> given <var>adaptation</var></li>
-										<li>uppercasing the first character.</li>
-									</ul>
-								</li>
-								<li>display <var>adaptation_string</var>.</li>
-							</ol>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-adaptation-sign-language">"Sign language"</code>.</span>
 						</li>
 					</ol>
 				</section>
@@ -1166,52 +1153,38 @@ chemml</var></dt>
 
 					<h5>Instructions</h5>
 					<ol class="condition">
-						<li><b>LET</b> <var>clarity</var> be  an empty array.</li>
+
 						<li>
 							<span><b>IF</b> <var>aria</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-clarity-aria">"aria"</code> to <var>clarity</var>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-clarity-aria">"ARIA"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>full_ruby_annotations</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-clarity-full-ruby-annotations">"full ruby annotations"</code> to <var>clarity</var>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-clarity-full-ruby-annotations">"Full ruby annotations"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>text_to_speech_hinting</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-clarity-text-to-speech-hinting">"text-to-speech hinting provided"</code> to <var>clarity</var>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-clarity-text-to-speech-hinting">"Text-to-speech hinting provided"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>high_contrast_between_foreground_and_background_audio</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-clarity-high-contrast-between-foreground-and-background-audio">"high contrast between foreground and background audio"</code> to <var>clarity</var>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-clarity-high-contrast-between-foreground-and-background-audio">"High contrast between foreground and background audio"</code> .</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>high_contrast_between_text_and_background</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-clarity-high-contrast-between-text-and-background">"high contrast between text and background"</code> to <var>clarity</var>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-clarity-high-contrast-between-text-and-background">"High contrast between foreground text and background"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>large_print</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-clarity-large-print">"large print"</code> to <var>clarity</var>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-clarity-large-print">"Large print"</code>.</span>
 						</li>
                         <li>
                             <span><b>IF</b> <var>page_break_markers</var>:</span>
-                            <span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-clarity-page-breaks">"page breaks"</code> to <var>clarity</var>.</span>
+                            <span><b>THEN</b> display <code id="additional-accessibility-information-clarity-page-breaks">"Visible page breaks"</code>.</span>
                         </li>
 						<li>
 							<span><b>IF</b> <var>ruby_annotations</var>:</span>
-							<span><b>THEN</b> <b>APPEND</b> <code id="additional-accessibility-information-clarity-ruby-annotations">"ruby annotations"</code> to <var>clarity</var>.</span>
-						</li>
-
-
-                        <li><b>IF</b> <var>clarity</var> is <b>NOT</b> empty:
-							<ol class="condition">
-								<li><b>LET</b> <var>clarity_string</var> be the result of:
-									<ul class="condition">
-										<li>calling <a href="#join-array-to-comma-list">join array to comma list</a> given <var>clarity</var></li>
-										<li>uppercasing the first character.</li>
-									</ul>
-								</li>
-								<li>display <var>clarity_string</var>.</li>
-							</ol>
-						</li>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-clarity-ruby-annotations">"Some Ruby annotations"</code>.</span></li>
 					</ol>
 				</section>
 


### PR DESCRIPTION
There are several commits here:
One moved the declaration of variables for closed and open captions and transcript to rich content.
Added three variables that were missed.
Removed the concatination approach in the additional information.
Capatilized the first character in each string.
Added the word "Visible" to the page break item. I know we have go to page in the navigation, and that seems to relate to the page list, but this is about the page break markers in the content. I thought the only meaningful thing to say about this is if they are visible. I know that they do not necessarly need to be visible, but then what is the point in including this metadata?
Happy New Year! 