### PR TITLE
Add starter examples

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1405,8 +1405,7 @@
 							data-localization-mode="compact">Go to page</p>
 						<p data-localization-id="navigation-page-navigation"
 							data-localization-mode="descriptive">Page list to go to pages from the print
-							source
-							version</p>
+							source version</p>
 					</dd>
 					
 					<dt>If no metadata is provided:</dt>
@@ -1422,6 +1421,30 @@
 			<section id="nav-examples">
 				<h5>Examples</h5>
 				
+				<aside class="example" title="Publication with some navigation features">
+					<p>The following example shows the descriptive and compact statements that would display
+						for a publication with a table of contents and page navigation.</p>
+					
+					<dl>
+						<dt>Compact display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="navigation-title">Navigation</p>
+							<ul>
+								<li>Table of contents</li>
+								<li>Go to page</li>
+							</ul>
+						</dd>
+						
+						<dt>Descriptive display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="navigation-title">Navigation</p>
+							<ul>
+								<li>Table of contents to all chapters of the text via links</li>
+								<li>Page list to go to pages from the print source version</li>
+							</ul>
+						</dd>
+					</dl>
+				</aside>
 			</section>
 			
 			<section id="nav-techniques">
@@ -1547,6 +1570,33 @@
 			<section id="rc-examples">
 				<h5>Examples</h5>
 				
+				<aside class="example" title="Publication with math and video">
+					<p>The following example shows the descriptive and compact statements that would display
+						for a publication with a math equations in MathML and videos with closed captions and
+						transcripts of the dialogue.</p>
+					
+					<dl>
+						<dt>Compact display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="rich-content-title">Rich content</p>
+							<ul>
+								<li>Math as MathML</li>
+								<li>Videos have closed captions</li>
+								<li>Transcript(s) provided)</li>
+							</ul>
+						</dd>
+						
+						<dt>Descriptive display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="rich-content-title">Rich content</p>
+							<ul>
+								<li>Math formulas in accessible format (MathML)</li>
+								<li>Videos included in publications have closed captions</li>
+								<li>Transcript(s) provided)</li>
+							</ul>
+						</dd>
+					</dl>
+				</aside>
 			</section>
 			
 			<section id="rc-techniques">
@@ -1614,7 +1664,7 @@
 						<p data-localization-id="hazards-none"
 							data-localization-mode="compact">No hazards</p>
 						<p data-localization-id="hazards-none"
-								data-localization-mode="descriptive">No hazards</p>
+							data-localization-mode="descriptive">The publication contains no hazards</p>
 					</dd>
 					
 					<dt>If there is a flashing hazard:</dt>
@@ -1670,8 +1720,26 @@
 			</section>
 
 			<section id="hazards-examples">
-				<h5>Examples</h5>
+				<h4>Examples</h4>
 				
+				<aside class="example" title="Publication with no hazards">
+					<p>The following example shows the descriptive and compact statements that would display
+						for a publication with no flashing, motion simulation, or sound hazards.</p>
+					
+					<dl>
+						<dt>Compact display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="hazards-title">Rich content</p>
+							<p>No hazards</p>
+						</dd>
+						
+						<dt>Descriptive display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="hazards-title">Rich content</p>
+							<p>The publication contains no hazards</p>
+						</dd>
+					</dl>
+				</aside>
 			</section>
 			
 			<section id="hazards-techniques">
@@ -1845,8 +1913,27 @@
 			</section>
 
 			<section id="legal-examples">
-				<h5>Examples</h5>
+				<h4>Examples</h4>
 				
+				<aside class="example" title="Publication with an exemption">
+					<p>The following example shows the descriptive and compact statements that would display
+						for a publication that claims legal exemption from a jurisidiction's accessibility
+						requirements.</p>
+					
+					<dl>
+						<dt>Compact display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="legal-title">Legal considerations</p>
+							<p>Claims an accessibility exemption in some jurisdictions</p>
+						</dd>
+						
+						<dt>Descriptive display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="legal-title">Legal considerations</p>
+							<p>This publication claims an accessibility exemption in some jurisdictions</p>
+						</dd>
+					</dl>
+				</aside>
 			</section>
 			
 			<section id="legal-techniques">
@@ -1987,6 +2074,30 @@
 			<section id="add-info-examples">
 				<h5>Examples</h5>
 				
+				<aside class="example" title="Publication with ARIA roles">
+					<p>The following example shows the descriptive and compact statements that would display
+						for a publication that includes ARIA roles and has visible static page numbers.</p>
+					
+					<dl>
+						<dt>Compact display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="add-info-title">Additional accessibility information</p>
+							<ul>
+								<li>ARIA roles included</li>
+								<li>Visible page numbering</li>
+							</ul>
+						</dd>
+						
+						<dt>Descriptive display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="add-info-title">Additional accessibility information</p>
+							<ul>
+								<li>Content is enhanced with ARIA roles to optimize organization and facilitate navigation</li>
+								<li>Page breaks included from the original print source</li>
+							</ul>
+						</dd>
+					</dl>
+				</aside>
 			</section>
 			
 			<section id="add-info-techniques">


### PR DESCRIPTION
This pull request adds a basic example for each section that didn't have any. These can be replaced or improved on later.

(edit: fixed the diff link to compare the right files)

***

[Preview](https://raw.githack.com/w3c/publ-a11y/add/guideline-examples/a11y-meta-display-guide/2.0/draft/guidelines/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/add/guideline-examples/a11y-meta-display-guide/2.0/draft/guidelines/index.html)
