### PR TITLE
Add string IDs using javascript

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/common/js/add_ids.js
+++ b/a11y-meta-display-guide/2.0/draft/common/js/add_ids.js
@@ -1,0 +1,13 @@
+
+function addStringIDs() {
+	
+	var id_elements = document.querySelectorAll('code[id]');
+	var code_array = [...id_elements];
+	
+	code_array.forEach(code => {
+		var id_span = document.createElement('span');
+			id_span.classList.add('str-id')
+			id_span.appendChild(document.createTextNode('[ID: ' + code.id + ']'));
+		code.insertAdjacentElement('beforeEnd', id_span);
+	});
+}

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>Display Techniques for EPUB Accessibility Metadata 2.0</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
+		<script src="../../common/js/add_ids.js" class="remove"></script>
 		<script class="remove">
 			// <![CDATA[
 			var respecConfig = {
@@ -29,7 +30,8 @@
 				github:			 {
 					repoURL: "https://github.com/w3c/publ-a11y/",
 					branch: "main"
-				}
+				},
+				preProcess: [addStringIDs]
 			};
 			// ]]>
 	  </script>
@@ -51,16 +53,13 @@
 	  	code.xpath {
 	  		word-break: keep-all;
 	  	}
-	  	code[id]::before, code[id]::after {
+	  	span.str-id {
 			background: #faa;
 			border-radius: 3px;
 			font: normal normal 400 1em/1.2 monospace;
-			margin-left: 0.2em;
+			margin-left: 0.5em;
 			padding: 0.1em;
-		}
-              code[id]::after {
-                  content: "[ID: " attr(id) "]";
-              }
+	  	}
 	  </style>
 	</head>
 	<body>

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>Display Techniques for ONIX Accessibility Metadata 2.0</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
+		<script src="../../common/js/add_ids.js" class="remove"></script>
 		<script class="remove">
 			// <![CDATA[
 			var respecConfig = {
@@ -40,7 +41,8 @@
 				github:			 {
 					repoURL: "https://github.com/w3c/publ-a11y/",
 					branch: "main"
-				}
+				},
+				preProcess: [addStringIDs]
 			};
 			// ]]>
 	  </script>
@@ -62,16 +64,13 @@
 	  	code.xpath {
 	  		word-break: keep-all;
 	  	}
-	  	code[id]::before, code[id]::after {
+	  	span.str-id {
 			background: #faa;
 			border-radius: 3px;
 			font: normal normal 400 1em/1.2 monospace;
-			margin-left: 0.2em;
+			margin-left: 0.5em;
 			padding: 0.1em;
-		}
-		code[id]::after {
-			content: "[ID: " attr(id) "]";
-		}
+	  	}
 	  </style>
 	</head>
 	<body>


### PR DESCRIPTION
Switches from using the css ::after pseudo-selector to inject the ID strings to javascript to avoid browsers not allowing you to search for or select the values.

***

[EPUB Preview](https://raw.githack.com/w3c/publ-a11y/fix/id-inject/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html) | [EPUB Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/id-inject/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html)
[ONIX Preview](https://raw.githack.com/w3c/publ-a11y/fix/id-inject/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html) | [ONIX Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/id-inject/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html)

