### PR TITLE
Add ids and modes to example strings

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -2084,9 +2084,9 @@
 
 					<dt>If there are tactile graphics:</dt>
 					<dd>
-						<p data-localization-id="additional-accessibility-information-adaptation-tactile_graphics"
+						<p data-localization-id="additional-accessibility-information-adaptation-tactile-graphics"
 							data-localization-mode="compact">Tactile graphics included</p>
-						<p data-localization-id="additional-accessibility-information-adaptation-tactile_graphics"
+						<p data-localization-id="additional-accessibility-information-adaptation-tactile-graphics"
 							data-localization-mode="descriptive">Tactile graphics have been integrated to
 							facilitate access to visual elements for
 							blind people</p>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -894,24 +894,33 @@
 						<dt>Compact display</dt>
 						<dd>
 							<p class="ex-hd" data-localization-id="ways-of-reading-title">Ways of reading</p>
-							<p>Appearance can be modified</p>
-							<p>Readable in read aloud or dynamic braille</p>
-							<p>Has alternative text</p>
-							<p>Prerecorded audio synchronized with text</p>
+							<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
+								data-localization-mode="compact">Appearance can be modified</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
+								data-localization-mode="compact">Readable in
+								read aloud or dynamic braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
+								data-localization-mode="compact">Has alternative text</p>
+							<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
+								data-localization-mode="compact">Prerecorded audio synchronized with text</p>
 						</dd>
 
 						<dt>Descriptive display</dt>
 						<dd>
 							<p class="ex-hd" data-localization-id="ways-of-reading-title">Ways of reading</p>
-							<p>Appearance of the text and page layout can be
+							<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
+								data-localization-mode="descriptive">Appearance of the text and page layout can be
 								modified according to the capabilities of
 								the reading system (font family and font size,
 								spaces between paragraphs, sentences, words,
 								and letters, as well as color of background
 								and text)</p>
-							<p>All content can be read as read aloud speech or dynamic braille</p>
-							<p>Has alternative text descriptions for images</p>
-							<p>All the content is available as prerecorded audio synchronized with text</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
+								data-localization-mode="descriptive">All content can be read as read aloud speech or dynamic braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
+								data-localization-mode="descriptive">Has alternative text descriptions for images</p>
+							<p data-localization-id="ways-of-reading-prerecorded-audio-synchronized"
+								data-localization-mode="descriptive">All the content is available as prerecorded audio synchronized with text</p>
 						</dd>
 					</dl>
 				</aside>
@@ -1438,8 +1447,10 @@
 						<dd>
 							<p class="ex-hd" data-localization-id="navigation-title">Navigation</p>
 							<ul>
-								<li>Table of contents</li>
-								<li>Go to page</li>
+								<li data-localization-id="navigation-toc"
+									data-localization-mode="compact">Table of contents</li>
+								<li data-localization-id="navigation-page-navigation"
+									data-localization-mode="compact">Go to page</li>
 							</ul>
 						</dd>
 
@@ -1447,8 +1458,12 @@
 						<dd>
 							<p class="ex-hd" data-localization-id="navigation-title">Navigation</p>
 							<ul>
-								<li>Table of contents to all chapters of the text via links</li>
-								<li>Page list to go to pages from the print source version</li>
+								<li data-localization-id="navigation-toc"
+									data-localization-mode="descriptive">Table of contents to all 
+									chapters of the text via links</li>
+								<li data-localization-id="navigation-page-navigation"
+									data-localization-mode="compact">Page list to go to pages from 
+									the print source version</li>
 							</ul>
 						</dd>
 					</dl>
@@ -1586,9 +1601,12 @@
 						<dd>
 							<p class="ex-hd" data-localization-id="rich-content-title">Rich content</p>
 							<ul>
-								<li>Math as MathML</li>
-								<li>Videos have closed captions</li>
-								<li>Transcript(s) provided)</li>
+								<li data-localization-id="rich-content-accessible-math-as-mathml"
+									data-localization-mode="compact">Math as MathML</li>
+								<li data-localization-id="rich-content-closed-captions"
+									data-localization-mode="compact">Videos have closed captions</li>
+								<li data-localization-id="rich-content-transcript"
+									data-localization-mode="compact">Transcript(s) provided)</li>
 							</ul>
 						</dd>
 
@@ -1596,9 +1614,12 @@
 						<dd>
 							<p class="ex-hd" data-localization-id="rich-content-title">Rich content</p>
 							<ul>
-								<li>Math formulas in accessible format (MathML)</li>
-								<li>Videos included in publications have closed captions</li>
-								<li>Transcript(s) provided)</li>
+								<li data-localization-id="rich-content-accessible-math-as-mathml"
+									data-localization-mode="descriptive">Math formulas in accessible format (MathML)</li>
+								<li data-localization-id="rich-content-closed-captions"
+									data-localization-mode="descriptive">Videos included in publications have closed captions</li>
+								<li data-localization-id="rich-content-transcript"
+									data-localization-mode="compact">Transcript(s) provided)</li>
 							</ul>
 						</dd>
 					</dl>
@@ -1736,13 +1757,15 @@
 						<dt>Compact display</dt>
 						<dd>
 							<p class="ex-hd" data-localization-id="hazards-title">Hazards</p>
-							<p>No hazards</p>
+							<p data-localization-id="hazards-none"
+								data-localization-mode="compact">No hazards</p>
 						</dd>
 
 						<dt>Descriptive display</dt>
 						<dd>
 							<p class="ex-hd" data-localization-id="hazards-title">Hazards</p>
-							<p>The publication contains no hazards</p>
+							<p data-localization-id="hazards-none"
+								data-localization-mode="descriptive">The publication contains no hazards</p>
 						</dd>
 					</dl>
 				</aside>
@@ -1923,13 +1946,15 @@
 						<dt>Compact display</dt>
 						<dd>
 							<p class="ex-hd" data-localization-id="legal-considerations-title">Legal considerations</p>
-							<p>Claims an accessibility exemption in some jurisdictions</p>
+							<p data-localization-id="legal-considerations-exempt"
+								data-localization-mode="compact">Claims an accessibility exemption in some jurisdictions</p>
 						</dd>
 
 						<dt>Descriptive display</dt>
 						<dd>
 							<p class="ex-hd" data-localization-id="legal-considerations-title">Legal considerations</p>
-							<p>This publication claims an accessibility exemption in some jurisdictions</p>
+							<p data-localization-id="legal-considerations-exempt"
+								data-localization-mode="descriptive">This publication claims an accessibility exemption in some jurisdictions</p>
 						</dd>
 					</dl>
 				</aside>
@@ -2040,32 +2065,39 @@
 				<dl>
 					<dt>If there are ARIA roles:</dt>
 					<dd>
-						<p data-localization-mode="compact">ARIA roles included</p>
-						<p data-localization-mode="descriptive">Content is enhanced with ARIA roles to
+						<p data-localization-id="additional-accessibility-information-clarity-aria"
+							data-localization-mode="compact">ARIA roles included</p>
+						<p data-localization-id="additional-accessibility-information-clarity-aria"
+							data-localization-mode="descriptive">Content is enhanced with ARIA roles to
 							optimize organization and facilitate
 							navigation</p>
 					</dd>
 
 					<dt>If there are page break markers:</dt>
 					<dd>
-						<p data-localization-mode="compact">Page breaks included</p>
-						<p data-localization-mode="descriptive">Page breaks included from the original print
+						<p data-localization-id="additional-accessibility-information-clarity-page-breaks"
+							data-localization-mode="compact">Page breaks included</p>
+						<p data-localization-id="additional-accessibility-information-clarity-page-breaks"
+							data-localization-mode="descriptive">Page breaks included from the original print
 							source</p>
 					</dd>
 
 					<dt>If there are tactile graphics:</dt>
 					<dd>
-						<p data-localization-mode="compact">Tactile graphics included</p>
-						<p data-localization-mode="descriptive">Tactile graphics have been integrated to
+						<p data-localization-id="additional-accessibility-information-adaptation-tactile_graphics"
+							data-localization-mode="compact">Tactile graphics included</p>
+						<p data-localization-id="additional-accessibility-information-adaptation-tactile_graphics"
+							data-localization-mode="descriptive">Tactile graphics have been integrated to
 							facilitate access to visual elements for
-							blind
-							people</p>
+							blind people</p>
 					</dd>
 
 					<dt>If no metadata is provided:</dt>
 					<dd>
-						<p data-localization-mode="compact">No information is available</p>
-						<p data-localization-mode="descriptive">No information is available</p>
+						<p data-localization-id="additional-accessibility-information-no-metadata"
+							data-localization-mode="compact">No information is available</p>
+						<p data-localization-id="additional-accessibility-information-no-metadata"
+							data-localization-mode="descriptive">No information is available</p>
 					</dd>
 				</dl>
 			</section>
@@ -2073,17 +2105,19 @@
 			<section id="add-info-examples">
 				<h5>Examples</h5>
 
-				<aside class="example" title="Publication with ARIA roles">
+				<aside class="example" title="Publication with ARIA roles and page breaks">
 					<p>The following example shows the descriptive and compact statements that would display
-						for a publication that includes ARIA roles and has visible static page numbers.</p>
+						for a publication that includes ARIA roles and has static page numbers.</p>
 
 					<dl>
 						<dt>Compact display</dt>
 						<dd>
 							<p class="ex-hd" data-localization-id="additional-accessibility-information-title">Additional accessibility information</p>
 							<ul>
-								<li>ARIA roles included</li>
-								<li>Page breaks included</li>
+								<li data-localization-id="additional-accessibility-information-clarity-aria"
+									data-localization-mode="compact">ARIA roles included</li>
+								<li data-localization-id="additional-accessibility-information-clarity-page-breaks"
+									data-localization-mode="compact">Page breaks included</li>
 							</ul>
 						</dd>
 
@@ -2091,8 +2125,11 @@
 						<dd>
 							<p class="ex-hd" data-localization-id="additional-accessibility-information-title">Additional accessibility information</p>
 							<ul>
-								<li>Content is enhanced with ARIA roles to optimize organization and facilitate navigation</li>
-								<li>Page breaks included from the original print source</li>
+								<li data-localization-id="additional-accessibility-information-clarity-aria"
+									data-localization-mode="descriptive">Content is enhanced with ARIA roles to 
+									optimize organization and facilitate navigation</li>
+								<li data-localization-id="additional-accessibility-information-clarity-page-breaks"
+									data-localization-mode="descriptive">Page breaks included from the original print source</li>
 							</ul>
 						</dd>
 					</dl>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -2091,14 +2091,6 @@
 							facilitate access to visual elements for
 							blind people</p>
 					</dd>
-
-					<dt>If no metadata is provided:</dt>
-					<dd>
-						<p data-localization-id="additional-accessibility-information-no-metadata"
-							data-localization-mode="compact">No information is available</p>
-						<p data-localization-id="additional-accessibility-information-no-metadata"
-							data-localization-mode="descriptive">No information is available</p>
-					</dd>
 				</dl>
 			</section>
 


### PR DESCRIPTION
This is mostly a straightforward add of missing attributes, but I did come across a couple of oddities:

- Why do we have a "no information is available" string for the additional accessibility information section? Wouldn't the section just be suppressed if there is nothing else to report? I don't see this string in the localization file, so can I delete it from the guidelines? (None of the strings in this section were tagged so it probably wasn't caught by the script that compares them.)
- The ID for tactile graphics uses an underscore instead of a dash. Can this be standardized?

***

[Preview](https://raw.githack.com/w3c/publ-a11y/fix/ex-tagging/a11y-meta-display-guide/2.0/draft/guidelines/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/ex-tagging/a11y-meta-display-guide/2.0/draft/guidelines/index.html)
