### PR TITLE
Typo

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1729,13 +1729,13 @@
 					<dl>
 						<dt>Compact display</dt>
 						<dd>
-							<p class="ex-hd" data-localization-id="hazards-title">Rich content</p>
+							<p class="ex-hd" data-localization-id="hazards-title">Hazards</p>
 							<p>No hazards</p>
 						</dd>
 						
 						<dt>Descriptive display</dt>
 						<dd>
-							<p class="ex-hd" data-localization-id="hazards-title">Rich content</p>
+							<p class="ex-hd" data-localization-id="hazards-title">Hazards</p>
 							<p>The publication contains no hazards</p>
 						</dd>
 					</dl>


### PR DESCRIPTION
Accidentally copied the "Rich content" example headers into the hazards section