### PR TITLE
Change uses of "key info" that aren't about the recommended display fields

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -444,7 +444,7 @@
 			</section>
 
 			<section id="rec-fields">
-				<h4>Recommended fields</h4>
+				<h4>Recommended display fields</h4>
 
 				<p>When focusing on the accessibility of any digital
 					publication, several areas of key information come to
@@ -477,7 +477,7 @@
 				</ul>
 
 				<p>This is why these guidelines recommend that the following <a
-						href="#order-of-key-information">key accessibility information</a> should be
+						href="#order-of-information">accessibility fields</a> should be
 					displayed:</p>
 
 				<ul>
@@ -488,11 +488,11 @@
 				</ul>
 
 				<p>The other areas provide details about specific features or shortcomings in publications. It is
-					expected that these other areas of key information will give people what they need to make an
+					expected that these other areas of information will give people what they need to make an
 					informed choice to read a particular e-book.</p>
 
 				<div class="note">
-					<p>This document does not define the order in which to show the key accessibility information; each
+					<p>This document does not define the order in which to show the accessibility information; each
 						implementer can decide the preferred order and appropriate headings to use to show the
 						accessibility information that follows.</p>
 				</div>
@@ -596,8 +596,8 @@
 		</section>
 	</section>
 
-	<section id="order-of-key-information">
-		<h2>Key accessibility information</h2>
+	<section id="order-of-information">
+		<h2>Accessibility display fields</h2>
 
 		<section id="ways-of-reading">
 			<h3 data-localization-id="ways-of-reading-title">Ways of reading</h3>
@@ -606,7 +606,7 @@
 				<h4>Visual adjustments</h4>
 
 				<div class="note">
-					<p>This key information should be displayed, even
+					<p>This dispaly field should be displayed even
 						if there is no metadata (See the examples
 						where "No information is available"). </p>
 				</div>
@@ -615,7 +615,7 @@
 					and the page layout according to the
 					possibilities offered by the reading system.</p>
 
-				<p>This field answers whether visual adjustments are
+				<p>This display field answers whether visual adjustments are
 					possible, not possible, or unknown.</p>
 
 				<p>Readers with visual impairments or cognitive disabilities
@@ -702,7 +702,7 @@
 				<h4>Support for nonvisual reading</h4>
 
 				<div class="note">
-					<p>This key information should be displayed, even
+					<p>This display field should be displayed even
 						if there is no metadata (See the examples
 						where "No information is available"). </p>
 				</div>
@@ -712,7 +712,7 @@
 					available to reading systems with [=read aloud speech=]
 					or [=dynamic braille=] capabilities.</p>
 
-				<p>This field answers whether nonvisual reading is possible,
+				<p>This display field answers whether nonvisual reading is possible,
 					not possible, or unknown.</p>
 
 				<p>Digital publications with essential content included in
@@ -802,7 +802,7 @@
 				<h4>Prerecorded audio</h4>
 
 				<div class="note">
-					<p>This key information can be hidden if metadata is
+					<p>This display field can be hidden if metadata is
 						missing. Alternatively it can be stated that
 						<span
 							data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
@@ -930,7 +930,7 @@
 			<h3 data-localization-id="conformance-title">Conformance</h3>
 
 			<div class="note">
-				<p>This key information should be displayed, even
+				<p>This display field should be displayed even
 					if there is no metadata (See the examples
 					where "No information is available"). </p>
 			</div>
@@ -1350,7 +1350,7 @@
 			<h3 data-localization-id="navigation-title">Navigation</h3>
 
 			<div class="note">
-				<p>This key information can be hidden if metadata is
+				<p>This display field can be hidden if metadata is
 					missing. Alternatively it can be stated that
 					<span data-localization-id="navigation-no-metadata"
 						data-localization-mode="descriptive">No information is available</span>.
@@ -1491,7 +1491,7 @@
 			<h3 data-localization-id="rich-content-title">Rich content</h3>
 
 			<div class="note">
-				<p>This key information can be hidden if metadata is
+				<p>This display field can be hidden if metadata is
 					missing. Alternatively it can be stated that
 					<span
 						data-localization-id="rich-content-unknown"
@@ -1648,7 +1648,7 @@
 			<h3 data-localization-id="hazards-title">Hazards</h3>
 
 			<div class="note">
-				<p>This key information can be hidden if metadata is
+				<p>This display field can be hidden if metadata is
 					missing. Alternatively it can be stated that
 					<span data-localization-id="hazards-no-metadata"
 						data-localization-mode="descriptive">No information is available</span>
@@ -1793,7 +1793,7 @@
 				Accessibility summary</h3>
 
 			<div class="note">
-				<p>This key information can be hidden if metadata is
+				<p>This display field can be hidden if metadata is
 					missing. Alternatively it can be stated that
 					<span
 						data-localization-id="accessibility-summary-no-metadata"
@@ -1859,7 +1859,7 @@
 				considerations</h3>
 
 			<div class="note">
-				<p>This key information should be hidden if metadata is
+				<p>This display field should be hidden if metadata is
 					not present .</p>
 			</div>
 
@@ -1982,7 +1982,7 @@
 				information</h3>
 
 			<div class="note">
-				<p>This key information can be hidden if metadata is
+				<p>This display field can be hidden if metadata is
 					missing.</p>
 			</div>
 

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -606,7 +606,7 @@
 				<h4>Visual adjustments</h4>
 
 				<div class="note">
-					<p>This dispaly field should be displayed even
+					<p>This display field should be rendered even
 						if there is no metadata (See the examples
 						where "No information is available"). </p>
 				</div>
@@ -702,7 +702,7 @@
 				<h4>Support for nonvisual reading</h4>
 
 				<div class="note">
-					<p>This display field should be displayed even
+					<p>This display field should be rendered even
 						if there is no metadata (See the examples
 						where "No information is available"). </p>
 				</div>
@@ -930,7 +930,7 @@
 			<h3 data-localization-id="conformance-title">Conformance</h3>
 
 			<div class="note">
-				<p>This display field should be displayed even
+				<p>This display field should be rendered even
 					if there is no metadata (See the examples
 					where "No information is available"). </p>
 			</div>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -196,7 +196,7 @@
             <section id="ways-of-reading">
                 <h3>Ways of reading</h3>
 
-                <p>This technique relates to <a href="../../guidelines/#way-of-reading">Ways of reading key information</a>.</p>
+                <p>This technique relates to the <a href="../../guidelines/#way-of-reading">Ways of reading accessibility display field</a>.</p>
   
                 <p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 
@@ -204,7 +204,7 @@
                 <section id="visual-adjustments">
                     <!-- https://www.w3.org/TR/pub-manifest/#manifest-processing -->
                     <h4>Visual adjustments</h4>
-                    <p>This technique relates to <a href="../../guidelines/#visual-adjustments">Visual adjustments key information</a>.</p>
+                    <p>This technique relates to the <a href="../../guidelines/#visual-adjustments">Visual adjustments accessibility display field</a>.</p>
   
                     <h5>Understanding the variables</h5>
                     <dl>
@@ -245,7 +245,7 @@
 
                 <section id="supports-nonvisual-reading">
                     <h4>Supports nonvisual reading</h4>
-                    <p>This technique relates to <a href="../../guidelines/#supports-nonvisual-reading">Supports nonvisual reading key information</a>.</p>
+                    <p>This technique relates to the <a href="../../guidelines/#supports-nonvisual-reading">Supports nonvisual reading accessibility display field</a>.</p>
 
                     <h5>Understanding the variables</h5>
                     <dl>
@@ -317,7 +317,7 @@
                 
                 <section id="prerecorded-audio">
                     <h4>Prerecorded audio</h4>
-                    <p>This technique relates to <a href="../../guidelines/#prerecorded-audio">Prerecorded audio key information</a>.</p>
+                    <p>This technique relates to the <a href="../../guidelines/#prerecorded-audio">Prerecorded audio accessibility display field</a>.</p>
 
                      <h5>Understanding the variables</h5>
                     <dl>
@@ -368,7 +368,7 @@
                         </li>
 
                         <li>
-                            <b>ELSE</b> either omit this key information if metadata is missing or display <code id="ways-of-reading-prerecorded-audio-no-metadata">"No information about prerecorded audio is available"</code>.
+                            <b>ELSE</b> either omit this display field if metadata is missing or display <code id="ways-of-reading-prerecorded-audio-no-metadata">"No information about prerecorded audio is available"</code>.
                         </li>
                     </ol>
                 </section>
@@ -377,7 +377,7 @@
 
 			<section id="conformance-group">
 				<h3>Conformance</h3>
-				<p>This technique relates to <a href="../../guidelines/#conformance-group">Conformance key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#conformance-group">Conformance accessibility display field</a>.</p>
 
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 
@@ -579,7 +579,7 @@
 
 	      <section id="navigation">
 			<h3>Navigation</h3>
-    	  	<p>This technique relates to <a href="../../guidelines/#navigation">Navigation key information</a>.</p>
+    	  	<p>This technique relates to the <a href="../../guidelines/#navigation">Navigation accessibility display field</a>.</p>
                 <p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 
 				<h4>Understanding the variables</h4>
@@ -648,14 +648,14 @@
 
 
 					<li>
-						<b>ELSE</b> either omit this key information if metadata is missing or display <code id="navigation-no-metadata">"No information is available"</code>.
+						<b>ELSE</b> either omit this display field if metadata is missing or display <code id="navigation-no-metadata">"No information is available"</code>.
 					</li>
 				</ol>
 			</section>
 
 			<section id="rich-content">
 				<h3>Rich content</h3>
-				<p>This technique relates to <a href="../../guidelines/#rich-content">Charts, diagrams, math, and formulas key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#rich-content">Rich content accessibility display field</a>.</p>
 
                 <p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 				<h4>Understanding the variables</h4>
@@ -782,14 +782,14 @@
 					</li>
 					<li>
 						<span><b>IF</b> <b>NOT</b> (<var>math_formula_as_mathml</var> <b>OR</b> <var>math_formula_as_latex</var> <b>OR</b> (<var>contains_math_formula</var> <b>AND</b> <var>long_text_descriptions</var>) <b>OR</b> <var>chemical_formula_as_mathml</var> <b>OR</b> <var>long_text_descriptions</var> <b>OR</b> <var>closed_captions</var> <b>OR</b> <var>open_captions</var> <b>OR</b> <var>transcript</var>):</span>
-						<span><b>THEN</b> either omit this key information if metadata is missing or display <code id="rich-content-unknown">"No information is available"</code>.</span>
+						<span><b>THEN</b> either omit this display field if metadata is missing or display <code id="rich-content-unknown">"No information is available"</code>.</span>
 					</li>
 				</ol>
 			</section>
 
 			<section id="hazards">
 				<h3>Hazards</h3>
-				<p>This technique relates to <a href="../../guidelines/#hazards">Hazards key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#hazards">Hazards accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 
         <h4>Understanding the variables</h4>
@@ -892,7 +892,7 @@
 						<span><b>THEN</b> display <code id="hazards-unknown">"The presence of hazards is unknown"</code>.</span>
                     </li>
 					<li>
-						<b>ELSE</b> either omit this key information if metadata is missing or display <code id="hazards-no-metadata">"No information is available"</code>.
+						<b>ELSE</b> either omit this display field if metadata is missing or display <code id="hazards-no-metadata">"No information is available"</code>.
 
                     </li>
 				</ol>
@@ -901,7 +901,7 @@
 
 			<section id="accessibility-summary">
 				<h3>Accessibility summary</h3>
-				<p>This technique relates to <a href="../../guidelines/#accessibility-summary">Accessibility summary key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#accessibility-summary">Accessibility summary accessibility display field</a>.</p>
 
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 
@@ -952,7 +952,7 @@
 						<span><b>IF</b> <var>accessibility_summary</var> is <b>NOT</b> empty:</span>
 						<span><b>THEN</b> display the content of <var>accessibility_summary</var> with <var>language_accessibility_summary</var> as language.</span></li>
 					<li>
-						<b>ELSE</b> either omit this key informtion if metadata is missing or display <code id="accessibility-summary-no-metadata">"No information is available"</code>.
+						<b>ELSE</b> either omit this display field if metadata is missing or display <code id="accessibility-summary-no-metadata">"No information is available"</code>.
 					</li>
 				</ol>
 			</section>
@@ -961,7 +961,7 @@
 				<h3>Legal considerations</h3>
                 <div class="issue" data-number="350">We are actively seeking comments on this "legal consideration" section. If you are a publisher, we want your feedback! Please visit the GitHub Issue tracking linked above to leave a comment.</div>
 
-            	<p>This technique relates to <a href="../../guidelines/#legal-considerations">Legal considerations key information</a>.</p>
+            	<p>This technique relates to the <a href="../../guidelines/#legal-considerations">Legal considerations accessibility display field</a>.</p>
 
                  <p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 
@@ -997,7 +997,7 @@
 						<span><b>THEN</b> display <code id="legal-considerations-exempt">"Claims an accessibility exemption in some jurisdictions"</code>.</span>
 					</li>
 					<li>
-						<b>ELSE</b> either omit this key information if metadata is missing or display <code id="legal-considerations-no-metadata">"No information is available"</code>.
+						<b>ELSE</b> either omit this display field if metadata is missing or display <code id="legal-considerations-no-metadata">"No information is available"</code>.
 					</li>
 				</ol>
 			</section>
@@ -1005,7 +1005,7 @@
 
 			<section id="additional-accessibility-information">
 				<h3>Additional accessibility information</h3>
-				<p>This technique relates to <a href="../../guidelines/#additional-accessibility-information">Additional accessibility information key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#additional-accessibility-information">Additional accessibility information accessibility display field</a>.</p>
 
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -236,14 +236,14 @@
 			<section id="ways-of-reading">
                 <h3>Ways of reading</h3>
 
-                <p>This technique relates to <a href="../../guidelines/#way-of-reading">Ways of reading key information</a>.</p>
+                <p>This technique relates to the <a href="../../guidelines/#way-of-reading">Ways of reading accessibility display field</a>.</p>
   
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 
 
 				<section id="visual-adjustments">
 					<h3>Visual adjustments</h3>
-					<p>This technique relates to <a href="../../guidelines/#visual-adjustments">Visual adjustments key information</a>.</p>
+					<p>This technique relates to the <a href="../../guidelines/#visual-adjustments">Visual adjustments accessibility display field</a>.</p>
 					<h4>Understanding the variables</h4>
 					<dl>
 						<dt><var>all_textual_content_can_be_modified</var></dt>
@@ -279,7 +279,7 @@
 	
 				<section id="supports-nonvisual-reading">
 					<h3>Supports nonvisual reading</h3>
-					<p>This technique relates to <a href="../../guidelines/#supports-nonvisual-reading">Supports nonvisual reading key information</a>.</p>
+					<p>This technique relates to the <a href="../../guidelines/#supports-nonvisual-reading">Supports nonvisual reading accessibility display field</a>.</p>
 					<h4>Understanding the variables</h4>
 					<dl>
 						<dt><var>all_necessary_content_textual</var></dt>
@@ -348,7 +348,7 @@
 				
 				<section id="prerecorded-audio">
 					<h3>Prerecorded audio</h3>
-					<p>This technique relates to <a href="../../guidelines/#pre-recorded-audio">Pre-recorded audio key information</a>.</p>
+					<p>This technique relates to the <a href="../../guidelines/#pre-recorded-audio">Pre-recorded audio accessibility display field</a>.</p>
 					<h4>Understanding the variables</h4>
 					<dl>
 						<dt><var>audiobook</var></dt>
@@ -431,7 +431,7 @@
 							<span><b>THEN</b> display <code id="ways-of-reading-prerecorded-audio-synchronized">"Prerecorded audio synchronized with text"</code>.</span>
 						</li>
 						<li>
-							<b>ELSE</b> either omit this key information if metadata is missing or display <code id="ways-of-reading-prerecorded-audio-no-metadata">"No information about prerecorded audio is available"</code>.
+							<b>ELSE</b> either omit this display field if metadata is missing or display <code id="ways-of-reading-prerecorded-audio-no-metadata">"No information about prerecorded audio is available"</code>.
 						</li>
 					</ol>
 				</section>
@@ -439,7 +439,7 @@
 
 			<section id="conformance-group">
 				<h3>Conformance</h3>
-				<p>This technique relates to <a href="../../guidelines/#conformance-group">Conformance key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#conformance-group">Conformance accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
@@ -629,7 +629,7 @@
 
 			<section id="navigation">
 				<h3>Navigation</h3>
-				<p>This technique relates to <a href="../../guidelines/#navigation">Navigation key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#navigation">Navigation accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
@@ -686,14 +686,14 @@
 						</ol>
 					</li>
 					<li>
-						<b>ELSE</b> either omit this key information if metadata is missing or display <code id="navigation-no-metadata">"No information is available"</code>.
+						<b>ELSE</b> either omit this display field if metadata is missing or display <code id="navigation-no-metadata">"No information is available"</code>.
 					</li>
 				</ol>
 			</section>
 
 			<section id="rich-content">
 				<h3>Rich content</h3>
-				<p>This technique relates to <a href="../../guidelines/#rich-content">Rich content key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#rich-content">Rich content accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
@@ -803,14 +803,14 @@
 					</li>
 					<li>
 						<span><b>IF</b> <b>NOT</b> (<var>math_formula_as_mathml</var> <b>OR</b> <var>math_formula_as_latex</var> <b>OR</b> (<var>contains_math_formula</var> <b>AND</b> <var>short_textual_alternative_images</var>) <b>OR</b> <var>chemical_formula_as_mathml</var> <b>OR</b> <var>charts_diagrams_as_non_graphical_data</var> <b>OR</b> <var>full_alternative_textual_descriptions</var> <b>OR</b> <var>closed_captions</var> <b>OR</b> <var>open_captions</var> <b>OR</b> <var>transcript</var>):</span>
-						<span><b>THEN</b> either omit this key information if metadata is missing or display <code id="rich-content-unknown">"No information is available"</code>.</span>
+						<span><b>THEN</b> either omit this display field if metadata is missing or display <code id="rich-content-unknown">"No information is available"</code>.</span>
 					</li>
 				</ol>
 			</section>
 
 			<section id="hazards">
 				<h3>Hazards</h3>
-				<p>This technique relates to <a href="../../guidelines/#hazards">Hazards key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#hazards">Hazards accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
@@ -897,14 +897,14 @@
 					</li>
 					<li>
 						<b>ELSE</b> display <code id="hazards-no-metadata">"No information is available"</code>.
-						<aside class="note">This key information can be hidden if metadata is missing.</aside>
+						<aside class="note">This display field can be hidden if metadata is missing.</aside>
 					</li>
 				</ol>
 			</section>
 
 			<section id="accessibility-summary">
 				<h3>Accessibility summary</h3>
-				<p>This technique relates to <a href="../../guidelines/#accessibility-summary">Accessibility summary key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#accessibility-summary">Accessibility summary accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<aside class="note">
 					Being human-written, the accessibility summary and addendum will appear in the original language of the publication. Therefore it is necessary of take care of setting up the correct language tag information.
@@ -997,7 +997,7 @@
 						<span><b>THEN</b> display the content of <var>accessibility_summary</var> with <var>language_accessibility_summary</var> as language.</span>
 					</li>
 					<li>
-						<b>ELSE</b> either omit this key informtion if metadata is missing or display <code id="accessibility-summary-no-metadata">"No information is available"</code>.
+						<b>ELSE</b> either omit this display field if metadata is missing or display <code id="accessibility-summary-no-metadata">"No information is available"</code>.
 					</li>
 				</ol>
 			</section>
@@ -1005,7 +1005,7 @@
 			<section id="legal-considerations">
 				<h3>Legal considerations</h3>
 				<p class="issue" data-number="350">We are actively seeking comments on this "legal consideration" section. If you are a publisher, we want your feedback! Please visit the GitHub Issue tracking linked above to leave a comment.</p>
-				<p>This technique relates to <a href="../../guidelines/#legal-considerations">Legal considerations key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#legal-considerations">Legal considerations accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
@@ -1039,14 +1039,14 @@
 						<span><b>THEN</b> display <code id="legal-considerations-exempt">"Claims an accessibility exemption in some jurisdictions"</code>.</span>
 					</li>
 					<li>
-						<b>ELSE</b> either omit this key information if metadata is missing or display <code id="legal-considerations-no-metadata">"No information is available"</code>.
+						<b>ELSE</b> either omit this display field if metadata is missing or display <code id="legal-considerations-no-metadata">"No information is available"</code>.
 					</li>
 				</ol>
 			</section>
 
 			<section id="additional-accessibility-information">
 				<h3>Additional accessibility information</h3>
-				<p>This technique relates to <a href="../../guidelines/#additional-accessibility-information">Additional accessibility information key information</a>.</p>
+				<p>This technique relates to the <a href="../../guidelines/#additional-accessibility-information">Additional accessibility information accessibility display field</a>.</p>
 
 				<section id="additional-accessibility-information-adaptation">
 					<h3>Adaptation</h3>


### PR DESCRIPTION
The guidelines already had a more apt term in "fields", which was being used to call out the actual key ones for rendering purposes.

Most of this PR just changes "key information" to "display field" or "accessibility display fields" where we're relating the techniques back to the guidelines.  Section 3 is also renamed "Accessibility display fields".

If this doesn't work for anyone, or you want to suggest changes, please feel free to comment. This is just my thought on how we can stop overloading all the metadata as "key".
