### PR TITLE
Update conformance examples

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1144,19 +1144,6 @@
 			<section id="conf-examples">
 				<h4>Examples</h4>
 
-				<p>Four examples are provided for the conformance
-					statement, one shows a statement that claims to
-					meet recommended accessibility standards and a
-					second that claims to meet the minimum level. The
-					third example shows a publication with unknown
-					accessibility, and the final one shows that the
-					conformance information is missing.</p>
-
-				<p>The examples present the conformance statement, the
-					certifier, the certifiers credentials and is
-					followed by the detailed conformance information
-					section.</p>
-				
 				<aside class="example"
 					title="Conformance statement that claims to meet accepted accessibility standards followed by detailed conformance information">
 					

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1155,158 +1155,120 @@
 				<p>The examples present the conformance statement, the
 					certifier, the certifiers credentials and is
 					followed by the detailed conformance information
-					section </p>
-
+					section.</p>
+				
 				<aside class="example"
 					title="Conformance statement that claims to meet accepted accessibility standards followed by detailed conformance information">
-								<h4 data-localization-id="conformance-title">Conformance</h4>
-					<p data-localization-id="conformance-aa"
-						data-localization-mode="compact">This
-						publication meets
-						accepted accessibility standards</p>
-					<p>
-						<span
-							data-localization-id="conformance-certifier"
-							data-localization-mode="compact">The
-							publication was certified by</span>
-						Foo's Accessibility Testing
-					</p>
-					<p>
-						<span
-							data-localization-id="conformance-certifier-credentials"
-							data-localization-mode="compact">The certifier's credential is</span> "Enterprise
-						Accessibility Rating"
-					</p>
-
-					<p data-localization-id="conformance-details">
-						Detailed conformance information</p>
-					<p>
-						<span
-							data-localization-id="conformance-claim">This
-							publication claims to meet</span>
-						<span
-							data-localization-id="conformance-epub-accessibility-1-1">EPUB
-							Accessibility
-							1.1</span>
-						<span
-							data-localization-id="conformance-wcag-2-1"
-							data-localization-mode="descriptive">Web
-							Accessibility Content Guidelines (WCAG)
-							2.1</span>
-						<span
-							data-localization-id="conformance-level-aa">Level
-							AA</span>
-					</p>
-					<p><span data-localization-id="conformance-certification-info">The
-							publication was certified on</span>
-						2021-09-07</p>
-						<p><span
-							data-localization-id="conformance-certifier-report">For
-							more information refer to the
-							<a
-								href="http://www.example.com/a11y/report/9780000000001">certifier's
-								report</a></span>
-					</p>
-
-
-				</aside>
-
-				<aside class="example"
-					title="Conformance statement that claims to meet minimum accessibility standards followed by detailed conformance information">
-					<h4 data-localization-id="conformance-title">Conformance</h4>
-					<p data-localization-id="conformance-a"
-						data-localization-mode="compact">This
-						publication meets
-						minimum accessibility standards</p>
-					<p>
-						<span
-							data-localization-id="conformance-certifier"
-							data-localization-mode="compact">The
-							publication was certified by</span>
-						Foo's Accessibility Testing
-					</p>
-					<p>
-						<span
-							data-localization-id="conformance-certifier-credentials"
-							data-localization-mode="compact">The certifier's credential is</span> "Enterprise
-						Accessibility Rating"
-					</p>
-					<p data-localization-id="conformance-details">
-						Detailed conformance information</p>
-					<p>
-						<span
-							data-localization-id="conformance-claim">This
-							publication claims to meet</span>
-						<span
-							data-localization-id="conformance-epub-accessibility-1-0">
-							EPUB Accessibility 1.0 </span>
-						<span
-							data-localization-id="conformance-wcag-2-2"
-							data-localization-mode="descriptive">Web
-							Content Accessibility Guidelines (WCAG)
-							2.2</span>
-						<span
-							data-localization-id="conformance-level-a">Level
-							A</span>
-					</p>
-					<p><span data-localization-id="conformance-certification-info">The
-							publication was certified on</span>
-					2021-09-07</p>
-						<p><span data-localization-id="conformance-certifier-credentials">The certifier's credential is</span> "Enterprise
-						Accessibility Rating"</p>
-<p><span
-							data-localization-id="conformance-certifier-report">For
-							more information refer to the
-							<a
-								href="http://www.example.com/a11y/report/9780000000001">certifier's
-								report</a></span>
-					</p>
-
-				</aside>
-
-
-
-				<aside class="example"
-					title="Conformance to accepted standards for accessibility of this publication cannot be determined followed by detailed conformance information">
-					<h4 data-localization-id="conformance-title">Conformance</h4>
-					<p><span
-							data-localization-id="conformance-unknown-standard">Conformance
-							to accepted standards
-							for accessibility of this publication cannot
-							be determined</span></p>
-					<p><span
-							data-localization-id="conformance-certifier">This
-							publication is certified by
-						</span>Foo's Accessibility Testing </p>
-					<p><span
-							data-localization-id="conformance-certifier-credentials">The certifier's credential is</span> "Enterprise
-						Accessibility Rating</p>
-
-
-					<p data-localization-id="conformance-details">
-						Detailed conformance information</p>
-					<p>This publication reports (Publisher's in-house
-						specification</p>
-					<p> The publication was certified
-						on 2021-09-07 </p>
-<p>
-						The certifier 's credential is"Enterprise Accessibility
-						Rating" </p>
-<p>For more information refer to the <a
-							href="http://www.example.com/a11y/report/9780000000001">certifier's
-							report.</a></p>
-
+					
+					<dl>
+						<dt>Compact display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="conformance-title">Conformance</p>
+							<p data-localization-id="conformance-aa"
+								data-localization-mode="compact">This
+								publication meets accepted accessibility standards</p>
+							<p>
+								<span
+									data-localization-id="conformance-certifier"
+									data-localization-mode="compact">The
+									publication was certified by</span>
+								Foo's Accessibility Testing
+							</p>
+							<p>
+								<span
+									data-localization-id="conformance-certifier-credentials"
+									data-localization-mode="compact">The certifier's credential is</span> "Enterprise
+								Accessibility Rating"
+							</p>
+							
+							<p class="ex-hd" data-localization-id="conformance-details">
+								Detailed conformance information</p>
+							<p>
+								<span
+									data-localization-id="conformance-claim">This
+									publication claims to meet</span>
+								<span
+									data-localization-id="conformance-epub-accessibility-1-1">EPUB
+									Accessibility
+									1.1</span>
+								<span
+									data-localization-id="conformance-wcag-2-1"
+									data-localization-mode="descriptive">Web
+									Accessibility Content Guidelines (WCAG)
+									2.1</span>
+								<span
+									data-localization-id="conformance-level-aa">Level
+									AA</span>
+							</p>
+							<p><span data-localization-id="conformance-certification-info">The
+									publication was certified on</span>
+								2021-09-07</p>
+							<p><span data-localization-id="conformance-certifier-report">For
+									more information refer to the
+									<a
+										href="http://www.example.com/a11y/report/9780000000001">certifier's
+										report</a></span>
+							</p>
+						</dd>
+						
+						<dt>Descriptive display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="conformance-title">Conformance</p>
+							<p data-localization-id="conformance-aa"
+								data-localization-mode="compact">The publication contains a conformance statement
+								that it meets the EPUB Accessibility and WCAG 2 Level AA standard.</p>
+							<p>
+								<span
+									data-localization-id="conformance-certifier"
+									data-localization-mode="compact">The
+									publication was certified by</span>
+								Foo's Accessibility Testing
+							</p>
+							<p>
+								<span
+									data-localization-id="conformance-certifier-credentials"
+									data-localization-mode="compact">The certifier's credential is</span> "Enterprise
+								Accessibility Rating"
+							</p>
+							
+							<p class="ex-hd" data-localization-id="conformance-details">
+								Detailed conformance information</p>
+							<p>
+								<span
+									data-localization-id="conformance-claim">This
+									publication claims to meet</span>
+								<span
+									data-localization-id="conformance-epub-accessibility-1-1">EPUB
+									Accessibility
+									1.1</span>
+								<span
+									data-localization-id="conformance-wcag-2-1"
+									data-localization-mode="descriptive">Web
+									Accessibility Content Guidelines (WCAG)
+									2.1</span>
+								<span
+									data-localization-id="conformance-level-aa">Level
+									AA</span>
+							</p>
+							<p><span data-localization-id="conformance-certification-info">The
+									publication was certified on</span>
+								2021-09-07</p>
+							<p><span data-localization-id="conformance-certifier-report">For
+									more information refer to the
+									<a
+										href="http://www.example.com/a11y/report/9780000000001">certifier's
+										report</a></span>
+							</p>
+						</dd>
+					</dl>
 				</aside>
 
 				<aside class="example"
 					title="Missing a conformance statement">
-					<h4 data-localization-id="conformance-title">Conformance</h4>
+					<p class="ex-hd" data-localization-id="conformance-title">Conformance</p>
 					<p data-localization-id="conformance-no"
 						data-localization-mode="compact">No information is available</p>
-
-
-
-
+					<p class="note">There is no difference between the compact and descriptive outputs in this case.</p>
 				</aside>
 			</section>
 


### PR DESCRIPTION
I was looking to standardize the conformance examples with the other ones I added, but I noticed that they're basically all the same. The only statement that changes is the initial generic conformance one. Otherwise, all the output is identical. Making three examples with compact and descriptive displays would mean we'd have essentially the same info six times.

If we're going to have multiple examples, we should try and make them substantively different.

For now, what I've done is remove the second and third examples that only differed by the "meets minimum" and "exceeds accepted" lines. That leaves one example of meeting accessibility standards in compact and descriptive form and the other about no information being available.

If we want to show the other two strings as examples, maybe we could reduce the amount of information to make them shorter?