### PR TITLE
Create new statements sections for metadata strings

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -620,7 +620,7 @@
 					clipped by its container).</p>
 	
 				<section id="va-statements">
-					<h5>Statements</h5>
+					<h5>Display statements</h5>
 	
 					<p>The descriptive and compact statements for visual adjustment are as follows.</p>
 					
@@ -717,7 +717,7 @@
 					the nonvisual content.</p>
 	
 				<section id="nv-statements">
-					<h5>Statements</h5>
+					<h5>Display statements</h5>
 	
 					<p>The descriptive and compact statements for nonvisual reading are as follows.</p>
 					
@@ -812,7 +812,7 @@
 					books.</p>
 	
 				<section id="prerecorded-audio-statements">
-					<h5>Statements</h5>
+					<h5>Display statements</h5>
 					
 					<p>The descriptive and compact statements for prerecorded audio are as follows.</p>
 					
@@ -963,7 +963,7 @@
 			</section>
 
 			<section id="conf-statements">
-				<h4>Statements</h4>
+				<h4>Display statements</h4>
 				
 				<div class="note">
 					<p>Some conformance statements incorporate publication metadata. To indicate where
@@ -984,8 +984,8 @@
 							data-localization-mode="compact">This publication meets minimum accessibility
 							standards</p>
 						<p data-localization-id="conformance-a"
-							data-localization-mode="descriptive">This publication meets minimum accessibility
-							standards</p>
+							data-localization-mode="descriptive">The publication contains a conformance 
+							statement that it meets the EPUB Accessibility and WCAG 2 Level A standard</p>
 					</dd>
 					
 					<dt>If the publication meets widely accepted accessibility requirements:</dt>
@@ -994,8 +994,18 @@
 							data-localization-mode="compact">This publication meets accepted accessibility
 							standards</p>
 						<p data-localization-id="conformance-aa"
-							data-localization-mode="descriptive">This publication meets accepted accessibility
+							data-localization-mode="descriptive">The publication contains a conformance
+							statement that it meets the EPUB Accessibility and WCAG 2 Level AA standard</p>
+					</dd>
+					
+					<dt>If the publication meets exceeds accepted accessibility requirements:</dt>
+					<dd>
+						<p data-localization-id="conformance-aaa"
+							data-localization-mode="compact">This publication exceeds accepted accessibility
 							standards</p>
+						<p data-localization-id="conformance-aaa"
+							data-localization-mode="descriptive">The publication contains a conformance
+							statement that it meets the EPUB Accessibility and WCAG 2 Level AAA standard</p>
 					</dd>
 					
 					<dt>If no metadata is provided:</dt>
@@ -1355,7 +1365,7 @@
 </p></div>
 
 			<section id="nav-statements">
-				<h4>Statements</h4>
+				<h4>Display statements</h4>
 				
 				<p>The descriptive and compact statements for navigation are as follows.</p>
 				
@@ -1449,7 +1459,7 @@
 				indicates the presence of math, chemical formulas, charts, diagrams, figures, graphs, videos, or transcripts of audio within the title, otherwise it can be hidden.</p>
 
 			<section id="rc-statements">
-				<h4>Statements</h4>
+				<h4>Display statements</h4>
 				
 				<p>The descriptive and compact statements for rich content are as follows.</p>
 				
@@ -1470,7 +1480,7 @@
 								data-localization-mode="descriptive">Math formulas in accessible format (LaTeX)</p>
 					</dd>
 					
-					<dt>If math is represented as images:</dt>
+					<dt>If math equations are described:</dt>
 					<dd>
 						<p data-localization-id="rich-content-accessible-math-described"
 							data-localization-mode="compact">Text descriptions of math is provided</p>
@@ -1594,7 +1604,7 @@
 				different than providing no metadata for this property.</p>
 
 			<section id="hazards-statements">
-				<h4>Statements</h4>
+				<h4>Display statements</h4>
 				
 				<p>The descriptive and compact statements for hazards are as follows.</p>
 				
@@ -1800,7 +1810,7 @@
 				is to provide as much accessibility information as possible.</p>
 
 			<section id="legal-statements">
-				<h5>Statements</h5>
+				<h5>Display statements</h5>
 				
 				<p>The descriptive and compact statements for legal exemptions are as follows.</p>
 				
@@ -1933,7 +1943,7 @@
 			</dl>
 
 			<section id="add-info-statements">
-				<h4>Statements</h4>
+				<h4>Display statements</h4>
 
 				<p>The descriptive and compact statements for additional information are as follows.</p>
 				

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -122,9 +122,11 @@
 		}
 		p[data-localization-mode="descriptive"]:before {
 			content: 'Descriptive: ';
+			font-style: italic;
 		}
 		p[data-localization-mode="compact"]:before {
 			content: 'Compact: ';
+			font-style: italic;
 		}
 	</style>
 </head>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -143,6 +143,13 @@
 			font-style: italic;
 			color: red;
 		}
+		.example h4,
+		.example h5,
+		.example h6 {
+			margin: 1rem 0 0 0;
+			padding: 0;
+			font-variant: small-caps
+		}
 	</style>
 </head>
 
@@ -581,296 +588,315 @@
 			</div>
 		</section>
 		<section id="ways-of-reading">
-                <h3 data-localization-id="ways-of-reading-title">Ways of reading</h3>
+			<h3 data-localization-id="ways-of-reading-title">Ways of reading</h3>
 
-		<section id="visual-adjustments">
-			<h4 data-localization-id="ways-to-read-visual-adjustments-title">Visual
-				adjustments</h4>
-
-			<div class="note">
-				<p>This key information should be displayed, even
-					if there is no metadata (See the examples
-					where "No information is available"). </p>
-			</div>
-
-			<p>Indicates if users can modify the appearance of the text
-				and the page layout according to the
-				possibilities offered by the reading system.</p>
-
-			<p>This field answers whether visual adjustments are
-				possible, not possible, or unknown.</p>
-
-			<p>Readers with visual impairments or cognitive disabilities
-				need the ability to change the color of
-				text and its background (contrast), the font family and
-				font size used, as well as spacing between
-				letters, words, sentences, or paragraphs.</p>
-
-			<p>Knowing
-				that a publication can reflow to fit the
-				reading system's display area is not sufficient to know
-				that modifications to the font, spacing, and
-				colors are possible or that the changes will not cause
-				other readability issues (e.g., text being
-				clipped by its container).</p>
-
-			<section id="va-statements">
-				<h5>Statements</h5>
-
-				<p>The descriptive and compact statements for visual adjustment are as follows.</p>
+			<section id="visual-adjustments">
+				<h4 data-localization-id="ways-to-read-visual-adjustments-title">Visual
+					adjustments</h4>
+	
+				<div class="note">
+					<p>This key information should be displayed, even
+						if there is no metadata (See the examples
+						where "No information is available"). </p>
+				</div>
+	
+				<p>Indicates if users can modify the appearance of the text
+					and the page layout according to the
+					possibilities offered by the reading system.</p>
+	
+				<p>This field answers whether visual adjustments are
+					possible, not possible, or unknown.</p>
+	
+				<p>Readers with visual impairments or cognitive disabilities
+					need the ability to change the color of
+					text and its background (contrast), the font family and
+					font size used, as well as spacing between
+					letters, words, sentences, or paragraphs.</p>
+	
+				<p>Knowing
+					that a publication can reflow to fit the
+					reading system's display area is not sufficient to know
+					that modifications to the font, spacing, and
+					colors are possible or that the changes will not cause
+					other readability issues (e.g., text being
+					clipped by its container).</p>
+	
+				<section id="va-statements">
+					<h5>Statements</h5>
+	
+					<p>The descriptive and compact statements for visual adjustment are as follows.</p>
+					
+					<dl>
+						<dt>If the display is modifiable:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
+								data-localization-mode="compact">Appearance
+								can be modified</p>
+							<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
+								data-localization-mode="descriptive">
+								Appearance of the text and page layout can
+								be
+								modified according to the capabilities of
+								the reading system (font family and font
+								size,
+								spaces between paragraphs, sentences, words,
+								and letters, as well as color of background
+								and text)</p>
+						</dd>
+						
+						<dt>If the display is not modifiable:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
+								data-localization-mode="compact">Appearance
+								cannot be modified</p>
+							<p data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
+								data-localization-mode="descriptive">Text
+								and page layout cannot be modified as the
+								reading experience is close to a print
+								version, but reading systems can still
+								provide zooming options</p>
+						</dd>
+						
+						<dt>If no metadata is provided:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
+								data-localization-mode="compact">No information about appearance modifiability is available</p>
+							<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
+								data-localization-mode="descriptive">
+								No information about appearance modifiability is available</p>
+						</dd>
+					</dl>
+				</section>
 				
-				<dl>
-					<dt>If the display is modifiable:</dt>
-					<dd>
-						<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
-							data-localization-mode="compact">Appearance
-							can be modified</p>
-						<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
-							data-localization-mode="descriptive">
-							Appearance of the text and page layout can
-							be
+				<section id="va-examples">
+					<h5>Examples</h5>
+					
+					<aside class="example" title="Display for a publication with modifiable appearance">
+						<h6 data-localization-id="ways-of-reading-title">Ways of reading</h6>
+						<p>Appearance of the text and page layout can be
 							modified according to the capabilities of
-							the reading system (font family and font
-							size,
+							the reading system (font family and font size,
 							spaces between paragraphs, sentences, words,
 							and letters, as well as color of background
 							and text)</p>
-					</dd>
+					</aside>
 					
-					<dt>If the display is not modifiable:</dt>
-					<dd>
-						<p data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
-							data-localization-mode="compact">Appearance
-							cannot be modified</p>
+					<aside class="example" title="Display for a publication without modifiable appearance">
+						<h6 data-localization-id="ways-of-reading-title">Ways of reading</h6>
 						<p data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
 							data-localization-mode="descriptive">Text
 							and page layout cannot be modified as the
 							reading experience is close to a print
 							version, but reading systems can still
 							provide zooming options</p>
-					</dd>
-					
-					<dt>If no metadata is provided:</dt>
-					<dd>
-						<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
-							data-localization-mode="compact">No information about appearance modifiability is available</p>
-						<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
-							data-localization-mode="descriptive">
-							No information about appearance modifiability is available</p>
-					</dd>
-				</dl>
+					</aside>
+				</section>
+				
+				<section id="va-techniques">
+					<h5>Display techniques for Visual adjustments support</h5>
+	
+					<p>Specific techniques for meeting this principle are
+						defined in the following documents:</p>
+	
+					<ul>
+						<li><a
+								href="../techniques/epub-metadata/index.html#visual-adjustments">EPUB
+								Accessibility:
+								Visual Adjustments</a></li>
+						<li><a
+								href="../techniques/onix-metadata/index.html#visual-adjustments">ONIX:
+								Visual
+								Adjustments</a></li>
+					</ul>
+				</section>
 			</section>
-			
-			<section id="va-techniques">
-				<h5>Display techniques for Visual adjustments support</h5>
-
-				<p>Specific techniques for meeting this principle are
-					defined in the following documents:</p>
-
-				<ul>
-					<li><a
-							href="../techniques/epub-metadata/index.html#visual-adjustments">EPUB
-							Accessibility:
-							Visual Adjustments</a></li>
-					<li><a
-							href="../techniques/onix-metadata/index.html#visual-adjustments">ONIX:
-							Visual
-							Adjustments</a></li>
-				</ul>
+	
+			<section id="supports-nonvisual-reading">
+				<h4 data-localization-id="ways-of-reading-nonvisual-reading-title">Support
+					for nonvisual reading</h4>
+	
+				<div class="note">
+					<p>This key information should be displayed, even
+						if there is no metadata (See the examples
+						where "No information is available"). </p>
+				</div>
+	
+				<p>Indicates whether all content required for comprehension
+					can be consumed in text and therefore is
+					available to reading systems with [=read aloud speech=]
+					or [=dynamic braille=] capabilities.</p>
+	
+				<p>This field answers whether nonvisual reading is possible,
+					not possible, or unknown.</p>
+	
+				<p>Digital publications with essential content included in
+					non-textual form (such as images, photographs, graphs,
+					tables or
+					equations presented as images, videos, etc.) must
+					include textual alternatives to ensure that users
+					reading with other senses than sight (mainly auditory
+					and tactile) have access to the same
+					information as visual readers. These textual
+					alternatives can include alt text on images, extended
+					descriptions,
+					transcripts, captions, etc. depending on the nature of
+					the nonvisual content.</p>
+	
+				<section id="nv-statements">
+					<h5>Statements</h5>
+	
+					<p>The descriptive and compact statements for nonvisual reading are as follows.</p>
+					
+					<dl>
+						<dt>If text alternatives are provided:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
+								data-localization-mode="compact">Has alternative text</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
+								data-localization-mode="descriptive">Has alternative text descriptions for images</p>
+						</dd>
+						
+						<dt>If all content is readable in text form:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
+								data-localization-mode="compact">Readable in
+								read aloud or dynamic braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
+								data-localization-mode="descriptive">All
+								content can be read as read aloud speech or
+								dynamic braille</p>
+						</dd>
+						
+						<dt>If not all content may be readable in text form:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
+								data-localization-mode="compact">May not be
+								fully readable in read aloud or dynamic
+								braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
+								data-localization-mode="descriptive">
+								Portions of the content may not be readable
+								as read aloud speech or dynamic braille</p>
+						</dd>
+						
+						<dt>If not all content is readable in text form:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
+								data-localization-mode="compact">Not
+								fully readable in read aloud or dynamic
+								braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
+								data-localization-mode="descriptive">Not all
+								of the content will be readable as read
+								aloud speech or dynamic braille</p>
+						</dd>
+					</dl>
+				</section>
+				
+				<section id="nv-techniques">
+					<h5>Display techniques for support for nonvisual reading support</h5>
+	
+					<p>Specific techniques for meeting this principle are
+						defined in the following documents:</p>
+	
+					<ul>
+						<li><a
+								href="../techniques/epub-metadata/index.html#supports-nonvisual-reading">EPUB
+								Accessibility: Support for nonvisual
+								reading</a></li>
+						<li><a
+								href="../techniques/onix-metadata/index.html#supports-nonvisual-reading">ONIX:
+								Support
+								for nonvisual reading</a></li>
+					</ul>
+				</section>
+			</section>
+	
+			<section id="prerecorded-audio">
+				<h4 data-localization-id="ways-to-read-prerecorded-audio-title">Prerecorded audio</h4>
+	
+				<div class="note">
+					<p>This key information can be hidden if metadata is
+						missing. Alternatively it can be stated that
+						<span
+							data-localization-id="prerecorded-audio-no-metadata"
+							data-localization-mode="descriptive">No information is available</span>
+					</p>
+				</div>
+	
+				<p>Indicates the presence of prerecorded audio and specifies if this audio is standalone (an audiobook), is an alternative to the text (synchronized text with audio playback), or is complementary audio (portions of audio, (e.g., reading of a poem).</p>
+	
+				<p>Audiobooks created for mainstream use provide important
+					access for many users with disabilities even
+					though they are not accessible to all. As they grow in
+					popularity, audiobooks may provide more
+					accessibility options in the future.</p>
+	
+				<p>Some publications provide prerecorded audio with text
+					synchronization. Users with hearing
+					impairments still can access the full content of these
+					books.</p>
+	
+				<section id="prerecorded-audio-statements">
+					<h5>Statements</h5>
+					
+					<p>The descriptive and compact statements for prerecorded audio are as follows.</p>
+					
+					<dl>
+						<dt>If the publication is a prerecorded audiobook:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-prerecorded-audio-only"
+								data-localization-mode="compact">Audio only</p>
+							<p data-localization-id="ways-of-reading-prerecorded-audio-only"
+								data-localization-mode="descriptive">
+								Audiobook with no text alternative</p>
+						</dd>
+						
+						<dt>If there is prerecorded audio synchronized with text:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
+								data-localization-mode="compact">Prerecorded audio synchronized with text</p>
+							<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
+								data-localization-mode="descriptive">All the
+								content is available as prerecorded audio
+								synchronized with text</p>
+						</dd>
+						
+						<dt>If there are prerecorded audio clips:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-prerecorded-audio-complementary" data-localization-mode="descriptive">Portions of prerecorded audio are available</p>
+						</dd>
+						
+						<dt>If no metadata is provided:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
+								data-localization-mode="compact">
+								No information about prerecorded audio is available</p>
+							<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
+								data-localization-mode="descriptive">
+								No information about prerecorded audio is available</p>
+						</dd>
+					</dl>
+				</section>
+				
+				<section id="prerecorded-audio-techniques">
+					<h5>Display techniques for prerecorded audio support
+					</h5>
+					<p>Specific techniques for meeting this principle are
+						defined in the following documents:</p>
+					<ul>
+						<li><a
+								href="../techniques/epub-metadata/index.html#prerecorded-audio">EPUB
+								Accessibility: Full
+								audio</a></li>
+						<li><a
+								href="../techniques/onix-metadata/index.html#prerecorded-audio">ONIX:
+								Full
+								audio</a></li>
+					</ul>
+				</section>
 			</section>
 		</section>
-
-
-		<section id="supports-nonvisual-reading">
-			<h4 data-localization-id="ways-of-reading-nonvisual-reading-title">Support
-				for nonvisual reading</h4>
-
-			<div class="note">
-				<p>This key information should be displayed, even
-					if there is no metadata (See the examples
-					where "No information is available"). </p>
-			</div>
-
-			<p>Indicates whether all content required for comprehension
-				can be consumed in text and therefore is
-				available to reading systems with [=read aloud speech=]
-				or [=dynamic braille=] capabilities.</p>
-
-			<p>This field answers whether nonvisual reading is possible,
-				not possible, or unknown.</p>
-
-			<p>Digital publications with essential content included in
-				non-textual form (such as images, photographs, graphs,
-				tables or
-				equations presented as images, videos, etc.) must
-				include textual alternatives to ensure that users
-				reading with other senses than sight (mainly auditory
-				and tactile) have access to the same
-				information as visual readers. These textual
-				alternatives can include alt text on images, extended
-				descriptions,
-				transcripts, captions, etc. depending on the nature of
-				the nonvisual content.</p>
-
-			<section id="nv-statements">
-				<h5>Statements</h5>
-
-				<p>The descriptive and compact statements for nonvisual reading are as follows.</p>
-				
-				<dl>
-					<dt>If text alternatives are provided:</dt>
-					<dd>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
-							data-localization-mode="compact">Has alternative text</p>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
-							data-localization-mode="descriptive">Has alternative text descriptions for images</p>
-					</dd>
-					
-					<dt>If all content is readable in text form:</dt>
-					<dd>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
-							data-localization-mode="compact">Readable in
-							read aloud or dynamic braille</p>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
-							data-localization-mode="descriptive">All
-							content can be read as read aloud speech or
-							dynamic braille</p>
-					</dd>
-					
-					<dt>If not all content may be readable in text form:</dt>
-					<dd>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
-							data-localization-mode="compact">May not be
-							fully readable in read aloud or dynamic
-							braille</p>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
-							data-localization-mode="descriptive">
-							Portions of the content may not be readable
-							as read aloud speech or dynamic braille</p>
-					</dd>
-					
-					<dt>If not all content is readable in text form:</dt>
-					<dd>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
-							data-localization-mode="compact">Not
-							fully readable in read aloud or dynamic
-							braille</p>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
-							data-localization-mode="descriptive">Not all
-							of the content will be readable as read
-							aloud speech or dynamic braille</p>
-					</dd>
-				</dl>
-			</section>
-			
-			<section id="nv-techniques">
-				<h5>Display techniques for support for nonvisual reading support
-				</h5>
-
-				<p>Specific techniques for meeting this principle are
-					defined in the following documents:</p>
-
-				<ul>
-					<li><a
-							href="../techniques/epub-metadata/index.html#supports-nonvisual-reading">EPUB
-							Accessibility: Support for nonvisual
-							reading</a></li>
-					<li><a
-							href="../techniques/onix-metadata/index.html#supports-nonvisual-reading">ONIX:
-							Support
-							for nonvisual reading</a></li>
-				</ul>
-			</section>
-		</section>
-
-		<section id="prerecorded-audio">
-			<h4 data-localization-id="ways-to-read-prerecorded-audio-title">Prerecorded audio</h4>
-
-			<div class="note">
-				<p>This key information can be hidden if metadata is
-					missing. Alternatively it can be stated that
-					<span
-						data-localization-id="prerecorded-audio-no-metadata"
-						data-localization-mode="descriptive">No information is available</span>
-				</p>
-			</div>
-
-			<p>Indicates the presence of prerecorded audio and specifies if this audio is standalone (an audiobook), is an alternative to the text (synchronized text with audio playback), or is complementary audio (portions of audio, (e.g., reading of a poem).</p>
-
-			<p>Audiobooks created for mainstream use provide important
-				access for many users with disabilities even
-				though they are not accessible to all. As they grow in
-				popularity, audiobooks may provide more
-				accessibility options in the future.</p>
-
-
-
-			<p>Some publications provide prerecorded audio with text
-				synchronization. Users with hearing
-				impairments still can access the full content of these
-				books.</p>
-
-			<section id="prerecorded-audio-statements">
-				<h5>Statements</h5>
-				
-				<p>The descriptive and compact statements for prerecorded audio are as follows.</p>
-				
-				<dl>
-					<dt>If the publication is a prerecorded audiobook:</dt>
-					<dd>
-						<p data-localization-id="ways-of-reading-prerecorded-audio-only"
-							data-localization-mode="compact">Audio only</p>
-						<p data-localization-id="ways-of-reading-prerecorded-audio-only"
-							data-localization-mode="descriptive">
-							Audiobook with no text alternative</p>
-					</dd>
-					
-					<dt>If there is prerecorded audio synchronized with text:</dt>
-					<dd>
-						<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
-							data-localization-mode="compact">Prerecorded audio synchronized with text</p>
-						<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
-							data-localization-mode="descriptive">All the
-							content is available as prerecorded audio
-							synchronized with text</p>
-					</dd>
-					
-					<dt>If there are prerecorded audio clips:</dt>
-					<dd>
-						<p data-localization-id="ways-of-reading-prerecorded-audio-complementary" data-localization-mode="descriptive">Portions of prerecorded audio are available</p>
-					</dd>
-					
-					<dt>If no metadata is provided:</dt>
-					<dd>
-						<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
-							data-localization-mode="compact">
-							No information about prerecorded audio is available</p>
-						<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
-							data-localization-mode="descriptive">
-							No information about prerecorded audio is available</p>
-					</dd>
-				</dl>
-			</section>
-			
-			<section id="prerecorded-audio-techniques">
-				<h5>Display techniques for prerecorded audio support
-				</h5>
-				<p>Specific techniques for meeting this principle are
-					defined in the following documents:</p>
-				<ul>
-					<li><a
-							href="../techniques/epub-metadata/index.html#prerecorded-audio">EPUB
-							Accessibility: Full
-							audio</a></li>
-					<li><a
-							href="../techniques/onix-metadata/index.html#prerecorded-audio">ONIX:
-							Full
-							audio</a></li>
-				</ul>
-			</section>
-		</section>
-
-</section>
 		<section id="conformance-group">
 			<h3 data-localization-id="conformance-title">Conformance</h3>
 

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -611,6 +611,9 @@
 					<dt>If the display is modifiable:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
+							data-localization-mode="compact">Appearance
+							can be modified</p>
+						<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
 							data-localization-mode="descriptive">
 							Appearance of the text and page layout can
 							be
@@ -620,31 +623,28 @@
 							spaces between paragraphs, sentences, words,
 							and letters, as well as color of background
 							and text)</p>
-						<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
-							data-localization-mode="compact">Appearance
-							can be modified</p>
 					</dd>
 					
 					<dt>If the display is not modifiable:</dt>
 					<dd>
+						<p data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
+							data-localization-mode="compact">Appearance
+							cannot be modified</p>
 						<p data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
 							data-localization-mode="descriptive">Text
 							and page layout cannot be modified as the
 							reading experience is close to a print
 							version, but reading systems can still
 							provide zooming options</p>
-						<p data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
-							data-localization-mode="compact">Appearance
-							cannot be modified</p>
 					</dd>
 					
 					<dt>If no metadata is provided:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
+							data-localization-mode="compact">No information about appearance modifiability is available</p>
+						<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
 							data-localization-mode="descriptive">
 							No information about appearance modifiability is available</p>
-						<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
-							data-localization-mode="compact">No information about appearance modifiability is available</p>
 					</dd>
 				</dl>
 			</section>
@@ -709,44 +709,44 @@
 					<dt>If text alternatives are provided:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
-							data-localization-mode="descriptive">Has alternative text descriptions for images</p>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
 							data-localization-mode="compact">Has alternative text</p>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
+							data-localization-mode="descriptive">Has alternative text descriptions for images</p>
 					</dd>
 					
 					<dt>If all content is readable in text form:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
+							data-localization-mode="compact">Readable in
+							read aloud or dynamic braille</p>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
 							data-localization-mode="descriptive">All
 							content can be read as read aloud speech or
 							dynamic braille</p>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
-							data-localization-mode="compact">Readable in
-							read aloud or dynamic braille</p>
 					</dd>
 					
 					<dt>If not all content may be readable in text form:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
-							data-localization-mode="descriptive">
-							Portions of the content may not be readable
-							as read aloud speech or dynamic braille</p>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
 							data-localization-mode="compact">May not be
 							fully readable in read aloud or dynamic
 							braille</p>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
+							data-localization-mode="descriptive">
+							Portions of the content may not be readable
+							as read aloud speech or dynamic braille</p>
 					</dd>
 					
 					<dt>If not all content is readable in text form:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
-							data-localization-mode="descriptive">Not all
-							of the content will be readable as read
-							aloud speech or dynamic braille</p>
-						<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
 							data-localization-mode="compact">Not
 							fully readable in read aloud or dynamic
 							braille</p>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
+							data-localization-mode="descriptive">Not all
+							of the content will be readable as read
+							aloud speech or dynamic braille</p>
 					</dd>
 				</dl>
 			</section>
@@ -807,20 +807,20 @@
 					<dt>If the publication is a prerecorded audiobook:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-prerecorded-audio-only"
+							data-localization-mode="compact">Audio only</p>
+						<p data-localization-id="ways-of-reading-prerecorded-audio-only"
 							data-localization-mode="descriptive">
 							Audiobook with no text alternative</p>
-						<p data-localization-id="ways-of-reading-prerecorded-audio-only"
-							data-localization-mode="compact">Audio only</p>
 					</dd>
 					
 					<dt>If there is prerecorded audio synchronized with text:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
+							data-localization-mode="compact">Prerecorded audio synchronized with text</p>
+						<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
 							data-localization-mode="descriptive">All the
 							content is available as prerecorded audio
 							synchronized with text</p>
-						<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
-							data-localization-mode="compact">Prerecorded audio synchronized with text</p>
 					</dd>
 					
 					<dt>If there are prerecorded audio clips:</dt>
@@ -831,10 +831,10 @@
 					<dt>If no metadata is provided:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
-							data-localization-mode="descriptive">
+							data-localization-mode="compact">
 							No information about prerecorded audio is available</p>
 						<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
-							data-localization-mode="compact">
+							data-localization-mode="descriptive">
 							No information about prerecorded audio is available</p>
 					</dd>
 				</dl>
@@ -1221,48 +1221,48 @@
 					<dt>If a table of contents is provided:</dt>
 					<dd>
 						<p data-localization-id="navigation-toc"
+							data-localization-mode="compact">Table
+							of contents</p>
+						<p data-localization-id="navigation-toc"
 							data-localization-mode="descriptive">Table
 							of contents to all chapters of the text via
 							links</p>
-						<p data-localization-id="navigation-toc"
-								data-localization-mode="compact">Table
-								of contents</p>
 					</dd>
 					
 					<dt>If index(es) are provided:</dt>
 					<dd>
 						<p data-localization-id="navigation-index"
+							data-localization-mode="compact">Index</p>
+						<p data-localization-id="navigation-index"
 							data-localization-mode="descriptive">Index
 							with links to referenced entries</p>
-						<p data-localization-id="navigation-index"
-								data-localization-mode="compact">Index</p>
 					</dd>
 					
 					<dt>If structural navigation is provided:</dt>
 					<dd>
 						<p data-localization-id="navigation-structural"
+							data-localization-mode="compact">Headings</p>
+						<p data-localization-id="navigation-structural"
 							data-localization-mode="descriptive">Elements such as headings, tables, etc for
 							structured navigation</p>
-						<p data-localization-id="navigation-structural"
-								data-localization-mode="compact">Headings</p>
 					</dd>
 					
 					<dt>If page navigation is provided:</dt>
 					<dd>
 						<p data-localization-id="navigation-page-navigation"
+							data-localization-mode="compact">Go to page</p>
+						<p data-localization-id="navigation-page-navigation"
 							data-localization-mode="descriptive">Page list to go to pages from the print
 							source
 							version</p>
-						<p data-localization-id="navigation-page-navigation"
-								data-localization-mode="compact">Go to page</p>
 					</dd>
 					
 					<dt>If no metadata is provided:</dt>
 					<dd>
 						<p data-localization-id="navigation-no-metadata"
-							data-localization-mode="descriptive">No information is available</p>
-						<p data-localization-id="navigation-no-metadata"
 							data-localization-mode="compact">No information is available</p>
+						<p data-localization-id="navigation-no-metadata"
+							data-localization-mode="descriptive">No information is available</p>
 					</dd>
 				</dl>
 			</section>
@@ -1315,79 +1315,79 @@
 					<dt>If math is marked up in MathML:</dt>
 					<dd>
 						<p data-localization-id="rich-content-accessible-math-as-mathml"
-								data-localization-mode="descriptive">Math formulas in accessible format (MathML)</p>
+							data-localization-mode="compact">Math as MathML</p>
 						<p data-localization-id="rich-content-accessible-math-as-mathml"
-								data-localization-mode="compact">Math as MathML</p>
+								data-localization-mode="descriptive">Math formulas in accessible format (MathML)</p>
 					</dd>
 					
 					<dt>If math is marked up in LaTeX:</dt>
 					<dd>
 						<p data-localization-id="rich-content-accessible-math-as-latex"
-								data-localization-mode="descriptive">Math formulas in accessible format (LaTeX)</p>
+							data-localization-mode="compact">Math as LaTeX</p>
 						<p data-localization-id="rich-content-accessible-math-as-latex"
-								data-localization-mode="compact">Math as LaTeX</p>
+								data-localization-mode="descriptive">Math formulas in accessible format (LaTeX)</p>
 					</dd>
 					
 					<dt>If math is represented as images:</dt>
 					<dd>
 						<p data-localization-id="rich-content-accessible-math-described"
-								data-localization-mode="descriptive">Text descriptions of math is provided</p>
+							data-localization-mode="compact">Text descriptions of math is provided</p>
 						<p data-localization-id="rich-content-accessible-math-described"
-								data-localization-mode="compact">Text descriptions of math is provided</p>
+								data-localization-mode="descriptive">Text descriptions of math is provided</p>
 					</dd>
 					
 					<dt>If chemical formulas are marked up in MathML:</dt>
 					<dd>
 						<p data-localization-id="rich-content-accessible-chemistry-as-mathml"
-								data-localization-mode="descriptive">Chemical formulas in accessible format (MathML)</p>
+							data-localization-mode="compact">Chemical formulas in MathML</p>
 						<p data-localization-id="rich-content-accessible-chemistry-as-mathml"
-								data-localization-mode="compact">Chemical formulas in MathML</p>
+								data-localization-mode="descriptive">Chemical formulas in accessible format (MathML)</p>
 					</dd>
 					
 					<dt>If chemical formulas are marked up in LaTeX:</dt>
 					<dd>
 						<p data-localization-id="rich-content-accessible-chemistry-as-latex"
-								data-localization-mode="descriptive">Chemical formulas in accessible format (LaTeX)</p>
+							data-localization-mode="compact">Chemical formulas in LaTeX</p>
 						<p data-localization-id="rich-content-accessible-chemistry-as-latex"
-								data-localization-mode="compact">Chemical formulas in LaTeX</p>
+								data-localization-mode="descriptive">Chemical formulas in accessible format (LaTeX)</p>
 					</dd>
 					
 					<dt>If extended descriptions are provided for images:</dt>
 					<dd>
 						<p data-localization-id="rich-content-extended"
-								data-localization-mode="descriptive">Information-rich images are described by extended descriptions</p>
+							data-localization-mode="compact">Information-rich images are described by extended descriptions</p>
 						<p data-localization-id="rich-content-extended"
-								data-localization-mode="compact">Information-rich images are described by extended descriptions</p>
+								data-localization-mode="descriptive">Information-rich images are described by extended descriptions</p>
 					</dd>
 					
 					<dt>If closed captions are provided for videos:</dt>
 					<dd>
+						<p data-localization-id="rich-content-closed-captions" data-localization-mode="compact">
+							Videos have closed captions</p>
 						<p data-localization-id="rich-content-closed-captions" data-localization-mode="descriptive">
 								Videos included in publications have closed captions</p>
-						<p data-localization-id="rich-content-closed-captions" data-localization-mode="compact">
-								Videos have closed captions</p>
 					</dd>
 					
 					<dt>If open captions are provided for videos:</dt>
 					<dd>
+						<p data-localization-id="rich-content-open-captions" data-localization-mode="compact">
+							Videos have open captions</p>
 						<p data-localization-id="rich-content-open-captions" data-localization-mode="descriptive">
 								Videos included in publications have open captions</p>
-						<p data-localization-id="rich-content-open-captions" data-localization-mode="compact">
-								Videos have open captions</p>
 					</dd>
 					
 					<dt>If transcripts are provided for auditory content:</dt>
 					<dd>
-						<p data-localization-id="rich-content-transcript" data-localization-mode="descriptive">
-								Transcript(s) provided)</p>
 						<p data-localization-id="rich-content-transcript" data-localization-mode="compact">
+							Transcript(s) provided)</p>
+						<p data-localization-id="rich-content-transcript" data-localization-mode="descriptive">
 								Transcript(s) provided)</p>
 					</dd>
 					
 					<dt>If no metadata is provided:</dt>
 					<dd>
-						<p data-localization-id="rich-content-unknown" data-localization-mode="descriptive">No information is available</p>
 						<p data-localization-id="rich-content-unknown" data-localization-mode="compact">No information is available</p>
+						<p data-localization-id="rich-content-unknown" data-localization-mode="descriptive">No information is available</p>
 					</dd>
 				</dl>
 			</section>
@@ -1460,59 +1460,59 @@
 					<dt>If there are no hazards:</dt>
 					<dd>
 						<p data-localization-id="hazards-none"
-								data-localization-mode="descriptive">No hazards</p>
+							data-localization-mode="compact">No hazards</p>
 						<p data-localization-id="hazards-none"
-								data-localization-mode="compact">No hazards</p>
+								data-localization-mode="descriptive">No hazards</p>
 					</dd>
 					
 					<dt>If there is a flashing hazard:</dt>
 					<dd>
 						<p data-localization-id="hazards-flashing"
+							data-localization-mode="compact">Flashing
+							content</p>
+						<p data-localization-id="hazards-flashing"
 								data-localization-mode="descriptive">The
 								publication contains flashing content
 								which can cause photosensitive
 								seizures</p>
-						<p data-localization-id="hazards-flashing"
-								data-localization-mode="compact">Flashing
-								content</p>
 					</dd>
 					
 					<dt>If there is a motion simulation hazard:</dt>
 					<dd>
 						<p data-localization-id="hazards-motion"
+							data-localization-mode="compact">Motion
+							simulation</p>
+						<p data-localization-id="hazards-motion"
 								data-localization-mode="descriptive">The
 								publication contains motion simulations
 								that can cause motion sickness</p>
-						<p data-localization-id="hazards-motion"
-								data-localization-mode="compact">Motion
-								simulation</p>
 					</dd>
 					
 					<dt>If there is a sound hazard:</dt>
 					<dd>
 						<p data-localization-id="hazards-sound"
+							data-localization-mode="compact">sounds</p>
+						<p data-localization-id="hazards-sound"
 								data-localization-mode="descriptive">The
 								publication contains sounds which
 								can be uncomfortable</p>
-						<p data-localization-id="hazards-sound"
-								data-localization-mode="compact">sounds</p>
 					</dd>
 					
 					<dt>If hazards are not known:</dt>
 					<dd>
 						<p data-localization-id="hazards-unknown"
+							data-localization-mode="compact">The presence of hazards is unknown</p>
+						<p data-localization-id="hazards-unknown"
 								data-localization-mode="descriptive">The presents
 								of hazards is unknown</p>
-						<p data-localization-id="hazards-unknown"
-								data-localization-mode="compact">The presence of hazards is unknown</p>
 					</dd>
 					
 					<dt>If no metadata is provided:</dt>
 					<dd>
+						<p data-localization-id="hazards-no-metadata"
+							data-localization-mode="compact">No information is available</p>
 						<p data-localization-id="hazards-no-metadata]."
 								data-localization-mode="descriptive">No information is available</p>
-						<p data-localization-id="hazards-no-metadata"
-								data-localization-mode="compact">No information is available</p>
 					</dd>
 				</dl>
 			</section>
@@ -1675,19 +1675,19 @@
 					<dt>If the publication claims an exemption:</dt>
 					<dd>
 						<p data-localization-id="legal-considerations-exempt"
+							data-localization-mode="compact">Claims an accessibility exemption in some jurisdictions</p>
+						<p data-localization-id="legal-considerations-exempt"
 							data-localization-mode="descriptive">This
 							publication claims an accessibility exemption in
 							some jurisdictions</p>
-						<p data-localization-id="legal-considerations-exempt"
-							data-localization-mode="compact">Claims an accessibility exemption in some jurisdictions</p>
 					</dd>
 					
 					<dt>If no metadata is provided:</dt>
 					<dd>
 						<p data-localization-id="legal-considerations-no-metadata"
-							data-localization-mode="descriptive">No information is available</p>
-						<p data-localization-id="legal-considerations-no-metadata"
 							data-localization-mode="compact">No information is available</p>
+						<p data-localization-id="legal-considerations-no-metadata"
+							data-localization-mode="descriptive">No information is available</p>
 					</dd>
 				</dl>	
 			</section>
@@ -1802,32 +1802,32 @@
 				<dl>
 					<dt>If there are ARIA roles:</dt>
 					<dd>
+						<p data-localization-mode="compact">ARIA roles included</p>
 						<p data-localization-mode="descriptive">Content is enhanced with ARIA roles to
 							optimize organization and facilitate
 							navigation</p>
-						<p data-localization-mode="compact">ARIA roles included</p>
 					</dd>
 					
 					<dt>If there are page break markers:</dt>
 					<dd>
+						<p data-localization-mode="compact">Visible page numbering</p>
 						<p data-localization-mode="descriptive">Page breaks included from the original print
 							source</p>
-						<p data-localization-mode="compact">Visible page numbering</p>
 					</dd>
 					
 					<dt>If there are tactile graphics:</dt>
 					<dd>
+						<p data-localization-mode="compact">Tactile graphics included</p>
 						<p data-localization-mode="descriptive">Tactile graphics have been integrated to
 							facilitate access to visual elements for
 							blind
 							people</p>
-						<p data-localization-mode="compact">Tactile graphics included</p>
 					</dd>
 					
 					<dt>If no metadata is provided:</dt>
 					<dd>
-						<p data-localization-mode="descriptive">No information is available</p>
 						<p data-localization-mode="compact">No information is available</p>
+						<p data-localization-mode="descriptive">No information is available</p>
 					</dd>
 				</dl>
 			</section>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -127,9 +127,21 @@
 			content: 'Descriptive: ';
 			font-style: italic;
 		}
+		aside.example p[data-localization-mode="descriptive"]:before {
+			content: '';
+			font-style: normal;
+		}
 		p[data-localization-mode="compact"]:before {
 			content: 'Compact: ';
 			font-style: italic;
+		}
+		aside.example p[data-localization-mode="compact"]:before {
+			content: '';
+			font-style: normal;
+		}
+		.placeholder {
+			font-style: italic;
+			color: red;
 		}
 	</style>
 </head>
@@ -887,73 +899,6 @@
 				identified along with their credentials and
 				placed immediately after the conformance statement.</p>
 
-			<section id="conf-statements">
-				<h4>Conformance statements</h4>
-				
-				<p>The following list explains the meaning of each
-					recommended conformance statement.</p>
-				<dl>
-					<dt data-localization-id="conformance-aaa"
-						data-localization-mode="compact">This
-						publication
-						exceeds accepted accessibility standards</dt>
-					<dd data-localization-id="conformance-aaa"
-						data-localization-mode="descriptive">
-						<p>The publication contains a conformance
-							statement that it meets the EPUB
-							Accessibility and
-							WCAG 2 Level AAA standard</p>
-					</dd>
-					<dt data-localization-id="conformance-aa"
-						data-localization-mode="compact">This
-						publication
-						meets accepted accessibility standards</dt>
-					<dd data-localization-id="conformance-aa"
-						data-localization-mode="descriptive">
-						<p>The publication contains a conformance
-							statement that it meets the EPUB
-							Accessibility and
-							WCAG 2 Level AA standard</p>
-					</dd>
-
-					<dt data-localization-id="conformance-a"
-						data-localization-mode="compact">This
-						publication meets
-						minimum accessibility standards</dt>
-					<dd data-localization-id="conformance-a"
-						data-localization-mode="descriptive">
-						<p>The publication contains a conformance
-							statement that it meets the EPUB
-							Accessibility and
-							WCAG 2 Level A standard</p>
-					</dd>
-
-					<dt data-localization-id="conformance-no"
-						data-localization-mode="compact">No information is available</dt>
-					<dd >
-						<p>The conformance metadata is missing and
-							conformity to a standard of this publication
-							is
-							unknown</p>
-					</dd>
-
-					<dt>Certifier's name</dt>
-					<dd>Identifies the organization providing the
-						certification review or process for
-						certification. </dd>
-
-					<dt>Certifier's Credentials </dt>
-					<dd>If the certifier has a badge or a credential,
-						then the text is provided. If there is a link
-						to their credential, then this can be provided
-						as a link. If the certifier has a logo or
-						badge, this can be displayed. The display of the
-						logo or badge can be arranged between the
-						certifier and the distributor showing the
-						accessibility metadata.</dd>
-
-				</dl>
-			</section>
 
 			<section id="detailled-conformance-information">
 				<h4>Detailed conformance information</h4>
@@ -982,9 +927,202 @@
 				</dl>
 			</section>
 
-			<section id="conformance-statements">
+			<section id="conf-statements">
 				<h4>Statements</h4>
 				
+				<div class="note">
+					<p>Some conformance statements incorporate publication metadata. To indicate where
+						this text will be inserted, the statements include placeholder variables. These
+						placeholders are identified by being enclosed in angle brackets (e.g., 
+						<span class="placeholder">&lt;placeholder&gt;</span>).</p>
+				</div>
+				
+				<dl>
+					<dt>If the publication meets minimal accessibility requirements:</dt>
+					<dd>
+						<p data-localization-id="conformance-a"
+							data-localization-mode="descriptive">This publication meets minimum accessibility
+							standards</p>
+						<p data-localization-id="conformance-a"
+							data-localization-mode="compact">This publication meets minimum accessibility
+							standards</p>
+					</dd>
+					
+					<dt>If the publication meets widely accepted accessibility requirements:</dt>
+					<dd>
+						<p data-localization-id="conformance-aa"
+							data-localization-mode="descriptive">This publication meets accepted accessibility
+							standards</p>
+						<p data-localization-id="conformance-aa"
+							data-localization-mode="compact">This publication meets accepted accessibility
+							standards</p>
+					</dd>
+					
+					<dt>If no metadata is provided:</dt>
+					<dd>
+						<p data-localization-id="conformance-no"
+							data-localization-mode="descriptive">No information is available</p>
+						<p data-localization-id="conformance-no"
+							data-localization-mode="compact">No information is available</p>
+					</dd>
+					
+					<dt>If the publication meets the requirements of the EPUB Accessibility standard:</dt>
+					<dd>
+						<p
+							data-localization-mode="descriptive">
+							<span
+								data-localization-id="conformance-claim">This
+								publication claims to meet</span>
+							
+							<span>EPUB
+								Accessibility</span>
+							<span class="placeholder">&lt;1.X&gt;</span>
+							
+							<span>Web
+								Accessibility Content Guidelines (WCAG)</span>
+							<span class="placeholder">&lt;2.X&gt;</span>
+							
+							<span>Level</span>
+							<span class="placeholder">&lt;A or AA or AAA&gt;</span>
+						</p>
+						<p
+							data-localization-mode="compact">
+							<span
+								data-localization-id="conformance-claim">This
+								publication claims to meet</span>
+							
+							<span>EPUB
+								Accessibility</span>
+							<span class="placeholder">&lt;1.X&gt;</span>
+							
+							<span>WCAG</span>
+							<span class="placeholder">&lt;2.X&gt;</span>
+							
+							<span>Level</span>
+							<span class="placeholder">&lt;A or AA or AAA&gt;</span>
+						</p>
+					</dd>
+					
+					<dt>If a certifier name is provided:</dt>
+					<dd>
+						<p data-localization-mode="descriptive"><span
+								data-localization-id="conformance-certifier"
+								data-localization-mode="descriptive">The
+								publication was certified by</span>
+							<span class="placeholder">&lt;certifier name&gt;</span></p>
+						<p data-localization-mode="compact"><span
+								data-localization-id="conformance-certifier"
+								data-localization-mode="compact">The
+								publication was certified by</span>
+							<span class="placeholder">&lt;certifier name&gt;</span></p>
+					</dd>
+					
+					<dt>If the certifier has a credential:</dt>
+					<dd>
+						<p data-localization-mode="descriptive"><span
+								data-localization-id="conformance-certifier-credentials"
+								data-localization-mode="descriptive">The certifier's credential is</span>
+							<span class="placeholder">&lt;certifier credential&gt;</span></p>
+						<p data-localization-mode="compact"><span
+								data-localization-id="conformance-certifier-credentials"
+								data-localization-mode="compact">The certifier's credential is</span>
+							<span class="placeholder">&lt;certifier credential&gt;</span></p>
+					</dd>
+					
+					<dt>If the certification date is provided:</dt>
+					<dd>
+						<p data-localization-mode="descriptive">
+							<span data-localization-id="conformance-certification-info"
+								data-localization-mode="descriptive">The
+								publication was certified on</span>
+							<span class="placeholder">&lt;certification date&gt;</span></p>
+						<p data-localization-mode="compact">
+							<span data-localization-id="conformance-certification-info"
+								data-localization-mode="compact">The
+								publication was certified on</span>
+							<span class="placeholder">&lt;certification date&gt;</span></p>
+					</dd>
+					
+					<dt>If the certifier provides an accessibility report:</dt>
+					<dd>
+						<p data-localization-id="conformance-certifier-report"
+							data-localization-mode="descriptive">For
+								more information refer to the
+								certifier's report</p>
+						<p data-localization-id="conformance-certifier-report"
+							data-localization-mode="compact">For
+								more information refer to the
+								certifier's report</p>
+					</dd>
+				</dl>
+				
+				<section id="conf-expl">
+					<h4>Explainer</h4>
+					
+					<p>The following list explains the meaning of each
+						recommended conformance statement.</p>
+					<dl>
+						<dt data-localization-id="conformance-aaa"
+							data-localization-mode="compact">This
+							publication
+							exceeds accepted accessibility standards</dt>
+						<dd data-localization-id="conformance-aaa"
+							data-localization-mode="descriptive">
+							<p>The publication contains a conformance
+								statement that it meets the EPUB
+								Accessibility and
+								WCAG 2 Level AAA standard</p>
+						</dd>
+						<dt data-localization-id="conformance-aa"
+							data-localization-mode="compact">This
+							publication
+							meets accepted accessibility standards</dt>
+						<dd data-localization-id="conformance-aa"
+							data-localization-mode="descriptive">
+							<p>The publication contains a conformance
+								statement that it meets the EPUB
+								Accessibility and
+								WCAG 2 Level AA standard</p>
+						</dd>
+						
+						<dt data-localization-id="conformance-a"
+							data-localization-mode="compact">This
+							publication meets
+							minimum accessibility standards</dt>
+						<dd data-localization-id="conformance-a"
+							data-localization-mode="descriptive">
+							<p>The publication contains a conformance
+								statement that it meets the EPUB
+								Accessibility and
+								WCAG 2 Level A standard</p>
+						</dd>
+						
+						<dt data-localization-id="conformance-no"
+							data-localization-mode="compact">No information is available</dt>
+						<dd >
+							<p>The conformance metadata is missing and
+								conformity to a standard of this publication
+								is
+								unknown</p>
+						</dd>
+						
+						<dt>Certifier's name</dt>
+						<dd>Identifies the organization providing the
+							certification review or process for
+							certification. </dd>
+						
+						<dt>Certifier's Credentials </dt>
+						<dd>If the certifier has a badge or a credential,
+							then the text is provided. If there is a link
+							to their credential, then this can be provided
+							as a link. If the certifier has a logo or
+							badge, this can be displayed. The display of the
+							logo or badge can be arranged between the
+							certifier and the distributor showing the
+							accessibility metadata.</dd>
+						
+					</dl>
+				</section>
 			</section>
 				
 			<section id="conf-examples">

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -568,7 +568,7 @@
 					shown in the examples.</p>
 			</div>
 		</section>
-		            <section id="ways-of-reading">
+		<section id="ways-of-reading">
                 <h3 data-localization-id="ways-of-reading-title">Ways of reading</h3>
 
 		<section id="visual-adjustments">
@@ -608,7 +608,7 @@
 				<p>The descriptive and compact statements for visual adjustment are as follows.</p>
 				
 				<dl>
-					<dt>Display is modifiable</dt>
+					<dt>If the display is modifiable:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
 							data-localization-mode="descriptive">
@@ -625,7 +625,7 @@
 							can be modified</p>
 					</dd>
 					
-					<dt>Display is not modifiable</dt>
+					<dt>If the display is not modifiable:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
 							data-localization-mode="descriptive">Text
@@ -638,7 +638,7 @@
 							cannot be modified</p>
 					</dd>
 					
-					<dt>No metadata provided</dt>
+					<dt>If no metadata is provided:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
 							data-localization-mode="descriptive">
@@ -706,7 +706,7 @@
 				<p>The descriptive and compact statements for nonvisual reading are as follows.</p>
 				
 				<dl>
-					<dt>Text alternatives are provided</dt>
+					<dt>If text alternatives are provided:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
 							data-localization-mode="descriptive">Has alternative text descriptions for images</p>
@@ -714,7 +714,7 @@
 							data-localization-mode="compact">Has alternative text</p>
 					</dd>
 					
-					<dt>All content is readable in text form</dt>
+					<dt>If all content is readable in text form:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
 							data-localization-mode="descriptive">All
@@ -725,7 +725,7 @@
 							read aloud or dynamic braille</p>
 					</dd>
 					
-					<dt>Not all content may be readable in text form</dt>
+					<dt>If not all content may be readable in text form:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
 							data-localization-mode="descriptive">
@@ -737,7 +737,7 @@
 							braille</p>
 					</dd>
 					
-					<dt>Not all content is readable in text form</dt>
+					<dt>If not all content is readable in text form:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
 							data-localization-mode="descriptive">Not all
@@ -804,7 +804,7 @@
 				<p>The descriptive and compact statements for prerecorded audio are as follows.</p>
 				
 				<dl>
-					<dt>Prerecorded audiobooks</dt>
+					<dt>If the publication is a prerecorded audiobook:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-prerecorded-audio-only"
 							data-localization-mode="descriptive">
@@ -813,7 +813,7 @@
 							data-localization-mode="compact">Audio only</p>
 					</dd>
 					
-					<dt>Prerecorded audio synchronized with text</dt>
+					<dt>If there is prerecorded audio synchronized with text:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
 							data-localization-mode="descriptive">All the
@@ -823,12 +823,12 @@
 							data-localization-mode="compact">Prerecorded audio synchronized with text</p>
 					</dd>
 					
-					<dt>Prerecorded audio clips</dt>
+					<dt>If there are prerecorded audio clips:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-prerecorded-audio-complementary" data-localization-mode="descriptive">Portions of prerecorded audio are available</p>
 					</dd>
 					
-					<dt>No metadata provided</dt>
+					<dt>If no metadata is provided:</dt>
 					<dd>
 						<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
 							data-localization-mode="descriptive">
@@ -859,10 +859,8 @@
 		</section>
 
 </section>
-
 		<section id="conformance-group">
-			<h3 data-localization-id="conformance-title">Conformance
-			</h3>
+			<h3 data-localization-id="conformance-title">Conformance</h3>
 
 			<div class="note">
 				<p>This key information should be displayed, even
@@ -1179,8 +1177,6 @@
 				</ul>
 			</section>
 		</section>
-
-
 		<section id="navigation">
 			<h3 data-localization-id="navigation-title">Navigation</h3>
 
@@ -1222,7 +1218,7 @@
 				<p>The descriptive and compact statements for navigation are as follows.</p>
 				
 				<dl>
-					<dt>Table of contents provided</dt>
+					<dt>If a table of contents is provided:</dt>
 					<dd>
 						<p data-localization-id="navigation-toc"
 							data-localization-mode="descriptive">Table
@@ -1233,7 +1229,7 @@
 								of contents</p>
 					</dd>
 					
-					<dt>Index(es) provided</dt>
+					<dt>If index(es) are provided:</dt>
 					<dd>
 						<p data-localization-id="navigation-index"
 							data-localization-mode="descriptive">Index
@@ -1242,7 +1238,7 @@
 								data-localization-mode="compact">Index</p>
 					</dd>
 					
-					<dt>Structural navigation provided</dt>
+					<dt>If structural navigation is provided:</dt>
 					<dd>
 						<p data-localization-id="navigation-structural"
 							data-localization-mode="descriptive">Elements such as headings, tables, etc for
@@ -1251,7 +1247,7 @@
 								data-localization-mode="compact">Headings</p>
 					</dd>
 					
-					<dt>Page navigation provided</dt>
+					<dt>If page navigation is provided:</dt>
 					<dd>
 						<p data-localization-id="navigation-page-navigation"
 							data-localization-mode="descriptive">Page list to go to pages from the print
@@ -1261,7 +1257,7 @@
 								data-localization-mode="compact">Go to page</p>
 					</dd>
 					
-					<dt>No metadata provided</dt>
+					<dt>If no metadata is provided:</dt>
 					<dd>
 						<p data-localization-id="navigation-no-metadata"
 							data-localization-mode="descriptive">No information is available</p>
@@ -1316,7 +1312,7 @@
 				<p>The descriptive and compact statements for rich content are as follows.</p>
 				
 				<dl>
-					<dt>Math marked up in MathML</dt>
+					<dt>If math is marked up in MathML:</dt>
 					<dd>
 						<p data-localization-id="rich-content-accessible-math-as-mathml"
 								data-localization-mode="descriptive">Math formulas in accessible format (MathML)</p>
@@ -1324,7 +1320,7 @@
 								data-localization-mode="compact">Math as MathML</p>
 					</dd>
 					
-					<dt>Math marked up in LaTeX</dt>
+					<dt>If math is marked up in LaTeX:</dt>
 					<dd>
 						<p data-localization-id="rich-content-accessible-math-as-latex"
 								data-localization-mode="descriptive">Math formulas in accessible format (LaTeX)</p>
@@ -1332,7 +1328,7 @@
 								data-localization-mode="compact">Math as LaTeX</p>
 					</dd>
 					
-					<dt>Math represented as images</dt>
+					<dt>If math is represented as images:</dt>
 					<dd>
 						<p data-localization-id="rich-content-accessible-math-described"
 								data-localization-mode="descriptive">Text descriptions of math is provided</p>
@@ -1340,7 +1336,7 @@
 								data-localization-mode="compact">Text descriptions of math is provided</p>
 					</dd>
 					
-					<dt>Chemical formulas marked up in MathML</dt>
+					<dt>If chemical formulas are marked up in MathML:</dt>
 					<dd>
 						<p data-localization-id="rich-content-accessible-chemistry-as-mathml"
 								data-localization-mode="descriptive">Chemical formulas in accessible format (MathML)</p>
@@ -1348,7 +1344,7 @@
 								data-localization-mode="compact">Chemical formulas in MathML</p>
 					</dd>
 					
-					<dt>Chemical formulas marked up in LaTeX</dt>
+					<dt>If chemical formulas are marked up in LaTeX:</dt>
 					<dd>
 						<p data-localization-id="rich-content-accessible-chemistry-as-latex"
 								data-localization-mode="descriptive">Chemical formulas in accessible format (LaTeX)</p>
@@ -1356,7 +1352,7 @@
 								data-localization-mode="compact">Chemical formulas in LaTeX</p>
 					</dd>
 					
-					<dt>Extended descriptions provided for images</dt>
+					<dt>If extended descriptions are provided for images:</dt>
 					<dd>
 						<p data-localization-id="rich-content-extended"
 								data-localization-mode="descriptive">Information-rich images are described by extended descriptions</p>
@@ -1364,7 +1360,7 @@
 								data-localization-mode="compact">Information-rich images are described by extended descriptions</p>
 					</dd>
 					
-					<dt>Closed captions provided for videos</dt>
+					<dt>If closed captions are provided for videos:</dt>
 					<dd>
 						<p data-localization-id="rich-content-closed-captions" data-localization-mode="descriptive">
 								Videos included in publications have closed captions</p>
@@ -1372,7 +1368,7 @@
 								Videos have closed captions</p>
 					</dd>
 					
-					<dt>Open captions provided for videos</dt>
+					<dt>If open captions are provided for videos:</dt>
 					<dd>
 						<p data-localization-id="rich-content-open-captions" data-localization-mode="descriptive">
 								Videos included in publications have open captions</p>
@@ -1380,7 +1376,7 @@
 								Videos have open captions</p>
 					</dd>
 					
-					<dt>Transcripts provided for auditory content</dt>
+					<dt>If transcripts are provided for auditory content:</dt>
 					<dd>
 						<p data-localization-id="rich-content-transcript" data-localization-mode="descriptive">
 								Transcript(s) provided)</p>
@@ -1388,7 +1384,7 @@
 								Transcript(s) provided)</p>
 					</dd>
 					
-					<dt>No metadata provided</dt>
+					<dt>If no metadata is provided:</dt>
 					<dd>
 						<p data-localization-id="rich-content-unknown" data-localization-mode="descriptive">No information is available</p>
 						<p data-localization-id="rich-content-unknown" data-localization-mode="compact">No information is available</p>
@@ -1419,7 +1415,6 @@
 				</ul>
 			</section>
 		</section>
-
 		<section id="hazards">
 			<h3 data-localization-id="hazards-title">Hazards</h3>
 
@@ -1461,56 +1456,65 @@
 				
 				<p>The descriptive and compact statements for hazards are as follows.</p>
 				
-				<p id="hazards-desc" class="list-hd">Descriptive statements</p>
-				<ul aria-labelledby="hazards-desc">
-					<li><span data-localization-id="hazards-none"
-							data-localization-mode="descriptive">No
-							hazards</span></li>
-					<li><span
-							data-localization-id="hazards-flashing"
-							data-localization-mode="descriptive">The
-							publication contains flashing content
-							which can cause photosensitive
-							seizures</span></li>
-<li><span data-localization-id="hazards-motion"
-							data-localization-mode="descriptive">The
-							publication contains motion simulations
-							that can cause motion sickness</span></li>
-					<li><span data-localization-id="hazards-sound"
-							data-localization-mode="descriptive">The
-							publication contains sounds which
-							can be uncomfortable</span></li>
-					<li><span data-localization-id="hazards-unknown"
-							data-localization-mode="descriptive">The presents
-							of hazards is unknown</span></li>
-					<li><span data-localization-id="hazards-no-metadata]."
-							data-localization-mode="descriptive">No information is available</span></li>
-
-				</ul>
-
-				<p id="hazards-compact" class="list-hd">Compact statements</p>
-				<ul aria-labelledby="hazards-compact">
-					<li>
-						<span data-localization-id="hazards-none"
-							data-localization-mode="compact">No
-							hazards</span>
-					</li>
-					<li><span
-							data-localization-id="hazards-flashing"
-							data-localization-mode="compact">Flashing
-							content</span></li>
-					<li><span data-localization-id="hazards-motion"
-							data-localization-mode="compact">Motion
-							simulation</span></li>
-<li><span data-localization-id="hazards-sound"
-							data-localization-mode="compact">sounds</span></li>
-<li><span
-							data-localization-id="hazards-unknown"
-							data-localization-mode="compact">The presence of hazards is unknown</span></li>
-					<li><span
-							data-localization-id="hazards-no-metadata"
-							data-localization-mode="compact">No information is available</span></li>
-				</ul>
+				<dl>
+					<dt>If there are no hazards:</dt>
+					<dd>
+						<p data-localization-id="hazards-none"
+								data-localization-mode="descriptive">No hazards</p>
+						<p data-localization-id="hazards-none"
+								data-localization-mode="compact">No hazards</p>
+					</dd>
+					
+					<dt>If there is a flashing hazard:</dt>
+					<dd>
+						<p data-localization-id="hazards-flashing"
+								data-localization-mode="descriptive">The
+								publication contains flashing content
+								which can cause photosensitive
+								seizures</p>
+						<p data-localization-id="hazards-flashing"
+								data-localization-mode="compact">Flashing
+								content</p>
+					</dd>
+					
+					<dt>If there is a motion simulation hazard:</dt>
+					<dd>
+						<p data-localization-id="hazards-motion"
+								data-localization-mode="descriptive">The
+								publication contains motion simulations
+								that can cause motion sickness</p>
+						<p data-localization-id="hazards-motion"
+								data-localization-mode="compact">Motion
+								simulation</p>
+					</dd>
+					
+					<dt>If there is a sound hazard:</dt>
+					<dd>
+						<p data-localization-id="hazards-sound"
+								data-localization-mode="descriptive">The
+								publication contains sounds which
+								can be uncomfortable</p>
+						<p data-localization-id="hazards-sound"
+								data-localization-mode="compact">sounds</p>
+					</dd>
+					
+					<dt>If hazards are not known:</dt>
+					<dd>
+						<p data-localization-id="hazards-unknown"
+								data-localization-mode="descriptive">The presents
+								of hazards is unknown</p>
+						<p data-localization-id="hazards-unknown"
+								data-localization-mode="compact">The presence of hazards is unknown</p>
+					</dd>
+					
+					<dt>If no metadata is provided:</dt>
+					<dd>
+						<p data-localization-id="hazards-no-metadata]."
+								data-localization-mode="descriptive">No information is available</p>
+						<p data-localization-id="hazards-no-metadata"
+								data-localization-mode="compact">No information is available</p>
+					</dd>
+				</dl>
 			</section>
 
 			<section id="hazards-examples">
@@ -1535,7 +1539,6 @@
 				</ul>
 			</section>
 		</section>
-
 		<section id="accessibility-summary">
 			<h3 data-localization-id="accessibility-summary-title">
 				Accessibility summary</h3>
@@ -1602,7 +1605,6 @@
 				</ul>
 			</section>
 		</section>
-
 		<section id="legal-considerations">
 			<h3 data-localization-id="legal-considerations-title">Legal
 				considerations</h3>
@@ -1669,24 +1671,25 @@
 					
 				</div>
 				
-				<p id="legal-desc" class="list-hd">Descriptive statements</p>
-				<ul aria-labelledby="legal-desc">
-					<li data-localization-id="legal-considerations-exempt"
-						data-localization-mode="descriptive">This
-						publication claims an accessibility exemption in
-						some jurisdictions</li>
+				<dl>
+					<dt>If the publication claims an exemption:</dt>
+					<dd>
+						<p data-localization-id="legal-considerations-exempt"
+							data-localization-mode="descriptive">This
+							publication claims an accessibility exemption in
+							some jurisdictions</p>
+						<p data-localization-id="legal-considerations-exempt"
+							data-localization-mode="compact">Claims an accessibility exemption in some jurisdictions</p>
+					</dd>
 					
-					<li data-localization-id="legal-considerations-no-metadata"
-						data-localization-mode="descriptive">No information is available</li>
-				</ul>	
-				
-				<p id="legal-compact" class="list-hd">Compact statements</p>
-				<ul>
-					<li data-localization-id="legal-considerations-exempt"
-						data-localization-mode="compact">Claims an accessibility exemption in some jurisdictions</li>
-					<li data-localization-id="legal-considerations-no-metadata"
-						data-localization-mode="compact">No information is available</li>
-				</ul>
+					<dt>If no metadata is provided:</dt>
+					<dd>
+						<p data-localization-id="legal-considerations-no-metadata"
+							data-localization-mode="descriptive">No information is available</p>
+						<p data-localization-id="legal-considerations-no-metadata"
+							data-localization-mode="compact">No information is available</p>
+					</dd>
+				</dl>	
 			</section>
 
 			<section id="legal-examples">
@@ -1711,7 +1714,6 @@
 			</section>
 
 		</section>
-
 		<section id="additional-accessibility-information">
 			<h3 data-localization-id="additional-accessibility-information-title">Additional accessibility
 				information</h3>
@@ -1794,33 +1796,40 @@
 				<p>The descriptive and compact statements for additional information are as follows.</p>
 				
 				<div class="note">There are many features that may be
-					present. Some of the features are listed in
-					the examples. A complete list can be found in the
-					techniques.</div>
+					present. Only some of the features are listed here.
+					A complete list can be found in the techniques.</div>
 
-				<p id="add-info-desc" class="list-hd">Descriptive statements</p>
-				<ul aria-labelledby="add-info-desc">
-					<li>Content is enhanced with ARIA roles to
-						optimize organization and facilitate
-						navigation</li>
-					<li>Page breaks included from the original print
-						source</li>
-					<li>Tactile graphics have been integrated to
-						facilitate access to visual elements for
-						blind
-						people</li>
-					<li>No information is available</li>
-				</ul>
-
-
-				<p id="add-info-compact" class="list-hd">Compact explanations</p>
-				<ul aria-labelledby="add-info-compact">
-					<li>ARIA roles included</li>
-					<li>Visible page numbering</li>
-					<li>Tactile graphics included</li>
-					<li>No information is available</li>
-				</ul>
-
+				<dl>
+					<dt>If there are ARIA roles:</dt>
+					<dd>
+						<p data-localization-mode="descriptive">Content is enhanced with ARIA roles to
+							optimize organization and facilitate
+							navigation</p>
+						<p data-localization-mode="compact">ARIA roles included</p>
+					</dd>
+					
+					<dt>If there are page break markers:</dt>
+					<dd>
+						<p data-localization-mode="descriptive">Page breaks included from the original print
+							source</p>
+						<p data-localization-mode="compact">Visible page numbering</p>
+					</dd>
+					
+					<dt>If there are tactile graphics:</dt>
+					<dd>
+						<p data-localization-mode="descriptive">Tactile graphics have been integrated to
+							facilitate access to visual elements for
+							blind
+							people</p>
+						<p data-localization-mode="compact">Tactile graphics included</p>
+					</dd>
+					
+					<dt>If no metadata is provided:</dt>
+					<dd>
+						<p data-localization-mode="descriptive">No information is available</p>
+						<p data-localization-mode="compact">No information is available</p>
+					</dd>
+				</dl>
 			</section>
 
 			<section id="add-info-examples">

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1,9 +1,5 @@
-		<!DOCTYPE html>
-
-
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US"
-	xml:lang="en-US">
-
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 <head>
 	<meta charset="utf-8" />
 	<title>Accessibility Metadata Display Guide for Digital Publications
@@ -123,6 +119,9 @@
 			bottom: 2px;
 			border: none;
 			display: inline-block;
+		}
+		p.list-hd {
+			font-weight: bold;
 		}
 	</style>
 </head>
@@ -595,59 +594,58 @@
 				other readability issues (e.g., text being
 				clipped by its container).</p>
 
-			<section id="va-examples">
-				<h5>Examples</h5>
+			<section id="va-statements">
+				<h5>Statements</h5>
 
-				<p>The examples are provided as lists of possible
-					descriptive and compact explanations for
-					flexibility of adoption.</p>
+				<p>The descriptive and compact statements for visual adjustment are as follows.</p>
+				
+				<p id="va-desc" class="list-hd">Descriptive statements</p>
 
-				<aside class="example" title="Descriptive explanations">
-				<h5 data-localization-id="ways-of-reading-title">Ways of reading</h5>
-					<ul>
-						<li data-localization-id="ways-of-reading-visual-adjustments-modifiable"
-							data-localization-mode="descriptive">
-							Appearance of the text and page layout can
-							be
-							modified according to the capabilities of
-							the reading system (font family and font
-							size,
-							spaces between paragraphs, sentences, words,
-							and letters, as well as color of background
-							and text)</li>
-						<li data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
-							data-localization-mode="descriptive">Text
-							and page layout cannot be modified as the
-							reading experience is close to a print
-							version, but reading systems can still
-							provide zooming options</li>
-						<li data-localization-id="ways-of-reading-visual-adjustments-unknown"
-							data-localization-mode="descriptive">
-							No information about appearance modifiability is available</li>
-					</ul>
-				</aside>
+				<ul>
+					<li data-localization-id="ways-of-reading-visual-adjustments-modifiable"
+						data-localization-mode="descriptive">
+						Appearance of the text and page layout can
+						be
+						modified according to the capabilities of
+						the reading system (font family and font
+						size,
+						spaces between paragraphs, sentences, words,
+						and letters, as well as color of background
+						and text)</li>
+					<li data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
+						data-localization-mode="descriptive">Text
+						and page layout cannot be modified as the
+						reading experience is close to a print
+						version, but reading systems can still
+						provide zooming options</li>
+					<li data-localization-id="ways-of-reading-visual-adjustments-unknown"
+						data-localization-mode="descriptive">
+						No information about appearance modifiability is available</li>
+				</ul>
 
-				<aside class="example" title="Compact explanations">
-				<h5 data-localization-id="ways-of-reading-title">Ways of reading</h5>
-					<ul>
-						<li data-localization-id="ways-of-reading-visual-adjustments-modifiable"
-							data-localization-mode="compact">Appearance
-							can be modified</li>
-						<!--if Display transformability is present-->
-						<li data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
-							data-localization-mode="compact">Appearance
-							cannot be modified</li>
-						<!--if display transformability is not present and text on visual is present-->
-						<li data-localization-id="ways-of-reading-visual-adjustments-unknown"
-							data-localization-mode="compact">No information about appearance modifiability is available</li>
-						<!--if neither display transformability nor text on visual are presents-->
-					</ul>
-				</aside>
+				<p id="va-compact" class="list-hd">Compact statements</p>
+				<ul aria-labelledby="va-compact">
+					<li data-localization-id="ways-of-reading-visual-adjustments-modifiable"
+						data-localization-mode="compact">Appearance
+						can be modified</li>
+					<!--if Display transformability is present-->
+					<li data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
+						data-localization-mode="compact">Appearance
+						cannot be modified</li>
+					<!--if display transformability is not present and text on visual is present-->
+					<li data-localization-id="ways-of-reading-visual-adjustments-unknown"
+						data-localization-mode="compact">No information about appearance modifiability is available</li>
+					<!--if neither display transformability nor text on visual are presents-->
+				</ul>
 			</section>
 
+			<section id="va-examples">
+				<h5>Examples</h5>
+			
+			</section>
+			
 			<section id="va-techniques">
-				<h5>Display techniques for Visual adjustments support
-				</h5>
+				<h5>Display techniques for Visual adjustments support</h5>
 
 				<p>Specific techniques for meeting this principle are
 					defined in the following documents:</p>
@@ -697,53 +695,52 @@
 				transcripts, captions, etc. depending on the nature of
 				the nonvisual content.</p>
 
-			<section id="nv-examples">
-				<h5>Examples</h5>
+			<section id="nv-statements">
+				<h5>Statements</h5>
 
-				<p>The examples are provided as lists of possible
-					descriptive and compact explanations for
-					flexibility of adoption.</p>
+				<p>The descriptive and compact statements for nonvisual reading are as follows.</p>
+				
+				<p id="nv-desc-expl" class="list-hd">Descriptive explanations</p>
+				<ul aria-labelledby="nv-desc-expl">
+					<li data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
+						data-localization-mode="descriptive">Has alternative text descriptions for images</li>
+					<li data-localization-id="ways-of-reading-nonvisual-reading-readable"
+						data-localization-mode="descriptive">All
+						content can be read as read aloud speech or
+						dynamic braille</li>
+					<li data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
+						data-localization-mode="descriptive">
+						Portions of the content may not be readable
+						as read aloud speech or dynamic braille</li>
+					<li data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
+						data-localization-mode="descriptive">Not all
+						of the content will be readable as read
+						aloud speech or dynamic braille</li>
+				</ul>
 
-				<aside class="example" title="Descriptive explanations">
-				<h5 data-localization-id="ways-of-reading-title">Ways of reading</h5>
-					<ul>
-						<li data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
-							data-localization-mode="descriptive">Has alternative text descriptions for images</li>
-						<li data-localization-id="ways-of-reading-nonvisual-reading-readable"
-							data-localization-mode="descriptive">All
-							content can be read as read aloud speech or
-							dynamic braille</li>
-						<li data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
-							data-localization-mode="descriptive">
-							Portions of the content may not be readable
-							as read aloud speech or dynamic braille</li>
-						<li data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
-							data-localization-mode="descriptive">Not all
-							of the content will be readable as read
-							aloud speech or dynamic braille</li>
-</ul>
-				</aside>
-
-				<aside class="example" title="Compact explanations">
-				<h5 data-localization-id="ways-of-reading-title">Ways of reading</h5>
-					<ul>
-						<li data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
-							data-localization-mode="compact">Has alternative text</li>
-						<li data-localization-id="ways-of-reading-nonvisual-reading-readable"
-							data-localization-mode="compact">Readable in
-							read aloud or dynamic braille</li>
-						<li data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
-							data-localization-mode="compact">May not be
-							fully readable in read aloud or dynamic
-							braille</li>
-						<li data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
-							data-localization-mode="compact">Not
-							fully readable in read aloud or dynamic
-							braille</li>
-</ul>
-				</aside>
+				<p id="nv-compact-expl" class="list-hd">Compact explanations</p>
+				<ul aria-labelledby="nv-compact-expl">
+					<li data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
+						data-localization-mode="compact">Has alternative text</li>
+					<li data-localization-id="ways-of-reading-nonvisual-reading-readable"
+						data-localization-mode="compact">Readable in
+						read aloud or dynamic braille</li>
+					<li data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
+						data-localization-mode="compact">May not be
+						fully readable in read aloud or dynamic
+						braille</li>
+					<li data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
+						data-localization-mode="compact">Not
+						fully readable in read aloud or dynamic
+						braille</li>
+				</ul>
 			</section>
 
+			<section id="nv-examples">
+				<h5>Examples</h5>
+				
+			</section>
+			
 			<section id="nv-techniques">
 				<h5>Display techniques for support for nonvisual reading support
 				</h5>
@@ -791,45 +788,45 @@
 				impairments still can access the full content of these
 				books.</p>
 
-			<section id="prerecorded-audio-examples">
-				<h5>Examples</h5>
+			<section id="prerecorded-audio-statements">
+				<h5>Statements</h5>
+				
+				<p>The descriptive and compact statements for prerecorded audio are as follows.</p>
+				
+				<p id="prerecorded-desc" class="list-hd">Descriptive statements</p>
 
-				<p>The examples are provided as lists of possible
-					descriptive and compact explanations for
-					flexibility of adoption.</p>
+				<ul aria-labelledby="prerecorded-desc">
+					<li data-localization-id="ways-of-reading-prerecorded-audio-only"
+						data-localization-mode="descriptive">
+						Audiobook with no text alternative</li>
 
-				<aside class="example" title="Descriptive explanations">
-				<h5 data-localization-id="ways-of-reading-title">Ways of reading</h5>
-					<ul>
-						<li data-localization-id="ways-of-reading-prerecorded-audio-only"
-							data-localization-mode="descriptive">
-							Audiobook with no text alternative</li>
-
-						<li data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
-							data-localization-mode="descriptive">All the
-							content is available as prerecorded audio
-							synchronized with text</li>
-							<li data-localization-id="ways-of-reading-prerecorded-audio-complementary" data-localization-mode="descriptive">Portions of prerecorded audio are available</li>
+					<li data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
+						data-localization-mode="descriptive">All the
+						content is available as prerecorded audio
+						synchronized with text</li>
+						<li data-localization-id="ways-of-reading-prerecorded-audio-complementary" data-localization-mode="descriptive">Portions of prerecorded audio are available</li>
 <li data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
-							data-localization-mode="descriptive">
-							No information about prerecorded audio is available</li>
-					</ul>
-				</aside>
+						data-localization-mode="descriptive">
+						No information about prerecorded audio is available</li>
+				</ul>
 
-				<aside class="example" title="Compact explanations">
-				<h5 data-localization-id="ways-of-reading-title">Ways of reading</h5>
-					<ul>
-						<li data-localization-id="ways-of-reading-prerecorded-audio-only"
-							data-localization-mode="compact">Audio only</li>
-						<li data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
-							data-localization-mode="compact">Prerecorded audio synchronized with text</li>
+				<p id="prerecorded-compact" class="list-hd">Compact statements</p>
+				<ul aria-labelledby="prerecorded-compact">
+					<li data-localization-id="ways-of-reading-prerecorded-audio-only"
+						data-localization-mode="compact">Audio only</li>
+					<li data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
+						data-localization-mode="compact">Prerecorded audio synchronized with text</li>
 <li data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
-							data-localization-mode="compact">
-							No information about prerecorded audio is available</li>
-					</ul>
-				</aside>
+						data-localization-mode="compact">
+						No information about prerecorded audio is available</li>
+				</ul>
 			</section>
 
+			<section id="prerecorded-audio-examples">
+				<h5>Examples</h5>
+				
+			</section>
+			
 			<section id="prerecorded-audio-techniques">
 				<h5>Display techniques for prerecorded audio support
 				</h5>
@@ -881,6 +878,7 @@
 
 			<section id="conf-statements">
 				<h4>Conformance statements</h4>
+				
 				<p>The following list explains the meaning of each
 					recommended conformance statement.</p>
 				<dl>
@@ -973,9 +971,14 @@
 				</dl>
 			</section>
 
+			<section id="conformance-statements">
+				<h4>Statements</h4>
+				
+			</section>
+				
 			<section id="conf-examples">
 				<h4>Examples</h4>
-
+				
 				<p>Four examples are provided for the conformance
 					statement, one shows a statement that claims to
 					meet recommended accessibility standards and a
@@ -1200,58 +1203,57 @@
 <div class="note"><p>While not required if available, it may be helpful to identify the bibliographic information about the page break source identified in metadata of the digital publication. Having sufficient information to identify the print source would assure students and educators that the digital version they are using is correctly associated with the print version used in the classroom. The goal is to have the go to page function take the digital user to the same page as the print version user.
 </p></div>
 
-			<section id="nav-examples">
-				<h4>Examples</h4>
+			<section id="nav-statements">
+				<h4>Statements</h4>
+				
+				<p>The descriptive and compact statements for navigation are as follows.</p>
+				
+				<p id="nav-desc" class="list-hd">Descriptive statements</p>
+				<ul aria-labelledby="nav-desc">
+					<li data-localization-id="navigation-toc"
+						data-localization-mode="descriptive">Table
+						of contents to all chapters of the text via
+						links</li>
+					<li data-localization-id="navigation-index"
+						data-localization-mode="descriptive">Index
+						with links to referenced entries</li>
+					<li data-localization-id="navigation-structural"
+						data-localization-mode="descriptive">Elements such as headings, tables, etc for
+						structured navigation</li>
+					<li data-localization-id="navigation-page-navigation"
+						data-localization-mode="descriptive">Page list to go to pages from the print
+						source
+						version</li>
+					<li data-localization-id="navigation-no-metadata"
+						data-localization-mode="descriptive">No information is available</li>
+				</ul>
 
-				<p>The examples are provided as descriptive and compact
-					explanations for flexibility of
-					adoption.</p>
-
-				<aside class="example" title="Descriptive explanations">
-<h4 data-localization-id="navigation-title">Navigation</h4>
-					<ul>
-						<li data-localization-id="navigation-toc"
-							data-localization-mode="descriptive">Table
-							of contents to all chapters of the text via
-							links</li>
-						<li data-localization-id="navigation-index"
-							data-localization-mode="descriptive">Index
-							with links to referenced entries</li>
-						<li data-localization-id="navigation-structural"
-							data-localization-mode="descriptive">Elements such as headings, tables, etc for
-							structured navigation</li>
-						<li data-localization-id="navigation-page-navigation"
-							data-localization-mode="descriptive">Page list to go to pages from the print
-							source
-							version</li>
-						<li data-localization-id="navigation-no-metadata"
-							data-localization-mode="descriptive">No information is available</li>
-					</ul>
-				</aside>
-
-				<aside class="example" title="Compact explanation">
-<h4 data-localization-id="navigation-title">Navigation</h4>
-					<ul>
-						<li><span data-localization-id="navigation-toc"
-								data-localization-mode="compact">Table
-								of contents</span></li>
-						<li><span
-								data-localization-id="navigation-index"
-								data-localization-mode="compact">Index</span>
-						</li>
-						<li><span
-								data-localization-id="navigation-structural"
-								data-localization-mode="compact">Headings</span>
-						</li>
-						<li><span
-								data-localization-id="navigation-page-navigation"
-								data-localization-mode="compact">Go to page </span></li>
-						<li data-localization-id="navigation-no-metadata"
-							data-localization-mode="compact">No information is available</li>
-					</ul>
-				</aside>
+				<p id="nav-compact" class="list-hd">Compact statements</p>
+				<ul aria-labelledby="nav-compact">
+					<li><span data-localization-id="navigation-toc"
+							data-localization-mode="compact">Table
+							of contents</span></li>
+					<li><span
+							data-localization-id="navigation-index"
+							data-localization-mode="compact">Index</span>
+					</li>
+					<li><span
+							data-localization-id="navigation-structural"
+							data-localization-mode="compact">Headings</span>
+					</li>
+					<li><span
+							data-localization-id="navigation-page-navigation"
+							data-localization-mode="compact">Go to page </span></li>
+					<li data-localization-id="navigation-no-metadata"
+						data-localization-mode="compact">No information is available</li>
+				</ul>
 			</section>
 
+			<section id="nav-examples">
+				<h5>Examples</h5>
+				
+			</section>
+			
 			<section id="nav-techniques">
 				<h4>Display techniques for navigation support</h4>
 
@@ -1286,37 +1288,32 @@
 			<p>This group should be displayed only if the metadata
 				indicates the presence of math, chemical formulas, charts, diagrams, figures, graphs, videos, or transcripts of audio within the title, otherwise it can be hidden.</p>
 
-			<section id="cdf-examples">
-				<h4>Examples</h4>
-
-				<p>The examples are provided as lists of possible
-					descriptive and compact explanations for
-					flexibility of adoption.</p>
-
-				<aside class="example" title="Descriptive explanations">
-			<h4 data-localization-id="rich-content-title">Rich content</h4>
-					<ul>
-<li><span data-localization-id="rich-content-accessible-math-as-mathml"
-								data-localization-mode="descriptive">Math formulas in accessible format (MathML)</span>
-						</li>
-<li><span data-localization-id="rich-content-accessible-math-as-latex"
-								data-localization-mode="descriptive">Math formulas in accessible format (LaTeX)</span>
-						</li>
-						<li><span
-								data-localization-id="rich-content-accessible-math-described"
-								data-localization-mode="descriptive">text descriptions of math is provided </span>
-						</li>
+			<section id="rc-statements">
+				<h4>Statements</h4>
+				
+				<p>The descriptive and compact statements for rich content are as follows.</p>
+				
+				<p id="rc-desc" class="list-hd">Descriptive statements</p>
+				<ul aria-labelledby="rc-desc">
+					<li><span data-localization-id="rich-content-accessible-math-as-mathml"
+										data-localization-mode="descriptive">Math formulas in accessible format (MathML)</span></li>
+					<li><span data-localization-id="rich-content-accessible-math-as-latex"
+										data-localization-mode="descriptive">Math formulas in accessible format (LaTeX)</span></li>
+					<li><span
+							data-localization-id="rich-content-accessible-math-described"
+							data-localization-mode="descriptive">text descriptions of math is provided </span>
+					</li>
 <li><span data-localization-id="rich-content-accessible-chemistry-as-mathml"
-								data-localization-mode="descriptive">Chemical formulas in accessible format (MathML)</span>
-						</li>
+							data-localization-mode="descriptive">Chemical formulas in accessible format (MathML)</span>
+					</li>
 <li><span data-localization-id="rich-content-accessible-chemistry-as-latex"
-								data-localization-mode="descriptive">Chemical formulas in accessible format (LaTeX)</span>
-						</li>
-						<li>
-							<span
-								data-localization-id="rich-content-extended"
-								data-localization-mode="descriptive">Information-rich images are described by extended descriptions</span>
-						</li>
+							data-localization-mode="descriptive">Chemical formulas in accessible format (LaTeX)</span>
+					</li>
+					<li>
+						<span
+							data-localization-id="rich-content-extended"
+							data-localization-mode="descriptive">Information-rich images are described by extended descriptions</span>
+					</li>
 <li><span data-localization-id="rich-content-closed-captions" data-localization-mode="descriptive">
 Videos included in publications have closed captions</span></li>
 
@@ -1325,46 +1322,48 @@ Videos included in publications have open captions</span></li>
 <li><span data-localization-id="rich-content-transcript" data-localization-mode="descriptive">
 Transcript(s) provided)</span></li>
 <li><span data-localization-id="rich-content-unknown" data-localization-mode="descriptive">No information is available</span></li>
-					</ul>
-				</aside>
+				</ul>
 
-				<aside class="example" title="Compact explanations">
-<h4 data-localization-id="rich-content-title">Rich content</h4>
-					<ul>
-						<li>
+				<p id="rc-compact" class="list-hd">Compact statements</p>
+				<ul aria-labelledby="rc-compact">
+					<li>
 <span  data-localization-id="rich-content-accessible-math-as-mathml"
-								data-localization-mode="compact">Math as MathML</span></li>
+							data-localization-mode="compact">Math as MathML</span></li>
 <li>
 <span data-localization-id="rich-content-accessible-math-as-latex"
-								data-localization-mode="compact">Math as LaTeX</span></li>
+							data-localization-mode="compact">Math as LaTeX</span></li>
 <li>
 <span data-localization-id="rich-content-accessible-math-described"
-								data-localization-mode="compact">text descriptions of math is provided </span></li>
+							data-localization-mode="compact">text descriptions of math is provided </span></li>
 <li><span data-localization-id="rich-content-accessible-chemistry-as-mathml"
-								data-localization-mode="compact">Chemical formulas in MathML</span>
-						</li>
+							data-localization-mode="compact">Chemical formulas in MathML</span>
+					</li>
 <li><span data-localization-id="rich-content-accessible-chemistry-as-latex"
-								data-localization-mode="compact">Chemical formulas in LaTeX</span>
-						</li>
+							data-localization-mode="compact">Chemical formulas in LaTeX</span>
+					</li>
 
 <li>
-							<span
-								data-localization-id="rich-content-extended"
-								data-localization-mode="compact">Information-rich images are described by extended descriptions</span>
+						<span
+							data-localization-id="rich-content-extended"
+							data-localization-mode="compact">Information-rich images are described by extended descriptions</span>
 </li>
 <li><span data-localization-id="rich-content-closed-captions" data-localization-mode="compact">
 Videos have closed captions </span></li>
-						<li>
+					<li>
 <span data-localization-id="rich-content-open-captions" data-localization-mode="compact">
 Videos have open captions</span></li>
 <li><span data-localization-id="rich-content-transcript" data-localization-mode="compact">
 Transcript(s) provided)</span></li>
 <li><span data-localization-id="rich-content-unknown" data-localization-mode="compact">No information is available</span></li>
-					</ul>
-				</aside>
+				</ul>
 			</section>
 
-			<section id="cdf-techniques">
+			<section id="rc-examples">
+				<h5>Examples</h5>
+				
+			</section>
+			
+			<section id="rc-techniques">
 				<h4>Display techniques for rich content support</h4>
 
 
@@ -1419,69 +1418,68 @@ Transcript(s) provided)</span></li>
 				not been checked for hazards. This is
 				different than providing no metadata for this property.</p>
 
-			<section id="hazards-examples">
-				<h4>Examples</h4>
-
-				<p>The examples are provided as lists of possible
-					descriptive and compact explanations for
-					flexibility of adoption.</p>
-
-				<aside class="example" title="Descriptive explanations">
-							<h4 data-localization-id="hazards-title">Hazards</h4>
-					<ul>
-						<li><span data-localization-id="hazards-none"
-								data-localization-mode="descriptive">No
-								hazards</span></li>
-						<li><span
-								data-localization-id="hazards-flashing"
-								data-localization-mode="descriptive">The
-								publication contains flashing content
-								which can cause photosensitive
-								seizures</span></li>
+			<section id="hazards-statements">
+				<h4>Statements</h4>
+				
+				<p>The descriptive and compact statements for hazards are as follows.</p>
+				
+				<p id="hazards-desc" class="list-hd">Descriptive statements</p>
+				<ul aria-labelledby="hazards-desc">
+					<li><span data-localization-id="hazards-none"
+							data-localization-mode="descriptive">No
+							hazards</span></li>
+					<li><span
+							data-localization-id="hazards-flashing"
+							data-localization-mode="descriptive">The
+							publication contains flashing content
+							which can cause photosensitive
+							seizures</span></li>
 <li><span data-localization-id="hazards-motion"
-								data-localization-mode="descriptive">The
-								publication contains motion simulations
-								that can cause motion sickness</span></li>
-						<li><span data-localization-id="hazards-sound"
-								data-localization-mode="descriptive">The
-								publication contains sounds which
-								can be uncomfortable</span></li>
-						<li><span data-localization-id="hazards-unknown"
-								data-localization-mode="descriptive">The presents
-								of hazards is unknown</span></li>
-						<li><span data-localization-id="hazards-no-metadata]."
-								data-localization-mode="descriptive">No information is available</span></li>
+							data-localization-mode="descriptive">The
+							publication contains motion simulations
+							that can cause motion sickness</span></li>
+					<li><span data-localization-id="hazards-sound"
+							data-localization-mode="descriptive">The
+							publication contains sounds which
+							can be uncomfortable</span></li>
+					<li><span data-localization-id="hazards-unknown"
+							data-localization-mode="descriptive">The presents
+							of hazards is unknown</span></li>
+					<li><span data-localization-id="hazards-no-metadata]."
+							data-localization-mode="descriptive">No information is available</span></li>
 
-					</ul>
-				</aside>
+				</ul>
 
-				<aside class="example" title="Compact explanations">
-				<h4 data-localization-id="hazards-title">Hazards</h4>
-					<ul>
-						<li>
-							<span data-localization-id="hazards-none"
-								data-localization-mode="compact">No
-								hazards</span>
-						</li>
-						<li><span
-								data-localization-id="hazards-flashing"
-								data-localization-mode="compact">Flashing
-								content</span></li>
-						<li><span data-localization-id="hazards-motion"
-								data-localization-mode="compact">Motion
-								simulation</span></li>
+				<p id="hazards-compact" class="list-hd">Compact statements</p>
+				<ul aria-labelledby="hazards-compact">
+					<li>
+						<span data-localization-id="hazards-none"
+							data-localization-mode="compact">No
+							hazards</span>
+					</li>
+					<li><span
+							data-localization-id="hazards-flashing"
+							data-localization-mode="compact">Flashing
+							content</span></li>
+					<li><span data-localization-id="hazards-motion"
+							data-localization-mode="compact">Motion
+							simulation</span></li>
 <li><span data-localization-id="hazards-sound"
-								data-localization-mode="compact">sounds</span></li>
+							data-localization-mode="compact">sounds</span></li>
 <li><span
-								data-localization-id="hazards-unknown"
-								data-localization-mode="compact">The presence of hazards is unknown</span></li>
-						<li><span
-								data-localization-id="hazards-no-metadata"
-								data-localization-mode="compact">No information is available</span></li>
-					</ul>
-				</aside>
+							data-localization-id="hazards-unknown"
+							data-localization-mode="compact">The presence of hazards is unknown</span></li>
+					<li><span
+							data-localization-id="hazards-no-metadata"
+							data-localization-mode="compact">No information is available</span></li>
+				</ul>
 			</section>
 
+			<section id="hazards-examples">
+				<h5>Examples</h5>
+				
+			</section>
+			
 			<section id="hazards-techniques">
 				<h4>Display techniques for hazards reporting</h4>
 
@@ -1619,33 +1617,45 @@ Transcript(s) provided)</span></li>
 				misunderstandings. Nevertheless, the objective
 				is to provide as much accessibility information as possible.</p>
 
-			<section id="legal-examples">
-				<h4>Examples</h4>
-				<aside class="example" title="Descriptive explanation">
+			<section id="legal-statements">
+				<h5>Statements</h5>
+				
+				<p>The descriptive and compact statements for legal exemptions are as follows.</p>
+				
+				<div class="note">
 					<p> In many cases no legal exception or exemption
 						information will be presented. The following
 						example is provided as a possible descriptive
 						explanation when legal exception or exemption
 						information needs to be presented.</p>
-									<h4 data-localization-id="legal-considerations-title">Legal considerations</h4>
-					<p data-localization-id="legal-considerations-exempt"
+					
+				</div>
+				
+				<p id="legal-desc" class="list-hd">Descriptive statements</p>
+				<ul aria-labelledby="legal-desc">
+					<li data-localization-id="legal-considerations-exempt"
 						data-localization-mode="descriptive">This
 						publication claims an accessibility exemption in
-						some jurisdictions</p>
-
-					<p data-localization-id="legal-considerations-no-metadata"
-						data-localization-mode="descriptive">No information is available</p>
-				</aside>
-<aside class="example" title="Compact explanation">
-<p data-localization-id="legal-considerations-exempt"
-						data-localization-mode="compact">Claims an accessibility exemption in some jurisdictions</p>
-					<p data-localization-id="legal-considerations-no-metadata"
-						data-localization-mode="compact">No information is available</p>
-
-				</aside>
+						some jurisdictions</li>
+					
+					<li data-localization-id="legal-considerations-no-metadata"
+						data-localization-mode="descriptive">No information is available</li>
+				</ul>	
+				
+				<p id="legal-compact" class="list-hd">Compact statements</p>
+				<ul>
+					<li data-localization-id="legal-considerations-exempt"
+						data-localization-mode="compact">Claims an accessibility exemption in some jurisdictions</li>
+					<li data-localization-id="legal-considerations-no-metadata"
+						data-localization-mode="compact">No information is available</li>
+				</ul>
 			</section>
 
-
+			<section id="legal-examples">
+				<h5>Examples</h5>
+				
+			</section>
+			
 			<section id="legal-techniques">
 				<h4> Display techniques for legal considerations</h4>
 				<p>Specific techniques for meeting this principle are
@@ -1740,45 +1750,46 @@ Transcript(s) provided)</span></li>
 				</dd>
 			</dl>
 
-			<section id="add-info-examples">
-				<h4>Examples</h4>
+			<section id="add-info-statements">
+				<h4>Statements</h4>
 
+				<p>The descriptive and compact statements for additional information are as follows.</p>
+				
 				<div class="note">There are many features that may be
 					present. Some of the features are listed in
 					the examples. A complete list can be found in the
-					techniques. </div>
+					techniques.</div>
 
-				<aside class="example" title="Descriptive explanations">
-<h4 data-localization-id="additional-accessibility-information-title">Additional accessibility
-				information</h4>
-					<ul>
-						<li>Content is enhanced with ARIA roles to
-							optimize organization and facilitate
-							navigation</li>
-						<li>Page breaks included from the original print
-							source</li>
-						<li>Tactile graphics have been integrated to
-							facilitate access to visual elements for
-							blind
-							people</li>
-<li>No information is available</li>
-</ul>
+				<p id="add-info-desc" class="list-hd">Descriptive statements</p>
+				<ul aria-labelledby="add-info-desc">
+					<li>Content is enhanced with ARIA roles to
+						optimize organization and facilitate
+						navigation</li>
+					<li>Page breaks included from the original print
+						source</li>
+					<li>Tactile graphics have been integrated to
+						facilitate access to visual elements for
+						blind
+						people</li>
+					<li>No information is available</li>
+				</ul>
 
-				</aside>
 
-				<aside class="example" title="Compact explanations">
-<h4 data-localization-id="additional-accessibility-information-title">Additional accessibility
-				information</h4>
-					<ul>
-						<li>ARIA roles included</li>
-						<li>Visible page numbering</li>
-						<li>Tactile graphics included</li>
-<li>No information is available</li>
-</ul>
+				<p id="add-info-compact" class="list-hd">Compact explanations</p>
+				<ul aria-labelledby="add-info-compact">
+					<li>ARIA roles included</li>
+					<li>Visible page numbering</li>
+					<li>Tactile graphics included</li>
+					<li>No information is available</li>
+				</ul>
 
-				</aside>
 			</section>
 
+			<section id="add-info-examples">
+				<h5>Examples</h5>
+				
+			</section>
+			
 			<section id="add-info-techniques">
 				<h4>Display techniques for additional accessibility
 					information</h4>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -120,6 +120,9 @@
 			border: none;
 			display: inline-block;
 		}
+		dt {
+			margin-bottom: 1rem;
+		}
 		p[data-localization-mode="descriptive"]:before {
 			content: 'Descriptive: ';
 			font-style: italic;
@@ -1218,45 +1221,54 @@
 				
 				<p>The descriptive and compact statements for navigation are as follows.</p>
 				
-				<p id="nav-desc" class="list-hd">Descriptive statements</p>
-				<ul aria-labelledby="nav-desc">
-					<li data-localization-id="navigation-toc"
-						data-localization-mode="descriptive">Table
-						of contents to all chapters of the text via
-						links</li>
-					<li data-localization-id="navigation-index"
-						data-localization-mode="descriptive">Index
-						with links to referenced entries</li>
-					<li data-localization-id="navigation-structural"
-						data-localization-mode="descriptive">Elements such as headings, tables, etc for
-						structured navigation</li>
-					<li data-localization-id="navigation-page-navigation"
-						data-localization-mode="descriptive">Page list to go to pages from the print
-						source
-						version</li>
-					<li data-localization-id="navigation-no-metadata"
-						data-localization-mode="descriptive">No information is available</li>
-				</ul>
-
-				<p id="nav-compact" class="list-hd">Compact statements</p>
-				<ul aria-labelledby="nav-compact">
-					<li><span data-localization-id="navigation-toc"
-							data-localization-mode="compact">Table
-							of contents</span></li>
-					<li><span
-							data-localization-id="navigation-index"
-							data-localization-mode="compact">Index</span>
-					</li>
-					<li><span
-							data-localization-id="navigation-structural"
-							data-localization-mode="compact">Headings</span>
-					</li>
-					<li><span
-							data-localization-id="navigation-page-navigation"
-							data-localization-mode="compact">Go to page </span></li>
-					<li data-localization-id="navigation-no-metadata"
-						data-localization-mode="compact">No information is available</li>
-				</ul>
+				<dl>
+					<dt>Table of contents provided</dt>
+					<dd>
+						<p data-localization-id="navigation-toc"
+							data-localization-mode="descriptive">Table
+							of contents to all chapters of the text via
+							links</p>
+						<p data-localization-id="navigation-toc"
+								data-localization-mode="compact">Table
+								of contents</p>
+					</dd>
+					
+					<dt>Index(es) provided</dt>
+					<dd>
+						<p data-localization-id="navigation-index"
+							data-localization-mode="descriptive">Index
+							with links to referenced entries</p>
+						<p data-localization-id="navigation-index"
+								data-localization-mode="compact">Index</p>
+					</dd>
+					
+					<dt>Structural navigation provided</dt>
+					<dd>
+						<p data-localization-id="navigation-structural"
+							data-localization-mode="descriptive">Elements such as headings, tables, etc for
+							structured navigation</p>
+						<p data-localization-id="navigation-structural"
+								data-localization-mode="compact">Headings</p>
+					</dd>
+					
+					<dt>Page navigation provided</dt>
+					<dd>
+						<p data-localization-id="navigation-page-navigation"
+							data-localization-mode="descriptive">Page list to go to pages from the print
+							source
+							version</p>
+						<p data-localization-id="navigation-page-navigation"
+								data-localization-mode="compact">Go to page</p>
+					</dd>
+					
+					<dt>No metadata provided</dt>
+					<dd>
+						<p data-localization-id="navigation-no-metadata"
+							data-localization-mode="descriptive">No information is available</p>
+						<p data-localization-id="navigation-no-metadata"
+							data-localization-mode="compact">No information is available</p>
+					</dd>
+				</dl>
 			</section>
 
 			<section id="nav-examples">
@@ -1303,69 +1315,85 @@
 				
 				<p>The descriptive and compact statements for rich content are as follows.</p>
 				
-				<p id="rc-desc" class="list-hd">Descriptive statements</p>
-				<ul aria-labelledby="rc-desc">
-					<li><span data-localization-id="rich-content-accessible-math-as-mathml"
-										data-localization-mode="descriptive">Math formulas in accessible format (MathML)</span></li>
-					<li><span data-localization-id="rich-content-accessible-math-as-latex"
-										data-localization-mode="descriptive">Math formulas in accessible format (LaTeX)</span></li>
-					<li><span
-							data-localization-id="rich-content-accessible-math-described"
-							data-localization-mode="descriptive">text descriptions of math is provided </span>
-					</li>
-<li><span data-localization-id="rich-content-accessible-chemistry-as-mathml"
-							data-localization-mode="descriptive">Chemical formulas in accessible format (MathML)</span>
-					</li>
-<li><span data-localization-id="rich-content-accessible-chemistry-as-latex"
-							data-localization-mode="descriptive">Chemical formulas in accessible format (LaTeX)</span>
-					</li>
-					<li>
-						<span
-							data-localization-id="rich-content-extended"
-							data-localization-mode="descriptive">Information-rich images are described by extended descriptions</span>
-					</li>
-<li><span data-localization-id="rich-content-closed-captions" data-localization-mode="descriptive">
-Videos included in publications have closed captions</span></li>
-
-<li><span data-localization-id="rich-content-open-captions" data-localization-mode="descriptive">
-Videos included in publications have open captions</span></li>
-<li><span data-localization-id="rich-content-transcript" data-localization-mode="descriptive">
-Transcript(s) provided)</span></li>
-<li><span data-localization-id="rich-content-unknown" data-localization-mode="descriptive">No information is available</span></li>
-				</ul>
-
-				<p id="rc-compact" class="list-hd">Compact statements</p>
-				<ul aria-labelledby="rc-compact">
-					<li>
-<span  data-localization-id="rich-content-accessible-math-as-mathml"
-							data-localization-mode="compact">Math as MathML</span></li>
-<li>
-<span data-localization-id="rich-content-accessible-math-as-latex"
-							data-localization-mode="compact">Math as LaTeX</span></li>
-<li>
-<span data-localization-id="rich-content-accessible-math-described"
-							data-localization-mode="compact">text descriptions of math is provided </span></li>
-<li><span data-localization-id="rich-content-accessible-chemistry-as-mathml"
-							data-localization-mode="compact">Chemical formulas in MathML</span>
-					</li>
-<li><span data-localization-id="rich-content-accessible-chemistry-as-latex"
-							data-localization-mode="compact">Chemical formulas in LaTeX</span>
-					</li>
-
-<li>
-						<span
-							data-localization-id="rich-content-extended"
-							data-localization-mode="compact">Information-rich images are described by extended descriptions</span>
-</li>
-<li><span data-localization-id="rich-content-closed-captions" data-localization-mode="compact">
-Videos have closed captions </span></li>
-					<li>
-<span data-localization-id="rich-content-open-captions" data-localization-mode="compact">
-Videos have open captions</span></li>
-<li><span data-localization-id="rich-content-transcript" data-localization-mode="compact">
-Transcript(s) provided)</span></li>
-<li><span data-localization-id="rich-content-unknown" data-localization-mode="compact">No information is available</span></li>
-				</ul>
+				<dl>
+					<dt>Math marked up in MathML</dt>
+					<dd>
+						<p data-localization-id="rich-content-accessible-math-as-mathml"
+								data-localization-mode="descriptive">Math formulas in accessible format (MathML)</p>
+						<p data-localization-id="rich-content-accessible-math-as-mathml"
+								data-localization-mode="compact">Math as MathML</p>
+					</dd>
+					
+					<dt>Math marked up in LaTeX</dt>
+					<dd>
+						<p data-localization-id="rich-content-accessible-math-as-latex"
+								data-localization-mode="descriptive">Math formulas in accessible format (LaTeX)</p>
+						<p data-localization-id="rich-content-accessible-math-as-latex"
+								data-localization-mode="compact">Math as LaTeX</p>
+					</dd>
+					
+					<dt>Math represented as images</dt>
+					<dd>
+						<p data-localization-id="rich-content-accessible-math-described"
+								data-localization-mode="descriptive">Text descriptions of math is provided</p>
+						<p data-localization-id="rich-content-accessible-math-described"
+								data-localization-mode="compact">Text descriptions of math is provided</p>
+					</dd>
+					
+					<dt>Chemical formulas marked up in MathML</dt>
+					<dd>
+						<p data-localization-id="rich-content-accessible-chemistry-as-mathml"
+								data-localization-mode="descriptive">Chemical formulas in accessible format (MathML)</p>
+						<p data-localization-id="rich-content-accessible-chemistry-as-mathml"
+								data-localization-mode="compact">Chemical formulas in MathML</p>
+					</dd>
+					
+					<dt>Chemical formulas marked up in LaTeX</dt>
+					<dd>
+						<p data-localization-id="rich-content-accessible-chemistry-as-latex"
+								data-localization-mode="descriptive">Chemical formulas in accessible format (LaTeX)</p>
+						<p data-localization-id="rich-content-accessible-chemistry-as-latex"
+								data-localization-mode="compact">Chemical formulas in LaTeX</p>
+					</dd>
+					
+					<dt>Extended descriptions provided for images</dt>
+					<dd>
+						<p data-localization-id="rich-content-extended"
+								data-localization-mode="descriptive">Information-rich images are described by extended descriptions</p>
+						<p data-localization-id="rich-content-extended"
+								data-localization-mode="compact">Information-rich images are described by extended descriptions</p>
+					</dd>
+					
+					<dt>Closed captions provided for videos</dt>
+					<dd>
+						<p data-localization-id="rich-content-closed-captions" data-localization-mode="descriptive">
+								Videos included in publications have closed captions</p>
+						<p data-localization-id="rich-content-closed-captions" data-localization-mode="compact">
+								Videos have closed captions</p>
+					</dd>
+					
+					<dt>Open captions provided for videos</dt>
+					<dd>
+						<p data-localization-id="rich-content-open-captions" data-localization-mode="descriptive">
+								Videos included in publications have open captions</p>
+						<p data-localization-id="rich-content-open-captions" data-localization-mode="compact">
+								Videos have open captions</p>
+					</dd>
+					
+					<dt>Transcripts provided for auditory content</dt>
+					<dd>
+						<p data-localization-id="rich-content-transcript" data-localization-mode="descriptive">
+								Transcript(s) provided)</p>
+						<p data-localization-id="rich-content-transcript" data-localization-mode="compact">
+								Transcript(s) provided)</p>
+					</dd>
+					
+					<dt>No metadata provided</dt>
+					<dd>
+						<p data-localization-id="rich-content-unknown" data-localization-mode="descriptive">No information is available</p>
+						<p data-localization-id="rich-content-unknown" data-localization-mode="compact">No information is available</p>
+					</dd>
+				</dl>
 			</section>
 
 			<section id="rc-examples">

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -120,8 +120,11 @@
 			border: none;
 			display: inline-block;
 		}
-		p.list-hd {
-			font-weight: bold;
+		p[data-localization-mode="descriptive"]:before {
+			content: 'Descriptive: ';
+		}
+		p[data-localization-mode="compact"]:before {
+			content: 'Compact: ';
 		}
 	</style>
 </head>
@@ -599,49 +602,46 @@
 
 				<p>The descriptive and compact statements for visual adjustment are as follows.</p>
 				
-				<p id="va-desc" class="list-hd">Descriptive statements</p>
-
-				<ul>
-					<li data-localization-id="ways-of-reading-visual-adjustments-modifiable"
-						data-localization-mode="descriptive">
-						Appearance of the text and page layout can
-						be
-						modified according to the capabilities of
-						the reading system (font family and font
-						size,
-						spaces between paragraphs, sentences, words,
-						and letters, as well as color of background
-						and text)</li>
-					<li data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
-						data-localization-mode="descriptive">Text
-						and page layout cannot be modified as the
-						reading experience is close to a print
-						version, but reading systems can still
-						provide zooming options</li>
-					<li data-localization-id="ways-of-reading-visual-adjustments-unknown"
-						data-localization-mode="descriptive">
-						No information about appearance modifiability is available</li>
-				</ul>
-
-				<p id="va-compact" class="list-hd">Compact statements</p>
-				<ul aria-labelledby="va-compact">
-					<li data-localization-id="ways-of-reading-visual-adjustments-modifiable"
-						data-localization-mode="compact">Appearance
-						can be modified</li>
-					<!--if Display transformability is present-->
-					<li data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
-						data-localization-mode="compact">Appearance
-						cannot be modified</li>
-					<!--if display transformability is not present and text on visual is present-->
-					<li data-localization-id="ways-of-reading-visual-adjustments-unknown"
-						data-localization-mode="compact">No information about appearance modifiability is available</li>
-					<!--if neither display transformability nor text on visual are presents-->
-				</ul>
-			</section>
-
-			<section id="va-examples">
-				<h5>Examples</h5>
-			
+				<dl>
+					<dt>Display is modifiable</dt>
+					<dd>
+						<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
+							data-localization-mode="descriptive">
+							Appearance of the text and page layout can
+							be
+							modified according to the capabilities of
+							the reading system (font family and font
+							size,
+							spaces between paragraphs, sentences, words,
+							and letters, as well as color of background
+							and text)</p>
+						<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
+							data-localization-mode="compact">Appearance
+							can be modified</p>
+					</dd>
+					
+					<dt>Display is not modifiable</dt>
+					<dd>
+						<p data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
+							data-localization-mode="descriptive">Text
+							and page layout cannot be modified as the
+							reading experience is close to a print
+							version, but reading systems can still
+							provide zooming options</p>
+						<p data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
+							data-localization-mode="compact">Appearance
+							cannot be modified</p>
+					</dd>
+					
+					<dt>No metadata provided</dt>
+					<dd>
+						<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
+							data-localization-mode="descriptive">
+							No information about appearance modifiability is available</p>
+						<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
+							data-localization-mode="compact">No information about appearance modifiability is available</p>
+					</dd>
+				</dl>
 			</section>
 			
 			<section id="va-techniques">
@@ -700,45 +700,50 @@
 
 				<p>The descriptive and compact statements for nonvisual reading are as follows.</p>
 				
-				<p id="nv-desc-expl" class="list-hd">Descriptive explanations</p>
-				<ul aria-labelledby="nv-desc-expl">
-					<li data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
-						data-localization-mode="descriptive">Has alternative text descriptions for images</li>
-					<li data-localization-id="ways-of-reading-nonvisual-reading-readable"
-						data-localization-mode="descriptive">All
-						content can be read as read aloud speech or
-						dynamic braille</li>
-					<li data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
-						data-localization-mode="descriptive">
-						Portions of the content may not be readable
-						as read aloud speech or dynamic braille</li>
-					<li data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
-						data-localization-mode="descriptive">Not all
-						of the content will be readable as read
-						aloud speech or dynamic braille</li>
-				</ul>
-
-				<p id="nv-compact-expl" class="list-hd">Compact explanations</p>
-				<ul aria-labelledby="nv-compact-expl">
-					<li data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
-						data-localization-mode="compact">Has alternative text</li>
-					<li data-localization-id="ways-of-reading-nonvisual-reading-readable"
-						data-localization-mode="compact">Readable in
-						read aloud or dynamic braille</li>
-					<li data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
-						data-localization-mode="compact">May not be
-						fully readable in read aloud or dynamic
-						braille</li>
-					<li data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
-						data-localization-mode="compact">Not
-						fully readable in read aloud or dynamic
-						braille</li>
-				</ul>
-			</section>
-
-			<section id="nv-examples">
-				<h5>Examples</h5>
-				
+				<dl>
+					<dt>Text alternatives are provided</dt>
+					<dd>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
+							data-localization-mode="descriptive">Has alternative text descriptions for images</p>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
+							data-localization-mode="compact">Has alternative text</p>
+					</dd>
+					
+					<dt>All content is readable in text form</dt>
+					<dd>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
+							data-localization-mode="descriptive">All
+							content can be read as read aloud speech or
+							dynamic braille</p>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
+							data-localization-mode="compact">Readable in
+							read aloud or dynamic braille</p>
+					</dd>
+					
+					<dt>Not all content may be readable in text form</dt>
+					<dd>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
+							data-localization-mode="descriptive">
+							Portions of the content may not be readable
+							as read aloud speech or dynamic braille</p>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
+							data-localization-mode="compact">May not be
+							fully readable in read aloud or dynamic
+							braille</p>
+					</dd>
+					
+					<dt>Not all content is readable in text form</dt>
+					<dd>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
+							data-localization-mode="descriptive">Not all
+							of the content will be readable as read
+							aloud speech or dynamic braille</p>
+						<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
+							data-localization-mode="compact">Not
+							fully readable in read aloud or dynamic
+							braille</p>
+					</dd>
+				</dl>
 			</section>
 			
 			<section id="nv-techniques">
@@ -793,38 +798,41 @@
 				
 				<p>The descriptive and compact statements for prerecorded audio are as follows.</p>
 				
-				<p id="prerecorded-desc" class="list-hd">Descriptive statements</p>
-
-				<ul aria-labelledby="prerecorded-desc">
-					<li data-localization-id="ways-of-reading-prerecorded-audio-only"
-						data-localization-mode="descriptive">
-						Audiobook with no text alternative</li>
-
-					<li data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
-						data-localization-mode="descriptive">All the
-						content is available as prerecorded audio
-						synchronized with text</li>
-						<li data-localization-id="ways-of-reading-prerecorded-audio-complementary" data-localization-mode="descriptive">Portions of prerecorded audio are available</li>
-<li data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
-						data-localization-mode="descriptive">
-						No information about prerecorded audio is available</li>
-				</ul>
-
-				<p id="prerecorded-compact" class="list-hd">Compact statements</p>
-				<ul aria-labelledby="prerecorded-compact">
-					<li data-localization-id="ways-of-reading-prerecorded-audio-only"
-						data-localization-mode="compact">Audio only</li>
-					<li data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
-						data-localization-mode="compact">Prerecorded audio synchronized with text</li>
-<li data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
-						data-localization-mode="compact">
-						No information about prerecorded audio is available</li>
-				</ul>
-			</section>
-
-			<section id="prerecorded-audio-examples">
-				<h5>Examples</h5>
-				
+				<dl>
+					<dt>Prerecorded audiobooks</dt>
+					<dd>
+						<p data-localization-id="ways-of-reading-prerecorded-audio-only"
+							data-localization-mode="descriptive">
+							Audiobook with no text alternative</p>
+						<p data-localization-id="ways-of-reading-prerecorded-audio-only"
+							data-localization-mode="compact">Audio only</p>
+					</dd>
+					
+					<dt>Prerecorded audio synchronized with text</dt>
+					<dd>
+						<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
+							data-localization-mode="descriptive">All the
+							content is available as prerecorded audio
+							synchronized with text</p>
+						<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
+							data-localization-mode="compact">Prerecorded audio synchronized with text</p>
+					</dd>
+					
+					<dt>Prerecorded audio clips</dt>
+					<dd>
+						<p data-localization-id="ways-of-reading-prerecorded-audio-complementary" data-localization-mode="descriptive">Portions of prerecorded audio are available</p>
+					</dd>
+					
+					<dt>No metadata provided</dt>
+					<dd>
+						<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
+							data-localization-mode="descriptive">
+							No information about prerecorded audio is available</p>
+						<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
+							data-localization-mode="compact">
+							No information about prerecorded audio is available</p>
+					</dd>
+				</dl>
 			</section>
 			
 			<section id="prerecorded-audio-techniques">

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -143,9 +143,7 @@
 			font-style: italic;
 			color: red;
 		}
-		.example h4,
-		.example h5,
-		.example h6 {
+		p.ex-hd {
 			margin: 1rem 0 0 0;
 			padding: 0;
 			font-variant: small-caps
@@ -668,30 +666,6 @@
 					</dl>
 				</section>
 				
-				<section id="va-examples">
-					<h5>Examples</h5>
-					
-					<aside class="example" title="Display for a publication with modifiable appearance">
-						<h6 data-localization-id="ways-of-reading-title">Ways of reading</h6>
-						<p>Appearance of the text and page layout can be
-							modified according to the capabilities of
-							the reading system (font family and font size,
-							spaces between paragraphs, sentences, words,
-							and letters, as well as color of background
-							and text)</p>
-					</aside>
-					
-					<aside class="example" title="Display for a publication without modifiable appearance">
-						<h6 data-localization-id="ways-of-reading-title">Ways of reading</h6>
-						<p data-localization-id="ways-of-reading-visual-adjustments-unmodifiable"
-							data-localization-mode="descriptive">Text
-							and page layout cannot be modified as the
-							reading experience is close to a print
-							version, but reading systems can still
-							provide zooming options</p>
-					</aside>
-				</section>
-				
 				<section id="va-techniques">
 					<h5>Display techniques for Visual adjustments support</h5>
 	
@@ -896,6 +870,41 @@
 					</ul>
 				</section>
 			</section>
+			
+			<section id="va-examples">
+				<h4>Examples</h4>
+				
+				<aside class="example" title="Publication with accessible ways of reading">
+					<p>The following example shows the descriptive and compact statements that would display
+						for a publication with a modifiable display, that is compatible with nonvisual reading,
+						and that has synchronized prerecorded audio with the text.</p>
+					
+					<dl>
+						<dt>Compact display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="ways-of-reading-title">Ways of reading</p>
+							<p>Appearance can be modified</p>
+							<p>Readable in read aloud or dynamic braille</p>
+							<p>Has alternative text</p>
+							<p>Prerecorded audio synchronized with text</p>
+						</dd>
+						
+						<dt>Descriptive display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="ways-of-reading-title">Ways of reading</p>
+							<p>Appearance of the text and page layout can be
+								modified according to the capabilities of
+								the reading system (font family and font size,
+								spaces between paragraphs, sentences, words,
+								and letters, as well as color of background
+								and text)</p>
+							<p>All content can be read as read aloud speech or dynamic braille</p>
+							<p>Has alternative text descriptions for images</p>
+							<p>All the content is available as prerecorded audio synchronized with text</p>
+						</dd>
+					</dl>
+				</aside>
+			</section>
 		</section>
 		<section id="conformance-group">
 			<h3 data-localization-id="conformance-title">Conformance</h3>
@@ -963,39 +972,43 @@
 						<span class="placeholder">&lt;placeholder&gt;</span>).</p>
 				</div>
 				
+				<div class="note">
+					<p>Not all conformance statements have compact and descriptive forms. In these cases,
+						the same string is used for both.</p>
+				</div>
+				
 				<dl>
 					<dt>If the publication meets minimal accessibility requirements:</dt>
 					<dd>
 						<p data-localization-id="conformance-a"
-							data-localization-mode="descriptive">This publication meets minimum accessibility
+							data-localization-mode="compact">This publication meets minimum accessibility
 							standards</p>
 						<p data-localization-id="conformance-a"
-							data-localization-mode="compact">This publication meets minimum accessibility
+							data-localization-mode="descriptive">This publication meets minimum accessibility
 							standards</p>
 					</dd>
 					
 					<dt>If the publication meets widely accepted accessibility requirements:</dt>
 					<dd>
 						<p data-localization-id="conformance-aa"
-							data-localization-mode="descriptive">This publication meets accepted accessibility
+							data-localization-mode="compact">This publication meets accepted accessibility
 							standards</p>
 						<p data-localization-id="conformance-aa"
-							data-localization-mode="compact">This publication meets accepted accessibility
+							data-localization-mode="descriptive">This publication meets accepted accessibility
 							standards</p>
 					</dd>
 					
 					<dt>If no metadata is provided:</dt>
 					<dd>
 						<p data-localization-id="conformance-no"
-							data-localization-mode="descriptive">No information is available</p>
-						<p data-localization-id="conformance-no"
 							data-localization-mode="compact">No information is available</p>
+						<p data-localization-id="conformance-no"
+							data-localization-mode="descriptive">No information is available</p>
 					</dd>
 					
 					<dt>If the publication meets the requirements of the EPUB Accessibility standard:</dt>
 					<dd>
-						<p
-							data-localization-mode="descriptive">
+						<p>
 							<span
 								data-localization-id="conformance-claim">This
 								publication claims to meet</span>
@@ -1011,72 +1024,37 @@
 							<span>Level</span>
 							<span class="placeholder">&lt;A or AA or AAA&gt;</span>
 						</p>
-						<p
-							data-localization-mode="compact">
-							<span
-								data-localization-id="conformance-claim">This
-								publication claims to meet</span>
-							
-							<span>EPUB
-								Accessibility</span>
-							<span class="placeholder">&lt;1.X&gt;</span>
-							
-							<span>WCAG</span>
-							<span class="placeholder">&lt;2.X&gt;</span>
-							
-							<span>Level</span>
-							<span class="placeholder">&lt;A or AA or AAA&gt;</span>
-						</p>
 					</dd>
 					
 					<dt>If a certifier name is provided:</dt>
 					<dd>
-						<p data-localization-mode="descriptive"><span
+						<p><span
 								data-localization-id="conformance-certifier"
 								data-localization-mode="descriptive">The
-								publication was certified by</span>
-							<span class="placeholder">&lt;certifier name&gt;</span></p>
-						<p data-localization-mode="compact"><span
-								data-localization-id="conformance-certifier"
-								data-localization-mode="compact">The
 								publication was certified by</span>
 							<span class="placeholder">&lt;certifier name&gt;</span></p>
 					</dd>
 					
 					<dt>If the certifier has a credential:</dt>
 					<dd>
-						<p data-localization-mode="descriptive"><span
+						<p><span
 								data-localization-id="conformance-certifier-credentials"
 								data-localization-mode="descriptive">The certifier's credential is</span>
-							<span class="placeholder">&lt;certifier credential&gt;</span></p>
-						<p data-localization-mode="compact"><span
-								data-localization-id="conformance-certifier-credentials"
-								data-localization-mode="compact">The certifier's credential is</span>
 							<span class="placeholder">&lt;certifier credential&gt;</span></p>
 					</dd>
 					
 					<dt>If the certification date is provided:</dt>
 					<dd>
-						<p data-localization-mode="descriptive">
+						<p>
 							<span data-localization-id="conformance-certification-info"
 								data-localization-mode="descriptive">The
-								publication was certified on</span>
-							<span class="placeholder">&lt;certification date&gt;</span></p>
-						<p data-localization-mode="compact">
-							<span data-localization-id="conformance-certification-info"
-								data-localization-mode="compact">The
 								publication was certified on</span>
 							<span class="placeholder">&lt;certification date&gt;</span></p>
 					</dd>
 					
 					<dt>If the certifier provides an accessibility report:</dt>
 					<dd>
-						<p data-localization-id="conformance-certifier-report"
-							data-localization-mode="descriptive">For
-								more information refer to the
-								certifier's report</p>
-						<p data-localization-id="conformance-certifier-report"
-							data-localization-mode="compact">For
+						<p data-localization-id="conformance-certifier-report">For
 								more information refer to the
 								certifier's report</p>
 					</dd>


### PR DESCRIPTION
Opening this as a draft pull request to get feedback on whether this is a direction we want to go in.

In a nutshell, I found it problematic that we introduce all the strings as examples, and the examples show every string instead of how the metadata is expected to be displayed. I've also always found it hard to have to go to different examples and read the strings to match up the compact and descriptive text.

To address this, I've been discussing with George how we can add new "Statements" section for each technique. The compact and descriptive statements will be grouped and introduced similar to how the techniques work with "if" statements. We can then add real examples of the output for each technique.

So far, I've added all the statement sections, but I still need to add more examples. There is one [example for ways of reading](https://raw.githack.com/w3c/publ-a11y/fix/normative-strings/a11y-meta-display-guide/2.0/draft/guidelines/index.html#va-examples) to show how I'd like to do them.

At any rate, it would help to hear what people think of this change before doing anything more.

***

[Preview](https://raw.githack.com/w3c/publ-a11y/fix/normative-strings/a11y-meta-display-guide/2.0/draft/guidelines/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/normative-strings/a11y-meta-display-guide/2.0/draft/guidelines/index.html)
