### PR TITLE
Fixed two names in links to techniques

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -875,12 +875,9 @@
 					<ul>
 						<li><a
 								href="../techniques/epub-metadata/index.html#prerecorded-audio">EPUB
-								Accessibility: Full
-								audio</a></li>
+								Accessibility: Prerecorded audio</a></li>
 						<li><a
-								href="../techniques/onix-metadata/index.html#prerecorded-audio">ONIX:
-								Full
-								audio</a></li>
+								href="../techniques/onix-metadata/index.html#prerecorded-audio">ONIX: Prerecorded audio</a></li>
 					</ul>
 				</section>
 			</section>
@@ -2119,10 +2116,10 @@
 				<ul>
 					<li><a
 							href="../techniques/epub-metadata/index.html#additional-accessibility-information">EPUB
-							Accessibility: Book Features</a></li>
+							Accessibility: Additional accessibility information</a></li>
 					<li><a
 							href="../techniques/onix-metadata/index.html#additional-accessibility-information">ONIX:
-							Book Features</a></li>
+							Additional accessibility information</a></li>
 				</ul>
 			</section>
 		</section>


### PR DESCRIPTION
Fixed links to Prerecorded audio and Additional accessibility information  in the go to the techniques.

I also discovered a bug in NVDA or Chrome. The link takes you to the right place in the techniques, but as soon as you press a key, it moves you to a different location. This threw me off until I figured out the problem with NVDA.

So, it ended up being an easy fix.