### PR TITLE
Rearrange of the guidelines intro sections

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -169,33 +169,192 @@
 	<section id="intro">
 		<h2>Introduction</h2>
 
-		<p>Reading a digital publication is a very personal experience.
-			For most people this is routine, and little
-			consideration is given to how the title was obtained before
-			it is read. Users may go to a bookstore or library,
-			search for the title to purchase online, or have the title
-			selected for them by an instructor for a
-			class.</p>
-
-		<p>Now consider that the person is blind and relies on assistive
-			technology. The user needs that technology
-			to assist them in the purchase process as well as to read
-			the e-book. The person may wonder: will
-			the screen reader work with this title; are there image
-			descriptions that will be spoken to describe
-			these images; are there page numbers which are accessible;
-			is the reading order correct so a caution will be announced
-			before reading the paragraph which could be dangerous? All
-			of these accessibility concerns are potential issues
-			consumers have when trying to purchase and ultimately read a
-			digital publication in any format.</p>
-
-		<p>The good news is more and more publishers are creating
-			digital publications that are Born Accessible (i.e.,
-			accessible from the outset, not fixed later) and getting the
-			accessibility validation or audit done by
-			independent organizations.</p>
-
+		<section id="overview">
+			<h3>Overview</h3>
+			
+			<p>Reading a digital publication is a very personal experience.
+				For most people this is routine, and little
+				consideration is given to how the title was obtained before
+				it is read. Users may go to a bookstore or library,
+				search for the title to purchase online, or have the title
+				selected for them by an instructor for a
+				class.</p>
+			
+			<p>Now consider that the person is blind and relies on assistive
+				technology. The user needs that technology
+				to assist them in the purchase process as well as to read
+				the e-book. The person may wonder: will
+				the screen reader work with this title; are there image
+				descriptions that will be spoken to describe
+				these images; are there page numbers which are accessible;
+				is the reading order correct so a caution will be announced
+				before reading the paragraph which could be dangerous? All
+				of these accessibility concerns are potential issues
+				consumers have when trying to purchase and ultimately read a
+				digital publication in any format.</p>
+			
+			<p>The good news is more and more publishers are creating
+				digital publications that are Born Accessible (i.e.,
+				accessible from the outset, not fixed later) and getting the
+				accessibility validation or audit done by
+				independent organizations.</p>
+			
+			<p>These guidelines help those who wish to render accessibility
+				metadata directly to users understand how to
+				represent the accessibility claims inherent in
+				machine-readable accessibility metadata in a
+				user-friendly User Interface / User Experience (UI/UX). This
+				document targets implementers such as
+				bookstores, libraries, retailers, distributors etc. Content
+				creators will benefit from reading these guidelines and
+				are encouraged to follow <a
+					href="https://www.w3.org/TR/epub-a11y-11/">EPUB
+					Accessibility 1.1
+					Conformance and Discoverability Requirements section and
+					its techniques.</a></p>
+			
+			<div class="note">
+				<p>This document presents high-level guidelines without
+					going into technical issues related to the
+					different metadata standards in the publishing industry.
+				</p>
+				<p>Therefore, <a href="#techniques">techniques are
+						available</a> that illustrate to developers how to
+					retrieve data to show the information outlined in this
+					document.</p>
+			</div>
+			
+			<p>Metadata found either inside a digital publication or in a
+				corresponding external record may have
+				important accessibility claims that help end users find and
+				determine if the publication can meet their
+				specific accessibility needs.</p>
+			
+			<p>This accessibility metadata uses controlled vocabularies to
+				allow it to be extracted and displayed uniformly across
+				different publications and localized to different user
+				interface languages. The one exception is the accessibility
+				summary, which allows accessibility statements that are
+				unique to a publication and that adds information not
+				covered by other metadata entries.</p>
+			
+			<p>One important aspect is that the role of the Accessibility
+				Summary metadata has changed in the latest
+				version of the EPUB Accessibility specification, so a more
+				in-depth analysis in the <a
+					href="#accessibility-summary">Accessibility summary</a>
+				section is recommended.</p>
+			
+			<p>This document offers guidance on how to aggregate and display
+				claims inherent in metadata to end users;
+				these are not strict guidelines, but suggestions for
+				providing a consistent experience for users through
+				different portals. Different implementers may choose to
+				implement these guidelines in a slightly
+				different way. Some examples can be seen in the <a
+					href="#implementations">Implementations</a> section
+				of the document.</p>
+		</section>
+		
+		<section id="processing-guide">
+			<h3>Metadata processing</h3>
+			
+			<p>The following diagram depicts how these guidelines relate
+				to the format-specific techniques in the
+				process of receiving and displaying accessibility
+				metadata.</p>
+			
+			<img class="responsive" src="media/MetadataProcessing.png"
+				aria-details="ecosystem"
+				alt="Outline of the processing for EPUB, PDF, ONIX and MARC metadata. Description follows." />
+			
+			<div class="note">
+				<p>Work on integrating PDF and MARC is ongoing. The
+					diagram and text of this section will be updated
+					in future versions as the related documents are
+					finalized.</p>
+			</div>
+			
+			<p>The diagram categorizes two ways that metadata
+				accompanies a publication. In the first are digital
+				publication formats that directly embed accessibility
+				metadata (EPUB and PDF). In the second are
+				external metadata record formats (ONIX and MARC) that
+				accompany a digital publication as it moves
+				through the supply chain.</p>
+			
+			<p>In some cases, a digital publication may include both
+				internal and external metadata (e.g., an EPUB
+				could have accessibility metadata in it package document
+				and also be provided to a vendor with an
+				ONIX record). In these cases, vendors and reading system
+				developers determine for themselves which
+				set of metadata they will use to display to users.</p>
+			
+			<div class="note">
+				<p>This guide assumes the metadata is already in one of
+					the formats described in the diagram, but
+					depending on how the metadata is submitted it may
+					need to be transformed. For example, if a vendor
+					prefers to handle only ONIX metadata for display
+					Then they would need to preprocess the metadata
+					embedded in an EPUB or PDF to create the ONIX.</p>
+				<p>The process of transforming metadata is not it scope
+					for this document nor is how to reconcile
+					metadata when it is provided in multiple forms. The
+					guide assumes any processing has already
+					occurred. For information on mapping between
+					formats, refer to the <a
+						href="https://w3c.github.io/publ-a11y/drafts/a11y-crosswalk-MARC/">Accessibility
+						Properties
+						Crosswalk</a>.</p>
+			</div>
+			
+			<p>The next level of the diagram depicts the encoding
+				standards expected for each format. This guide
+				assumes that the metadata conforms to a recognized
+				standard, otherwise it would be difficult to
+				anticipate and process the incoming information for
+				users:</p>
+			
+			<ul>
+				<li>For EPUB, the EPUB Accessibility standard
+					[[epub-a11y-11]] defines required and recommended
+					metadata for accessible publications. Guidance on
+					applying this metadata is found in the EPUB
+					Accessibility techniques [[epub-a11y-tech-11]].</li>
+				<li>For ONIX, the accessibility characteristics of the
+					corresponding digital publication are
+					expressed using <a
+						href="https://ns.editeur.org/onix/en">code
+						lists</a> [[onix]], and guidance
+					on applying these values is defined in the
+					application note <a
+						href="https://www.editeur.org/files/ONIX%203/APPNOTE%20Accessibility%20metadata%20in%20ONIX%20(advanced).pdf">Providing
+						accessibility metadata in ONIX (advanced)</a>.
+				</li>
+				<li>For PDF, the PDF/UA standard
+					[[iso14289-1]][[iso14289-2]] and <a
+						href="https://pdfa.org/wtpdf/">Well-Tagged PDF
+						guide</a> define how to describe accessibility
+					metadata.</li>
+			</ul>
+			
+			<p>Knowing how the metadata is encoded and how it is
+				expressed, the next stage of processing is to use
+				the algorithms defined in the respective techniques
+				documents to discover and translate the
+				information into human-readable statements. These
+				documents are intended primarily for developers,
+				to help them with the specific processing of the
+				metadata markup grammars.</p>
+			
+			<p>Finally, this document is shown at the last stage of
+				processing, as it defines the purpose of each
+				piece of metadata in more detail and prioritizes the
+				display for readers.</p>
+		</section>
+		
 		<section id="terminology">
 			<h3>Terminology</h3>
 
@@ -265,326 +424,180 @@
 			</dl>
 		</section>
 	</section>
-	<section id="general-overview">
-		<h2>General overview</h2>
+	<section id="meta-display">
+		<h2>Metadata display</h2>
+		
+		<section id="a11y-section">
+			<h3>Accessibility section</h3>
+			
+			<section id="a11y-section-hd">
+				<h4>Accessibility header</h4>
+				
+				<p>When presenting accessibility metadata provided by the
+					publisher, it is suggested that the section is
+					introduced using terms such as "claims" or
+					"declarations." This heading should clearly convey to
+					the end user that the information comes directly from the
+					publisher and represents the accessibility
+					information that the publisher intends to communicate.
+				</p>
+			</section>
+			
+			<section id="rec-fields">
+				<h4>Recommended fields</h4>
+				
+				<p>When focusing on the accessibility of any digital
+					publication, several areas of key information come to
+					mind:</p>
+				
+				<ul>
+					<li>People who need to adjust the visual presentation
+						want to know if they can enlarge the text,
+						which is essential for low vision users. People with
+						dyslexia must be able to select the font
+						and adjust the foreground, background, and line
+						spacing and length. People with low vision and
+						dyslexia
+						represent the largest percentage of the
+						print-disabled population.</li>
+					
+					<li>People who use a screen reader need to know if all
+						the content in the title will be accessible
+						to them. When images have text descriptions (alt
+						text), they are assured that they will be not
+						missing out on essential information. Blind users
+						will greatly benefit from this information as
+						well as individuals who use the read aloud feature
+						in Reading Systems.</li>
+					
+					<li>People who are selecting materials for public
+						institutions such as libraries or schools need
+						to know if the content conforms to accepted
+						standards.</li>
+				</ul>
+				
+				<p>This is why these guidelines recommend that the following <a 
+						href="#order-of-key-information">key accessibility information</a> should be
+					displayed:</p>
+				
+				<ul>
+					<li><a href="#ways-of-reading">Ways of reading</a> &#8212; specifically the
+						<a href="#visual-adjustments">visual adjustments</a>
+						and <a href="#supports-nonvisual-reading">support for nonvisual reading</a> statements</li>
+					<li><a href="#conformance-group">Conformance</a></li>
+				</ul>
+				
+				<p>The other areas provide details about specific features or shortcomings in publications. It is
+					expected that these other areas of key information will give people what they need to make an
+					informed choice to read a particular e-book.</p>
+				
+				<div class="note">
+					<p>This document does not define the order in which to show the key accessibility information; each
+						implementer can decide the preferred order and appropriate headings to use to show the
+						accessibility information that follows.</p>
+				</div>
+			</section>
+			
+			<section id="additional-a11y-meta">
+				<h4>Additional accessibility metadata</h4>
+				
+				<p>In this document are examples of important metadata that is expected to be in a wide range of
+					publications. However, we do not have examples of all possible features that the metadata can
+					express. The techniques have more values than are shown in the examples.</p>
+			</section>
+			
+			<section id="missing-metadata">
+				<h4>Missing metadata</h4>
+				
+				<p>When no accessibility metadata is provided by the publisher, it is best to 
+					avoid making a negative statement that could be attributed to them. 
+					The neutral statement "No information is available" is shown in the examples for this case.</p>
+				
+				<p>In some cases, the distributer may not be allowed to show statements the publisher did not make.
+					Hiding such sections is acceptable in these cases.</p>
+			</section>
 
-		<p>These guidelines help those who wish to render accessibility
-			metadata directly to users understand how to
-			represent the accessibility claims inherent in
-			machine-readable accessibility metadata in a
-			user-friendly User Interface / User Experience (UI/UX). This
-			document targets implementers such as
-			bookstores, libraries, retailers, distributors etc. Content
-			creators will benefit from reading these guidelines and
-			are encouraged to follow <a
-				href="https://www.w3.org/TR/epub-a11y-11/">EPUB
-				Accessibility 1.1
-				Conformance and Discoverability Requirements section and
-				its techniques.</a></p>
-
-		<div class="note">
-			<p>This document presents high-level guidelines without
-				going into technical issues related to the
-				different metadata standards in the publishing industry.
-			</p>
-			<p>Therefore, <a href="#techniques">techniques are
-					available</a> that illustrate to developers how to
-				retrieve data to show the information outlined in this
-				document.</p>
-		</div>
-
-		<p>Metadata found either inside a digital publication or in a
-			corresponding external record may have
-			important accessibility claims that help end users find and
-			determine if the publication can meet their
-			specific accessibility needs.</p>
-
-		<p>This accessibility metadata uses controlled vocabularies to
-			allow it to be extracted and displayed uniformly across
-			different publications and localized to different user
-			interface languages. The one exception is the accessibility
-			summary, which allows accessibility statements that are
-			unique to a publication and that adds information not
-			covered by other metadata entries.</p>
-
-		<p>One important aspect is that the role of the Accessibility
-			Summary metadata has changed in the latest
-			version of the EPUB Accessibility specification, so a more
-			in-depth analysis in the <a
-				href="#accessibility-summary">Accessibility summary</a>
-			section is recommended.</p>
-
-		<p>This document offers guidance on how to aggregate and display
-			claims inherent in metadata to end users;
-			these are not strict guidelines, but suggestions for
-			providing a consistent experience for users through
-			different portals. Different implementers may choose to
-			implement these guidelines in a slightly
-			different way. Some examples can be seen in the <a
-				href="#implementations">Implementations</a> section
-			of the document.</p>
-
-		<section id="accessibility-claims">
-			<h2>Accessibility claims and declarations</h2>
-
-			<p>When presenting accessibility metadata provided by the
-				publisher, it is suggested that the section is
-				introduced using terms such as "claims" or
-				"declarations." This heading should clearly convey to
-				the
-				end user that the information comes directly from the
-				publisher and represents the accessibility
-				information that the publisher intends to communicate.
-			</p>
+			<section id="techniques">
+				<h3>Display techniques</h3>
+				
+				<p>To assist developers in implementing these guidelines,
+					in-depth notes are available to explain how to
+					extract information from publishing industry metadata
+					standards.</p>
+				
+				<p>At the time of publishing this document the available
+					techniques for metadata standards are:</p>
+				
+				<ul>
+					<li>
+						<p><a href="../techniques/epub-metadata/index.html">EPUB
+								Accessibility Metadata</a></p>
+					</li>
+					<li>
+						<p><a href="../techniques/onix-metadata/index.html">ONIX
+								Accessibility Metadata</a></p>
+					</li>
+				</ul>
+				
+				<div class="note">
+					<p>Publishers update their ONIX records as needed. We
+						expect "unknown" accessibility metadata may be
+						initially provided but may change as more
+						information becomes available. For this reason,
+						implementors should be prepared to update the
+						accessibility metadata as new ONIX feeds are made
+						available.</p>
+				</div>
+			</section>
 		</section>
-
-		<section id="processing-guide">
-			<h2>Metadata processing overview</h2>
-
-			<p>The following diagram depicts how these guidelines relate
-				to the format-specific techniques in the
-				process of receiving and displaying accessibility
-				metadata.</p>
-
-			<img class="responsive" src="media/MetadataProcessing.png"
-				aria-details="ecosystem"
-				alt="Outline of the processing for EPUB, PDF, ONIX and MARC metadata. Description follows." />
-
-			<div class="note">
-				<p>Work on integrating PDF and MARC is ongoing. The
-					diagram and text of this section will be updated
-					in future versions as the related documents are
-					finalized.</p>
-			</div>
-
-			<p>The diagram categorizes two ways that metadata
-				accompanies a publication. In the first are digital
-				publication formats that directly embed accessibility
-				metadata (EPUB and PDF). In the second are
-				external metadata record formats (ONIX and MARC) that
-				accompany a digital publication as it moves
-				through the supply chain.</p>
-
-			<p>In some cases, a digital publication may include both
-				internal and external metadata (e.g., an EPUB
-				could have accessibility metadata in it package document
-				and also be provided to a vendor with an
-				ONIX record). In these cases, vendors and reading system
-				developers determine for themselves which
-				set of metadata they will use to display to users.</p>
-
-			<div class="note">
-				<p>This guide assumes the metadata is already in one of
-					the formats described in the diagram, but
-					depending on how the metadata is submitted it may
-					need to be transformed. For example, if a vendor
-					prefers to handle only ONIX metadata for display
-					Then they would need to preprocess the metadata
-					embedded in an EPUB or PDF to create the ONIX.</p>
-				<p>The process of transforming metadata is not it scope
-					for this document nor is how to reconcile
-					metadata when it is provided in multiple forms. The
-					guide assumes any processing has already
-					occurred. For information on mapping between
-					formats, refer to the <a
-						href="https://w3c.github.io/publ-a11y/drafts/a11y-crosswalk-MARC/">Accessibility
-						Properties
-						Crosswalk</a>.</p>
-			</div>
-
-			<p>The next level of the diagram depicts the encoding
-				standards expected for each format. This guide
-				assumes that the metadata conforms to a recognized
-				standard, otherwise it would be difficult to
-				anticipate and process the incoming information for
-				users:</p>
-
-			<ul>
-				<li>For EPUB, the EPUB Accessibility standard
-					[[epub-a11y-11]] defines required and recommended
-					metadata for accessible publications. Guidance on
-					applying this metadata is found in the EPUB
-					Accessibility techniques [[epub-a11y-tech-11]].</li>
-				<li>For ONIX, the accessibility characteristics of the
-					corresponding digital publication are
-					expressed using <a
-						href="https://ns.editeur.org/onix/en">code
-						lists</a> [[onix]], and guidance
-					on applying these values is defined in the
-					application note <a
-						href="https://www.editeur.org/files/ONIX%203/APPNOTE%20Accessibility%20metadata%20in%20ONIX%20(advanced).pdf">Providing
-						accessibility metadata in ONIX (advanced)</a>.
-				</li>
-				<li>For PDF, the PDF/UA standard
-					[[iso14289-1]][[iso14289-2]] and <a
-						href="https://pdfa.org/wtpdf/">Well-Tagged PDF
-						guide</a> define how to describe accessibility
-					metadata.</li>
-			</ul>
-
-			<p>Knowing how the metadata is encoded and how it is
-				expressed, the next stage of processing is to use
-				the algorithms defined in the respective techniques
-				documents to discover and translate the
-				information into human-readable statements. These
-				documents are intended primarily for developers,
-				to help them with the specific processing of the
-				metadata markup grammars.</p>
-
-			<p>Finally, this document is shown at the last stage of
-				processing, as it defines the purpose of each
-				piece of metadata in more detail and prioritizes the
-				display for readers.</p>
+		
+		<section id="alt-statements">
+			<h3>Alternative statements</h3>
+		
+			<p>&#8230;</p>
 		</section>
-
-		<section id="techniques">
-			<h3>Metadata techniques</h3>
-
-			<p>To assist developers in implementing these guidelines,
-				in-depth notes are available to explain how to
-				extract information from publishing industry metadata
-				standards.</p>
-
-			<p>At the time of publishing this document the available
-				techniques for metadata standards are:</p>
-
+		
+		<section id="non-a11y-meta">
+			<h3>Non-accessibility metadata</h3>
+			
+			<p>The product details provide important information about the usability of the e-book in relation to 
+				specific user needs. The following information should always be displayed:</p>
+			
 			<ul>
-				<li>
-					<p><a href="../techniques/epub-metadata/index.html">EPUB
-							Accessibility Metadata</a></p>
-				</li>
-				<li>
-					<p><a href="../techniques/onix-metadata/index.html">ONIX
-							Accessibility Metadata</a></p>
-				</li>
-			</ul>
-
-			<div class="note">
-				<p>Publishers update their ONIX records as needed. We
-					expect "unknown" accessibility metadata may be
-					initially provided but may change as more
-					information becomes available. For this reason,
-					implementors should be prepared to update the
-					accessibility metadata as new ONIX feeds are made
-					available.</p>
-			</div>
-		</section>
-	</section>
-	<section id="general-info">
-		<h2>General information</h2>
-
-		<p>To solve the problem of displaying the accessibility metadata
-			in a human readable form, vendors will
-			determine their correct statement to display (from the
-			Accessibility Metadata Display Guide for Digital
-			Publications) by parsing the metadata and using the
-			appropriate Display Techniques document. </p>
-
-		<p>The product details provide precious information about the
-			usability of the e-book in relation to specific
-			user needs. The following information should always be
-			displayed:</p>
-
-		<ul>
-			<li> File format (EPUB 2 or 3, PDF, MP3, Audiobook, etc.)
-			</li>
-			<li> Protection measure or lack thereof </li>
-			<li> Name of the publishing house </li>
-			<li> Main language of the content </li>
-		</ul>
-		<section>
-			<h3>Why this information is important for accessibility</h3>
-
-			<ul>
-				<li> The file format gives a strong indication of
+				<li>File format (EPUB 2 or 3, PDF, MP3, Audiobook, etc.) &#8212;
+					The file format gives a strong indication of
 					accessibility: a PDF does not allow for typography
 					modification, EPUB 2 is
 					deprecated, an EPUB 3 support page navigation and
 					better structural semantics; an MP3 format audiobook
-					will be
-					less structured than an Audiobook, etc. </li>
-				<li> The protection measure may block assistive
+					will be less structured than an Audiobook, etc.</li>
+				
+				<li>Protection measure or lack thereof &#8212; The 
+					protection measure may block assistive
 					technologies such as screen readers. In addition,
 					many specific eReading devices such as DAISY readers
 					or Braille note takers are not equipped to read
-					encrypted files. </li>
-
-				<li> The name of the publishing house can highlight the
+					encrypted files.</li>
+				
+				<li>Name of the publishing house  &#8212; The name of the 
+					publishing house can highlight the
 					efforts it has made in terms of
-					accessibility. </li>
-				<li> The main language of the content enables readers to
+					accessibility.</li>
+				
+				<li>Main language of the content &#8212; The main language 
+					of the content enables readers to
 					be confident that they will be able to read
 					with their Assistive Technology that uses
 					synthesized voice or the corresponding braille
 					translation table
-					for the language. </li>
+					for the language.</li>
 			</ul>
 		</section>
 	</section>
+	
 	<section id="order-of-key-information">
 		<h2>Key accessibility information</h2>
 
-		<section id="intro-key-info" class="introductory">
-			<h3>Introduction to key accessibility information</h3>
-
-			<p>When focusing on the accessibility of any digital
-				publication, several areas of key information come to
-				mind:</p>
-
-			<ul>
-				<li>People who need to adjust the visual presentation
-					want to know if they can enlarge the text,
-					which is essential for low vision users. People with
-					dyslexia must be able to select the font
-					and adjust the foreground, background, and line
-					spacing and length. People with low vision and
-					dyslexia
-					represent the largest percentage of the
-					print-disabled population.</li>
-				<li>People who use a screen reader need to know if all
-					the content in the title will be accessible
-					to them. When images have text descriptions (alt
-					text), they are assured that they will be not
-					missing out on essential information. Blind users
-					will greatly benefit from this information as
-					well as individuals who use the read aloud feature
-					in Reading Systems.</li>
-				<li> People who are selecting materials for public
-					institutions such as libraries or schools need
-					to know if the content conforms to accepted
-					standards.</li>
-			</ul>
-
-			<p>This is why these guidelines recommend that the following areas
-				of key information should be
-				displayed:</p>
-
-			<ul>
-				<li>Visual adjustments</li>
-				<li>Support for nonvisual reading</li>
-				<li>Conformance</li>
-			</ul>
-
-			<p>The other areas provide details about specific
-				features or shortcomings in publications. It is
-				expected that these other areas of key information will
-				give people what they need to make an
-				informed choice to read a particular e-book.</p>
-<div class="note"><p>When no accessibility metadata is being provided by the publisher, it is best to avoid making a negative statement, which could be attributed to the publisher. The distributer may not be allowed to show statements the publisher did not make.  The neutral statement "No information is available" is shown in the examples for this case.</p></div>
-
-			<div class="note">
-				<p>This document does not define the order in which to
-					show the key accessibility information; each
-					implementer can decide the preferred order and appropriate headings to use to show the accessibility information that
-					follows.</p>
-				<p>In this document are examples of important metadata
-					that is expected to be in a wide range of
-					publications. However, we do not have examples of
-					all possible features that the metadata can
-					express. The techniques have more values than are
-					shown in the examples.</p>
-			</div>
-		</section>
 		<section id="ways-of-reading">
 			<h3 data-localization-id="ways-of-reading-title">Ways of reading</h3>
 
@@ -2118,7 +2131,6 @@
 			</section>
 		</section>
 </section>
-
 	<section id="discovering-accessible-content">
 		<h2>Discovering accessible content</h2>
 

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -554,7 +554,8 @@
 		<section id="alt-statements">
 			<h3>Alternative statements</h3>
 		
-			<p>&#8230;</p>
+			<p>Although the display statements listed in this document and in the techniques are recommended
+				for use, it is possible to use alternative statements if the situation requires.</p>
 		</section>
 		
 		<section id="non-a11y-meta">


### PR DESCRIPTION
Open this as a draft pull request to get feedback on the restructuring. I still have to add some text about the use of alternative strings.

In a nutshell, I've taken the three preliminary sections plus the unnumbered section in the key accessibility section and combined them into two new sections.

The first is named "Introduction" and contains the overview (which is a combination of the previous overviews), the processing diagram, and the terminology.

The second section I've named "Metadata display" as it contains all the other sections that were describing different requirements for displaying the key information.

Let me know if you have any problems with this, or spot anything amiss, otherwise I'll switch it to a regular pull request once I get the additional text written.

***

[Preview](https://raw.githack.com/w3c/publ-a11y/fix/intro/a11y-meta-display-guide/2.0/draft/guidelines/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/intro/a11y-meta-display-guide/2.0/draft/guidelines/index.html)
