### PR TITLE
Ways of reading

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -264,7 +264,7 @@
                             <span><b>ELSE IF</b> <var>is_fixed_layout</var>:</span>
                             <span><b>THEN</b> display <code id="ways-of-reading-visual-adjustments-unmodifiable">"Appearance cannot be modified"</code>.</span>
                         </li>
-                        <li><b>ELSE</b> display <code id="ways-of-reading-visual-adjustments-unknown">"No information is available"</code>.</li>
+                        <li><b>ELSE</b> display <code id="ways-of-reading-visual-adjustments-unknown">"No information  about appearance modifiability is available"</code>.</li>
                     </ol>
                 </section>
 
@@ -393,7 +393,7 @@
                         </li>
 
                         <li>
-                            <b>ELSE</b> either omit this key information if metadata is missing or display <code id="ways-of-reading-prerecorded-audio-no-metadata">"No information is available"</code>.
+                            <b>ELSE</b> either omit this key information if metadata is missing or display <code id="ways-of-reading-prerecorded-audio-no-metadata">"No information is available about pre-recorded audio."</code>.
                         </li>
                     </ol>
                 </section>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -141,15 +141,14 @@
                 <p>The headings structure to use for the techniques is defined in the guidelines but is repeated here to help guide implementations. The headings are linked to the algorithm they are associated with.</p>
 
                 <ol>
-                    <li><code id="ways-of-reading-title">"<a href="#ways-of-reading-instructions">Ways of reading</a>"</code></li>
+                    <li><code id="ways-of-reading-title">"<a href="#ways-of-reading">Ways of reading</a>"</code></li>
                     <li><code id="conformance-title">"<a href="#conformance-instructions">Conformance</a>"</code></li>
                     <li><code id="navigation-title">"<a href="#navigation-instructions">Navigation</a>"</code></li>
                     <li><code id="rich-content-title">"<a href="#rich-content-instructions">Rich content</a>"</code></li>
                     <li><code id="hazards-title">"<a href="#hazards-instructions">Hazards</a>"</code></li>
                     <li><code id="accessibility-summary-title">"<a href="#accessibility-summary-instructions">Accessibility summary</a>"</code></li>
                     <li><code id="legal-considerations-title">"<a href="#legal-considerations-instructions">Legal considerations</a>"</code></li>
-                    <li><code id="#additional-accessibility-information-adaptation-title">"<a href="#additional-accessibility-information-adaptation-instructions">Additional accessibility information adaptation</a>"</code></li>
-                    <li><code id="#additional-accessibility-information-clarity-title">"<a href="#additional-accessibility-information-clarity-instructions">Additional accessibility information clarity</a>"</code></li>
+                    <li><code id="#additional-accessibility-information-title">"<a href="#additional-accessibility-information">Additional accessibility information</a>"</code></li>
                 </ol>
             
             <h3>Coding Conventions</h3>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -323,7 +323,7 @@
                     <ol class="condition">
                                 <li>
                                     <span><b>IF</b> <var>textual_alternative_images</var>:</span>
-                                    <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-alt-text">"Images have alt text descriptions"</code>.</span>
+                                    <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-alt-text">"Has alternative text"</code>.</span>
                                 </li>
 
                         <li>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -1010,7 +1010,7 @@
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 
                 <section id="additional-accessibility-information-adaptation">
-					<h3>Adaptation</h3>
+					<h4>Adaptation</h4>
 
 					<h5>Understanding the variables</h5>
 					<dl>
@@ -1078,7 +1078,7 @@
 				</section>
 
 				<section id="additional-accessibility-information-clarity">
-					<h3>Clarity</h3>
+					<h4>Clarity</h4>
 
 					<h5>Understanding the variables</h5>
 					<dl>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -323,7 +323,7 @@
                     <ol class="condition">
                                 <li>
                                     <span><b>IF</b> <var>textual_alternative_images</var>:</span>
-                                    <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-alt-text">"Has alt text"</code>.</span>
+                                    <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-alt-text">"Images have alt text descriptions"</code>.</span>
                                 </li>
 
                         <li>
@@ -381,7 +381,7 @@
                     <ol class="condition">
                         <li>
                             <span><b>IF</b> <var>all_content_audio</var>:</span>
-                            <span><b>THEN</b> display <code id="ways-of-reading-prerecorded-audio-only">"Audio only"</code>.</span>
+                            <span><b>THEN</b> display <code id="ways-of-reading-prerecorded-audio-only">"Prerecorded audio only"</code>.</span>
                         </li>
                         <li>
                             <span><b>ELSE IF</b> <var>synchronised_pre_recorded_audio</var>:</span>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -219,122 +219,187 @@
 		<section id="techniques">
 			<h2>Techniques</h2>
 
-			<section id="visual-adjustments">
-				<!-- https://www.w3.org/TR/pub-manifest/#manifest-processing -->
-				<h3>Visual adjustments</h3>
-				<p>This technique relates to <a href="../../guidelines/#visual-adjustments">Visual adjustments key information</a>.</p>
-				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
+            <section id="ways-of-reading">
+                <h3>Ways of reading</h3>
+
+                <p>This technique relates to <a href="../../guidelines/#way-of-reading">Ways of reading key information</a>.</p>
+  
+                <p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 
 
-                <h4>Understanding the variables</h4>
-				<dl>
-                    <dt><var>all_textual_content_can_be_modified</var></dt>
-                    <dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="displayTransformability"</i> (All textual content can be modified) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-                        <p><i>All textual content can be modified</i> means that the digital publication does not restrict the ability of users to modify and reflow the display of any textual content to the full extent allowed by the reading system (i.e. to change the text size or typeface, line height and word spacing, colors).</p>
-                    </dd>
-					<dt><var>is_fixed_layout</var></dt>
-					<dd>
-						<p>If true it indicates that the <i>layout="pre-paginated"</i> (Fixed format) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p><i>Fixed format</i> means that digital publication is in fixed format (e.g. EPUB Fixed Layout).</p>
-					</dd>
-				</dl>
+                <section id="visual-adjustments">
+                    <!-- https://www.w3.org/TR/pub-manifest/#manifest-processing -->
+                    <h4>Visual adjustments</h4>
+                    <p>This technique relates to <a href="../../guidelines/#visual-adjustments">Visual adjustments key information</a>.</p>
+  
+                    <h5>Understanding the variables</h5>
+                    <dl>
+                        <dt><var>all_textual_content_can_be_modified</var></dt>
+                        <dd>
+                            <p>If true it indicates that the <i>accessibilityFeature="displayTransformability"</i> (All textual content can be modified) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                            <p><i>All textual content can be modified</i> means that the digital publication does not restrict the ability of users to modify and reflow the display of any textual content to the full extent allowed by the reading system (i.e. to change the text size or typeface, line height and word spacing, colors).</p>
+                        </dd>
+                        <dt><var>is_fixed_layout</var></dt>
+                        <dd>
+                            <p>If true it indicates that the <i>layout="pre-paginated"</i> (Fixed format) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                            <p><i>Fixed format</i> means that digital publication is in fixed format (e.g. EPUB Fixed Layout).</p>
+                        </dd>
+                    </dl>
 
-                <h4>Variables setup</h4>
-				<ol class="condition">
-					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
+                    <h5>Variables setup</h5>
+                    <ol class="condition">
+                        <li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
-                    <li><b>LET</b> <var>all_textual_content_can_be_modified</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>displayTransformability</i>"]</code>.</li>
+                        <li><b>LET</b> <var>all_textual_content_can_be_modified</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>displayTransformability</i>"]</code>.</li>
 
-                    <li><b>LET</b> <var>is_fixed_layout</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="rendition:<i>layout</i>" and normalize-space()="<i>pre-paginated</i>"]</code>.</li>
+                        <li><b>LET</b> <var>is_fixed_layout</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="rendition:<i>layout</i>" and normalize-space()="<i>pre-paginated</i>"]</code>.</li>
 
-				</ol>
-				<h4>Instructions</h4>
-				<ol class="condition">
-					<li>
-						<span><b>IF</b> <var>all_textual_content_can_be_modified</var>:</span>
-						<span><b>THEN</b> display <code id="visual-adjustments-modifiable">"Appearance can be modified"</code>.</span>
-					</li>
-					<li>
-						<span><b>ELSE IF</b> <var>is_fixed_layout</var>:</span>
-						<span><b>THEN</b> display <code id="visual-adjustments-unmodifiable">"Appearance cannot be modified"</code>.</span>
-					</li>
-					<li><b>ELSE</b> display <code id="visual-adjustments-unknown">"No information is available"</code>.</li>
-				</ol>
-			</section>
+                    </ol>
+                    <h5>Instructions</h5>
+                    <ol class="condition">
+                        <li>
+                            <span><b>IF</b> <var>all_textual_content_can_be_modified</var>:</span>
+                            <span><b>THEN</b> display <code id="ways-of-reading-visual-adjustments-modifiable">"Appearance can be modified"</code>.</span>
+                        </li>
+                        <li>
+                            <span><b>ELSE IF</b> <var>is_fixed_layout</var>:</span>
+                            <span><b>THEN</b> display <code id="ways-of-reading-visual-adjustments-unmodifiable">"Appearance cannot be modified"</code>.</span>
+                        </li>
+                        <li><b>ELSE</b> display <code id="ways-of-reading-visual-adjustments-unknown">"No information is available"</code>.</li>
+                    </ol>
+                </section>
 
-			<section id="supports-nonvisual-reading">
-				<h3>Supports nonvisual reading</h3>
-				<p>This technique relates to <a href="../../guidelines/#supports-nonvisual-reading">Supports nonvisual reading key information</a>.</p>
-				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
-				<h4>Understanding the variables</h4>
-				<dl>
-					<dt><var>all_necessary_content_textual</var></dt>
-					<dd>
-						<p>If true it indicates that the <i>accessModeSufficient="textual"</i> (all main content is provided in textual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p><i>All non-decorative content supports reading without sight</i> means that all contents of the digital publication necessary to use and understanding, including text, images (via their alternative descriptions), audio and video material (via their transcripts, descriptions, captions or subtitles) are fully accessible via suitable reading devices, for example text-to-speech screen readers or tactile reading devices (‘Braille displays’), and nothing in the digital publication prevents or blocks the use of alternative reading modes. The entire publication can be navigated and ‘read’ using only text rendered via sound or touch, and does not require visual perception.</p>
-					</dd>
-					<dt><var>non_textual_content_images</var></dt>
-					<dd>
-						<p>If true it indicates that at least one of the following is present in the package document:</p>
-						<ul>
-							<li><i>accessMode="chartOnVisual"</i> (Charts and Graphs);</li>
-							<li><i>accessMode="chemOnVisual"</i> (Chemistry);</li>
-							<li><i>accessMode="diagramOnVisual"</i> (Diagrams);</li>
-							<li><i>accessMode="mathOnVisual"</i> (Math);</li>
-							<li><i>accessMode="musicOnVisual"</i> (Music);</li>
-							<li><i>accessMode="textOnVisual"</i> (Images of text);</li>
-							<li>otherwise if false it means that this metadata is not present.</li>
-						</ul>
-						<p>This means that the content contains images of any type.</p>
-					</dd>
-					<dt><var>textual_alternative_images</var></dt>
-					<dd>
-						<p>If true it indicates that at least one of the following is present in the package document:</p>
-						<ul>
-							<li><i>accessibilityFeature="alternativeText"</i> (Short alternative textual descriptions);</li>
-							<li><i>accessibilityFeature="longDescription"</i> (Full alternative textual descriptions);</li>
-							<li><i>accessibilityFeature="describedMath"</i> (Visual of math fully described));</li>
-							<li>otherwise if false it means that this metadata is not present.</li>ff
-						</ul>
-						<p>This means that there are textual alternatives for images.</p>
-					</dd>
-				</dl>
-				<h4>Variables setup</h4>
-				<ol class="condition">
-					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
+                <section id="supports-nonvisual-reading">
+                    <h4>Supports nonvisual reading</h4>
+                    <p>This technique relates to <a href="../../guidelines/#supports-nonvisual-reading">Supports nonvisual reading key information</a>.</p>
 
-					<li><b>LET</b> <var>all_necessary_content_textual</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessModeSufficient</i>" and normalize-space()="<i>textual</i>"]</code>.</li>
-					
-					<li>
-						<b>LET</b> <var>non_textual_content_images</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessMode</i>" and normalize-space() = ("chartOnVisual", "chemOnVisual", "diagramOnVisual", "mathOnVisual", "musicOnVisual", "textOnVisual")]</code>.
-					</li>
+                    <h5>Understanding the variables</h5>
+                    <dl>
+                        <dt><var>all_necessary_content_textual</var></dt>
+                        <dd>
+                            <p>If true it indicates that the <i>accessModeSufficient="textual"</i> (all main content is provided in textual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                            <p><i>All non-decorative content supports reading without sight</i> means that all contents of the digital publication necessary to use and understanding, including text, images (via their alternative descriptions), audio and video material (via their transcripts, descriptions, captions or subtitles) are fully accessible via suitable reading devices, for example text-to-speech screen readers or tactile reading devices (‘Braille displays’), and nothing in the digital publication prevents or blocks the use of alternative reading modes. The entire publication can be navigated and ‘read’ using only text rendered via sound or touch, and does not require visual perception.</p>
+                        </dd>
+                        <dt><var>non_textual_content_images</var></dt>
+                        <dd>
+                            <p>If true it indicates that at least one of the following is present in the package document:</p>
+                            <ul>
+                                <li><i>accessMode="chartOnVisual"</i> (Charts and Graphs);</li>
+                                <li><i>accessMode="chemOnVisual"</i> (Chemistry);</li>
+                                <li><i>accessMode="diagramOnVisual"</i> (Diagrams);</li>
+                                <li><i>accessMode="mathOnVisual"</i> (Math);</li>
+                                <li><i>accessMode="musicOnVisual"</i> (Music);</li>
+                                <li><i>accessMode="textOnVisual"</i> (Images of text);</li>
+                                <li>otherwise if false it means that this metadata is not present.</li>
+                            </ul>
+                            <p>This means that the content contains images of any type.</p>
+                        </dd>
+                        <dt><var>textual_alternative_images</var></dt>
+                        <dd>
+                            <p>If true it indicates that at least one of the following is present in the package document:</p>
+                            <ul>
+                                <li><i>accessibilityFeature="alternativeText"</i> (Short alternative textual descriptions);</li>
+                                <li><i>accessibilityFeature="longDescription"</i> (Full alternative textual descriptions);</li>
+                                <li><i>accessibilityFeature="describedMath"</i> (Visual of math fully described));</li>
+                                <li>otherwise if false it means that this metadata is not present.</li>ff
+                            </ul>
+                            <p>This means that there are textual alternatives for images.</p>
+                        </dd>
+                    </dl>
+                    <h5>Variables setup</h5>
+                    <ol class="condition">
+                        <li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
-                    <li>
-                    	<b>LET</b> <var>textual_alternative_images</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessibilityFeature</i>" and normalize-space()=("<i>longDescription</i>", "<i>alternativeText</i>","<i>describedMath"</i>)]</code>.
-					</li>
-                </ol>
-				<h4>Instructions</h4>
-				<ol class="condition">
-							<li>
-								<span><b>IF</b> <var>textual_alternative_images</var>:</span>
-								<span><b>THEN</b> display <code id="nonvisual-reading-alt-text">"Has alt text"</code>.</span>
-							</li>
+                        <li><b>LET</b> <var>all_necessary_content_textual</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessModeSufficient</i>" and normalize-space()="<i>textual</i>"]</code>.</li>
 
-					<li>
-						<span><b>IF</b> <var>all_necessary_content_textual</var>:</span>
-						<span><b>THEN</b> display <code id="nonvisual-reading-readable">"Readable in read aloud or dynamic braille"</code>.</span>
-					</li>
-					<li>
-						<span><b>ELSE IF</b> <var>non_textual_content_images</var> <b>AND</b> <b>NOT</b> <var>textual_alternative_images</var>:</span>
-						<span><b>THEN</b> display <code id="nonvisual-reading-not-fully">"Not fully readable in read aloud or dynamic braille"</code>.</span>
-					</li>
-					<li><b>ELSE</b> display <code id="nonvisual-reading-may-not-fully">"May not be fully readable in read aloud or dynamic braille"</code>.</li>
-				</ol>
+                        <li>
+                            <b>LET</b> <var>non_textual_content_images</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessMode</i>" and normalize-space() = ("chartOnVisual", "chemOnVisual", "diagramOnVisual", "mathOnVisual", "musicOnVisual", "textOnVisual")]</code>.
+                        </li>
+
+                        <li>
+                            <b>LET</b> <var>textual_alternative_images</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessibilityFeature</i>" and normalize-space()=("<i>longDescription</i>", "<i>alternativeText</i>","<i>describedMath"</i>)]</code>.
+                        </li>
+                    </ol>
+                    <h5>Instructions</h5>
+                    <ol class="condition">
+                                <li>
+                                    <span><b>IF</b> <var>textual_alternative_images</var>:</span>
+                                    <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-alt-text">"Has alt text"</code>.</span>
+                                </li>
+
+                        <li>
+                            <span><b>IF</b> <var>all_necessary_content_textual</var>:</span>
+                            <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-readable">"Readable in read aloud or dynamic braille"</code>.</span>
+                        </li>
+                        <li>
+                            <span><b>ELSE IF</b> <var>non_textual_content_images</var> <b>AND</b> <b>NOT</b> <var>textual_alternative_images</var>:</span>
+                            <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-not-fully">"Not fully readable in read aloud or dynamic braille"</code>.</span>
+                        </li>
+                        <li><b>ELSE</b> display <code id="ways-of-reading-nonvisual-reading-may-not-fully">"May not be fully readable in read aloud or dynamic braille"</code>.</li>
+                    </ol>
 
 
-			</section>
+                </section>
+                
+                <section id="prerecorded-audio">
+                    <h4>Prerecorded audio</h4>
+                    <p>This technique relates to <a href="../../guidelines/#prerecorded-audio">Prerecorded audio key information</a>.</p>
 
+                     <h5>Understanding the variables</h5>
+                    <dl>
+                        <dt><var>all_content_audio</var></dt>
+                        <dd>
+                            <p>If true it indicates that the <i>accessModeSufficient="auditory"</i> (all main content is provided in audio form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        </dd>
+                        <dt><var>synchronised_pre_recorded_audio</var></dt>
+                        <dd>
+                            <p>If true it indicates that the <i>accessibilityFeature="sychronizedAudioText"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
+
+                            <p>This indicates that text-synchronised prerecorded audio narration (natural or synthesized voice) is included for substantially all textual matter, including all alternative descriptions, e.g. via a SMIL media overlay.</p>
+                        </dd>
+
+                        <dt><var>audio_content</var></dt>
+                        <dd>
+                            <p>If true it indicates that the <i>accessMode="auditory"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
+
+                            <p>This indicates that prerecorded audio content is included as part of the work.</p>
+                        </dd>
+
+
+                    </dl>
+                    <h5>Variables setup</h5>
+                    <ol class="condition">
+                        <li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
+
+                        <li><b>LET</b> <var>all_content_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessModeSufficient</i>" and normalize-space()="<i>auditory</i>"]</code>.</li>
+
+                        <li><b>LET</b> <var>synchronised_pre_recorded_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>sychronizedAudioText</i>"]</code>.</li>
+
+                        <li><b>LET</b> <var>audio_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>auditory</i>"]</code>.</li>
+
+                    </ol>
+                    <h5>Instructions</h5>
+                    <ol class="condition">
+                        <li>
+                            <span><b>IF</b> <var>all_content_audio</var>:</span>
+                            <span><b>THEN</b> display <code id="ways-of-reading-prerecorded-audio-only">"Audio only"</code>.</span>
+                        </li>
+                        <li>
+                            <span><b>ELSE IF</b> <var>synchronised_pre_recorded_audio</var>:</span>
+                            <span><b>THEN</b> display <code id="ways-of-reading-prerecorded-audio-synchronized">"Prerecorded audio synchronized with text"</code>.</span>
+                        </li>
+                        <li>
+                            <span><b>ELSE IF</b> <var>audio_content</var>:</span>
+                            <span><b>THEN</b> display <code id="ways-of-reading-prerecorded-audio-complementary">"Complementary audio and text"</code>.</span>
+                        </li>
+
+                        <li>
+                            <b>ELSE</b> either omit this key information if metadata is missing or display <code id="ways-of-reading-prerecorded-audio-no-metadata">"No information is available"</code>.
+                        </li>
+                    </ol>
+                </section>
+
+            </section>
 
 			<section id="conformance-group">
 				<h3>Conformance</h3>
@@ -516,66 +581,6 @@
 
 			</section>
 
-
-			<section id="prerecorded-audio">
-				<h3>Prerecorded audio</h3>
-				<p>This technique relates to <a href="../../guidelines/#prerecorded-audio">Prerecorded audio key information</a>.</p>
-
-                <p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
-
-				<h4>Understanding the variables</h4>
-				<dl>
-					<dt><var>all_content_audio</var></dt>
-                    <dd>
-				        <p>If true it indicates that the <i>accessModeSufficient="auditory"</i> (all main content is provided in audio form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-                    </dd>
-                    <dt><var>synchronised_pre_recorded_audio</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="sychronizedAudioText"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
-
-						<p>This indicates that text-synchronised prerecorded audio narration (natural or synthesized voice) is included for substantially all textual matter, including all alternative descriptions, e.g. via a SMIL media overlay.</p>
-					</dd>
-
-  					<dt><var>audio_content</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessMode="auditory"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
-
-						<p>This indicates that prerecorded audio content is included as part of the work.</p>
-					</dd>
-
-
-                </dl>
-				<h4>Variables setup</h4>
-				<ol class="condition">
-					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
-
-					<li><b>LET</b> <var>all_content_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessModeSufficient</i>" and normalize-space()="<i>auditory</i>"]</code>.</li>
-
-					<li><b>LET</b> <var>synchronised_pre_recorded_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>sychronizedAudioText</i>"]</code>.</li>
-
-					<li><b>LET</b> <var>audio_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>auditory</i>"]</code>.</li>
-
-				</ol>
-				<h4>Instructions</h4>
-				<ol class="condition">
-					<li>
-						<span><b>IF</b> <var>all_content_audio</var>:</span>
-						<span><b>THEN</b> display <code id="prerecorded-audio-only">"Audio only"</code>.</span>
-					</li>
-					<li>
-						<span><b>ELSE IF</b> <var>synchronised_pre_recorded_audio</var>:</span>
-						<span><b>THEN</b> display <code id="prerecorded-audio-synchronized">"Prerecorded audio synchronized with text"</code>.</span>
-					</li>
-					<li>
-						<span><b>ELSE IF</b> <var>audio_content</var>:</span>
-						<span><b>THEN</b> display <code id="prerecorded-audio-complementary">"Complementary audio and text"</code>.</span>
-					</li>
-
-					<li>
-						<b>ELSE</b> either omit this key information if metadata is missing or display <code id="prerecorded-audio-no-metadata">"No information is available"</code>.
-					</li>
-				</ol>
-			</section>
 
       <section id="navigation">
 				<h3>Navigation</h3>


### PR DESCRIPTION
Wrapped the 3 sections into one "Ways of reading" technique like discussed.

Only changes other than moving these 3 sections into this combined section, were to the heading levels under this new section and the display strings have now the prefix "ways-of-reading-" added to each of the "visual-adjustments", "non-visual-reading", and "pre-recorded-audio" strings.