### PR TITLE
Add compact and descriptive conformance statements

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1053,7 +1053,7 @@
 										data-localization-mode="descriptive"> Level A</span>
 								</p>
 							</dd>
-							<dt>EPUB Accessibility 1.0 WCAG 2.0 Level A</dt>
+							<dt>EPUB Accessibility 1.0 WCAG 2.0 Level AA</dt>
 							<dd>
 								<p data-localization-mode="compact">
 									<span data-localization-id="conformance-claim"

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1221,7 +1221,7 @@
 									<span data-localization-id="conformance-wcag-2-1"
 										data-localization-mode="compact"> WCAG 2.1</span>
 									
-									<span data-localization-id="conformance-level-aa"
+									<span data-localization-id="conformance-level-a"
 										data-localization-mode="compact"> Level A</span>
 								</p>
 								<p data-localization-mode="descriptive">
@@ -1235,7 +1235,7 @@
 									<span data-localization-id="conformance-wcag-2-1"
 										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
 									
-									<span data-localization-id="conformance-level-aa"
+									<span data-localization-id="conformance-level-a"
 										data-localization-mode="descriptive"> Level A</span>
 								</p>
 							</dd>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1019,382 +1019,49 @@
 							data-localization-mode="descriptive">No information is available</p>
 					</dd>
 
-					<dt>If the publication meets:</dt>
+					<dt>If a detailed conformance claim is made:</dt>
 					<dd>
-						<dl>
-							<dt>EPUB Accessibility 1.0 WCAG 2.0 Level A</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="compact"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="compact"> Level A</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="descriptive"> Level A</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.0 WCAG 2.0 Level AA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="compact"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="compact"> Level AA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="descriptive"> Level AA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.0 WCAG 2.0 Level AAA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="compact"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="compact"> Level AAA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="descriptive"> Level AAA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.0 Level A</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="compact"> Level A</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="descriptive"> Level A</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.0 Level AA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="compact"> Level AA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="descriptive"> Level AA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.0 Level AAA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="compact"> Level AAA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="descriptive"> Level AAA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.1 Level A</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="compact"> WCAG 2.1</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="compact"> Level A</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="descriptive"> Level A</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.1 Level AA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="compact"> WCAG 2.1</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="compact"> Level AA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="descriptive"> Level AA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.1 Level AAA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="compact"> WCAG 2.1</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="compact"> Level AAA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="descriptive"> Level AAA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.2 Level A</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="compact"> WCAG 2.2</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="compact"> Level A</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="descriptive"> Level A</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.2 Level AA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="compact"> WCAG 2.2</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="compact"> Level AA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="descriptive"> Level AA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.2 Level AAA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="compact"> WCAG 2.2</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="compact"> Level AAA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="descriptive"> Level AAA</span>
-								</p>
-							</dd>
-						</dl>
+						<p data-localization-mode="compact">
+							<span data-localization-id="conformance-claim"
+								data-localization-mode="compact">This
+								publication claims to meet</span>
+							
+							EPUB Accessibility
+							<span class="placeholder">&lt;1.X&gt;</span>
+							
+							WCAG
+							<span class="placeholder">&lt;2.X&gt;</span>
+							
+							Level
+							<span class="placeholder">&lt;A or AA or AAA&gt;</span>
+						</p>
+						<p data-localization-mode="descriptive">
+							<span data-localization-id="conformance-claim"
+								data-localization-mode="descriptive">This
+								publication claims to meet</span>
+							
+							EPUB Accessibility
+							<span class="placeholder">&lt;1.X&gt;</span>
+							
+							Web Content Accessibility Guidelines (WCAG)
+							<span class="placeholder">&lt;2.X&gt;</span>
+							
+							Level
+							<span class="placeholder">&lt;A or AA or AAA&gt;</span>
+						</p>
+						
+						<div class="note">
+							<p>The placeholders in these strings allow the display of each version of the 
+								respective standard. For example, the descriptive statements for WCAG 2 would be:</p>
+							<ul>
+								<li data-localization-id="conformance-wcag-2-0"
+									data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG ) 2.0</li>
+								<li data-localization-id="conformance-wcag-2-1"
+									data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG ) 2.1</li>
+								<li data-localization-id="conformance-wcag-2-2"
+									data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG ) 2.2</li>
+							</ul>
+						</div>
 					</dd>
 
 					<dt>If a certifier name is provided:</dt>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1222,6 +1222,37 @@
 										data-localization-mode="compact"> WCAG 2.1</span>
 									
 									<span data-localization-id="conformance-level-aa"
+										data-localization-mode="compact"> Level A</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-1"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
+									
+									<span data-localization-id="conformance-level-aa"
+										data-localization-mode="descriptive"> Level A</span>
+								</p>
+							</dd>
+							<dt>EPUB Accessibility 1.1 WCAG 2.1 Level AA</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-1"
+										data-localization-mode="compact"> WCAG 2.1</span>
+									
+									<span data-localization-id="conformance-level-aa"
 										data-localization-mode="compact"> Level AA</span>
 								</p>
 								<p data-localization-mode="descriptive">

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1019,31 +1019,358 @@
 							data-localization-mode="descriptive">No information is available</p>
 					</dd>
 
-					<dt>If the publication meets the requirements of the EPUB Accessibility standard:</dt>
+					<dt>If the publication meets:</dt>
 					<dd>
-						<p>
-							<span
-								data-localization-id="conformance-claim">This
-								publication claims to meet</span>
-
-							<span>EPUB
-								Accessibility</span>
-							<span class="placeholder">&lt;1.X&gt;</span>
-
-							<span>Web
-								Accessibility Content Guidelines (WCAG)</span>
-							<span class="placeholder">&lt;2.X&gt;</span>
-
-							<span>Level</span>
-							<span class="placeholder">&lt;A or AA or AAA&gt;</span>
-						</p>
+						<dl>
+							<dt>EPUB Accessibility 1.0 WCAG 2.0 Level A</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-0"
+										data-localization-mode="compact"> EPUB Accessibility 1.0</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="compact"> WCAG 2.0</span>
+									
+									<span data-localization-id="conformance-level-a"
+										data-localization-mode="compact"> Level A</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-0"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+									
+									<span data-localization-id="conformance-level-a"
+										data-localization-mode="descriptive"> Level A</span>
+								</p>
+							</dd>
+							<dt>EPUB Accessibility 1.0 WCAG 2.0 Level A</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-0"
+										data-localization-mode="compact"> EPUB Accessibility 1.0</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="compact"> WCAG 2.0</span>
+									
+									<span data-localization-id="conformance-level-aa"
+										data-localization-mode="compact"> Level AA</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-0"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+									
+									<span data-localization-id="conformance-level-aa"
+										data-localization-mode="descriptive"> Level AA</span>
+								</p>
+							</dd>
+							<dt>EPUB Accessibility 1.0 WCAG 2.0 Level AAA</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-0"
+										data-localization-mode="compact"> EPUB Accessibility 1.0</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="compact"> WCAG 2.0</span>
+									
+									<span data-localization-id="conformance-level-aaa"
+										data-localization-mode="compact"> Level AAA</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-0"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+									
+									<span data-localization-id="conformance-level-aaa"
+										data-localization-mode="descriptive"> Level AAA</span>
+								</p>
+							</dd>
+							<dt>EPUB Accessibility 1.1 WCAG 2.0 Level A</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="compact"> WCAG 2.0</span>
+									
+									<span data-localization-id="conformance-level-a"
+										data-localization-mode="compact"> Level A</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+									
+									<span data-localization-id="conformance-level-a"
+										data-localization-mode="descriptive"> Level A</span>
+								</p>
+							</dd>
+							<dt>EPUB Accessibility 1.1 WCAG 2.0 Level AA</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="compact"> WCAG 2.0</span>
+									
+									<span data-localization-id="conformance-level-aa"
+										data-localization-mode="compact"> Level AA</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+									
+									<span data-localization-id="conformance-level-aa"
+										data-localization-mode="descriptive"> Level AA</span>
+								</p>
+							</dd>
+							<dt>EPUB Accessibility 1.1 WCAG 2.0 Level AAA</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="compact"> WCAG 2.0</span>
+									
+									<span data-localization-id="conformance-level-aaa"
+										data-localization-mode="compact"> Level AAA</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-0"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+									
+									<span data-localization-id="conformance-level-aaa"
+										data-localization-mode="descriptive"> Level AAA</span>
+								</p>
+							</dd>
+							<dt>EPUB Accessibility 1.1 WCAG 2.1 Level A</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-1"
+										data-localization-mode="compact"> WCAG 2.1</span>
+									
+									<span data-localization-id="conformance-level-aa"
+										data-localization-mode="compact"> Level AA</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-1"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
+									
+									<span data-localization-id="conformance-level-aa"
+										data-localization-mode="descriptive"> Level AA</span>
+								</p>
+							</dd>
+							<dt>EPUB Accessibility 1.1 WCAG 2.1 Level AAA</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-1"
+										data-localization-mode="compact"> WCAG 2.1</span>
+									
+									<span data-localization-id="conformance-level-aaa"
+										data-localization-mode="compact"> Level AAA</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-1"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
+									
+									<span data-localization-id="conformance-level-aaa"
+										data-localization-mode="descriptive"> Level AAA</span>
+								</p>
+							</dd>
+							<dt>EPUB Accessibility 1.1 WCAG 2.2 Level A</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-2"
+										data-localization-mode="compact"> WCAG 2.2</span>
+									
+									<span data-localization-id="conformance-level-a"
+										data-localization-mode="compact"> Level A</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-2"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
+									
+									<span data-localization-id="conformance-level-a"
+										data-localization-mode="descriptive"> Level A</span>
+								</p>
+							</dd>
+							<dt>EPUB Accessibility 1.1 WCAG 2.2 Level AA</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-2"
+										data-localization-mode="compact"> WCAG 2.2</span>
+									
+									<span data-localization-id="conformance-level-aa"
+										data-localization-mode="compact"> Level AA</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-2"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
+									
+									<span data-localization-id="conformance-level-aa"
+										data-localization-mode="descriptive"> Level AA</span>
+								</p>
+							</dd>
+							<dt>EPUB Accessibility 1.1 WCAG 2.2 Level AAA</dt>
+							<dd>
+								<p data-localization-mode="compact">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="compact">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-2"
+										data-localization-mode="compact"> WCAG 2.2</span>
+									
+									<span data-localization-id="conformance-level-aaa"
+										data-localization-mode="compact"> Level AAA</span>
+								</p>
+								<p data-localization-mode="descriptive">
+									<span data-localization-id="conformance-claim"
+										data-localization-mode="descriptive">This
+										publication claims to meet</span>
+									
+									<span data-localization-id="conformance-epub-accessibility-1-1"
+										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+									
+									<span data-localization-id="conformance-wcag-2-2"
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
+									
+									<span data-localization-id="conformance-level-aaa"
+										data-localization-mode="descriptive"> Level AAA</span>
+								</p>
+							</dd>
+						</dl>
 					</dd>
 
 					<dt>If a certifier name is provided:</dt>
 					<dd>
 						<p><span
 								data-localization-id="conformance-certifier"
-								data-localization-mode="descriptive">The
+								data-localization-mode="compact">The
 								publication was certified by</span>
 							<span class="placeholder">&lt;certifier name&gt;</span></p>
 					</dd>
@@ -1052,23 +1379,25 @@
 					<dd>
 						<p><span
 								data-localization-id="conformance-certifier-credentials"
-								data-localization-mode="descriptive">The certifier's credential is</span>
+								data-localization-mode="compact">The certifier's credential is </span>
 							<span class="placeholder">&lt;certifier credential&gt;</span></p>
 					</dd>
 
 					<dt>If the certification date is provided:</dt>
 					<dd>
 						<p>
-							<span data-localization-id="conformance-certification-info">The
-								publication was certified on</span>
+							<span data-localization-id="conformance-certification-info"
+								data-localization-mode="compact">The
+								publication was certified on </span>
 							<span class="placeholder">&lt;certification date&gt;</span></p>
 					</dd>
 
 					<dt>If the certifier provides an accessibility report:</dt>
 					<dd>
-						<p data-localization-id="conformance-certifier-report">For
+						<p><span data-localization-id="conformance-certifier-report"
+								data-localization-mode="compact">For
 								more information refer to the
-								certifier's report</p>
+								certifier's report</span></p>
 					</dd>
 				</dl>
 

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1045,7 +1045,7 @@
 				</section>
 				
 				<section id="detailed-conformance-information">
-					<h4>Detailed conformance</h4>
+					<h5>Detailed conformance</h5>
 		
 					<p>The following information can be placed in a section
 						that shows the details of the conformance


### PR DESCRIPTION
I just noticed that the compact and descriptive strings for the detailed conformance statement vary in whether they write out WCAG or not. I didn't spot this when I combined the strings in the guidelines, so right now it shows the compact string with some placeholder values.

For now, I opted to write out every string so that they can all be ID'd. (I also fixed up a few bugs on some of the other strings.)

If we don't want to list 12 sets of compact and descriptive conformance strings, the other option would be to use the old approach and use placeholder values. In that case, we'd have the following pair of strings:

 > Compact: This publication claims to meet EPUB Accessibility `<1.X>` WCAG `<2.X>` Level `<A or AA or AAA>`
 > Descriptive: This publication claims to meet EPUB Accessibility `<1.X>` Web Accessibility Content Guidelines (WCAG) `<2.X>` Level `<A or AA or AAA>`

But in this scenario most of the strings wouldn't be taggable with the data-* attributes.