### PR TITLE
Restructure the conformance display statements

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -966,567 +966,486 @@
 				publication. The certifying organization should be
 				identified along with their credentials and
 				placed immediately after the conformance statement.</p>
-
-
-			<section id="detailled-conformance-information">
-				<h4>Detailed conformance information</h4>
-
-				<p>The following information can be placed in a section
-					that shows the details of the conformance
-					information.</p>
-
-				<dl>
-					<dt>Conformance Statement</dt>
-					<dd>Identifies the accessibility specification and
-						the conformance level to which the
-						publication assertions are made. When the
-						publication claims to conform to more than one
-						specification, additional conformance statements
-						may be provided.</dd>
-
-					<dt id="certificate-date">Certification date</dt>
-					<dd>If the date of the certifier's evaluation is
-						provided, then this would be of interest. This
-						is normally associated with the certifier.</dd>
-
-					<dt id="certifier-report">Certifier's Report</dt>
-					<dd>If a link to a report is provided, this may be
-						of interest.</dd>
-				</dl>
-			</section>
-
+			
 			<section id="conf-statements">
 				<h4>Display statements</h4>
-
+				
 				<div class="note">
 					<p>Some conformance statements incorporate publication metadata. To indicate where
 						this text will be inserted, the statements include placeholder variables. These
 						placeholders are identified by being enclosed in angle brackets (e.g.,
 						<span class="placeholder">&lt;placeholder&gt;</span>).</p>
 				</div>
-
+				
 				<div class="note">
 					<p>Not all conformance statements have compact and descriptive forms. In these cases,
 						the same string is used for both.</p>
 				</div>
-
-				<dl>
-					<dt>If the publication meets minimal accessibility requirements:</dt>
-					<dd>
-						<p data-localization-id="conformance-a"
-							data-localization-mode="compact">This publication meets minimum accessibility
-							standards</p>
-						<p data-localization-id="conformance-a"
-							data-localization-mode="descriptive">The publication contains a conformance
-							statement that it meets the EPUB Accessibility and WCAG 2 Level A standard</p>
-					</dd>
-
-					<dt>If the publication meets widely accepted accessibility requirements:</dt>
-					<dd>
-						<p data-localization-id="conformance-aa"
-							data-localization-mode="compact">This publication meets accepted accessibility
-							standards</p>
-						<p data-localization-id="conformance-aa"
-							data-localization-mode="descriptive">The publication contains a conformance
-							statement that it meets the EPUB Accessibility and WCAG 2 Level AA standard</p>
-					</dd>
-
-					<dt>If the publication exceeds accepted accessibility requirements:</dt>
-					<dd>
-						<p data-localization-id="conformance-aaa"
-							data-localization-mode="compact">This publication exceeds accepted accessibility
-							standards</p>
-						<p data-localization-id="conformance-aaa"
-							data-localization-mode="descriptive">The publication contains a conformance
-							statement that it meets the EPUB Accessibility and WCAG 2 Level AAA standard</p>
-					</dd>
-
-					<dt>If no metadata is provided:</dt>
-					<dd>
-						<p data-localization-id="conformance-no"
-							data-localization-mode="compact">No information is available</p>
-						<p data-localization-id="conformance-no"
-							data-localization-mode="descriptive">No information is available</p>
-					</dd>
-
-					<dt>If the publication meets:</dt>
-					<dd>
-						<dl>
-							<dt>EPUB Accessibility 1.0 WCAG 2.0 Level A</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="compact"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="compact"> Level A</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="descriptive"> Level A</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.0 WCAG 2.0 Level AA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="compact"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="compact"> Level AA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="descriptive"> Level AA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.0 WCAG 2.0 Level AAA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="compact"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="compact"> Level AAA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-0"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="descriptive"> Level AAA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.0 Level A</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="compact"> Level A</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="descriptive"> Level A</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.0 Level AA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="compact"> Level AA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="descriptive"> Level AA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.0 Level AAA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="compact"> WCAG 2.0</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="compact"> Level AAA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="descriptive"> Level AAA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.1 Level A</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="compact"> WCAG 2.1</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="compact"> Level A</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="descriptive"> Level A</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.1 Level AA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="compact"> WCAG 2.1</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="compact"> Level AA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="descriptive"> Level AA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.1 Level AAA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="compact"> WCAG 2.1</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="compact"> Level AAA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="descriptive"> Level AAA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.2 Level A</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="compact"> WCAG 2.2</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="compact"> Level A</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
-									
-									<span data-localization-id="conformance-level-a"
-										data-localization-mode="descriptive"> Level A</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.2 Level AA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="compact"> WCAG 2.2</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="compact"> Level AA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
-									
-									<span data-localization-id="conformance-level-aa"
-										data-localization-mode="descriptive"> Level AA</span>
-								</p>
-							</dd>
-							<dt>EPUB Accessibility 1.1 WCAG 2.2 Level AAA</dt>
-							<dd>
-								<p data-localization-mode="compact">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="compact"> WCAG 2.2</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="compact"> Level AAA</span>
-								</p>
-								<p data-localization-mode="descriptive">
-									<span data-localization-id="conformance-claim"
-										data-localization-mode="descriptive">This
-										publication claims to meet</span>
-									
-									<span data-localization-id="conformance-epub-accessibility-1-1"
-										data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
-									
-									<span data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
-									
-									<span data-localization-id="conformance-level-aaa"
-										data-localization-mode="descriptive"> Level AAA</span>
-								</p>
-							</dd>
-						</dl>
-					</dd>
-
-					<dt>If a certifier name is provided:</dt>
-					<dd>
-						<p><span
-								data-localization-id="conformance-certifier"
-								data-localization-mode="compact">The
-								publication was certified by</span>
-							<span class="placeholder">&lt;certifier name&gt;</span></p>
-					</dd>
-
-					<dt>If the certifier has a credential:</dt>
-					<dd>
-						<p><span
-								data-localization-id="conformance-certifier-credentials"
-								data-localization-mode="compact">The certifier's credential is </span>
-							<span class="placeholder">&lt;certifier credential&gt;</span></p>
-					</dd>
-
-					<dt>If the certification date is provided:</dt>
-					<dd>
-						<p>
-							<span data-localization-id="conformance-certification-info"
-								data-localization-mode="compact">The
-								publication was certified on </span>
-							<span class="placeholder">&lt;certification date&gt;</span></p>
-					</dd>
-
-					<dt>If the certifier provides an accessibility report:</dt>
-					<dd>
-						<p><span data-localization-id="conformance-certifier-report"
-								data-localization-mode="compact">For
-								more information refer to the
-								certifier's report</span></p>
-					</dd>
-				</dl>
-
-				<section id="conf-expl">
-					<h4>Explainer</h4>
-
-					<p>The following list explains the meaning of each
-						recommended conformance statement.</p>
+				
+				
+				<section id="conformance-general">
+					<h4>General conformance</h4>
+		
 					<dl>
-						<dt data-localization-id="conformance-aaa"
-							data-localization-mode="compact">This
-							publication
-							exceeds accepted accessibility standards</dt>
-						<dd data-localization-id="conformance-aaa"
-							data-localization-mode="descriptive">
-							<p>The publication contains a conformance
-								statement that it meets the EPUB
-								Accessibility and
-								WCAG 2 Level AAA standard</p>
+						<dt>If the publication meets minimal accessibility requirements:</dt>
+						<dd>
+							<p data-localization-id="conformance-a"
+								data-localization-mode="compact">This publication meets minimum accessibility
+								standards</p>
+							<p data-localization-id="conformance-a"
+								data-localization-mode="descriptive">The publication contains a conformance
+								statement that it meets the EPUB Accessibility and WCAG 2 Level A standard</p>
 						</dd>
-						<dt data-localization-id="conformance-aa"
-							data-localization-mode="compact">This
-							publication
-							meets accepted accessibility standards</dt>
-						<dd data-localization-id="conformance-aa"
-							data-localization-mode="descriptive">
-							<p>The publication contains a conformance
-								statement that it meets the EPUB
-								Accessibility and
-								WCAG 2 Level AA standard</p>
+	
+						<dt>If the publication meets widely accepted accessibility requirements:</dt>
+						<dd>
+							<p data-localization-id="conformance-aa"
+								data-localization-mode="compact">This publication meets accepted accessibility
+								standards</p>
+							<p data-localization-id="conformance-aa"
+								data-localization-mode="descriptive">The publication contains a conformance
+								statement that it meets the EPUB Accessibility and WCAG 2 Level AA standard</p>
 						</dd>
-
-						<dt data-localization-id="conformance-a"
-							data-localization-mode="compact">This
-							publication meets
-							minimum accessibility standards</dt>
-						<dd data-localization-id="conformance-a"
-							data-localization-mode="descriptive">
-							<p>The publication contains a conformance
-								statement that it meets the EPUB
-								Accessibility and
-								WCAG 2 Level A standard</p>
+	
+						<dt>If the publication exceeds accepted accessibility requirements:</dt>
+						<dd>
+							<p data-localization-id="conformance-aaa"
+								data-localization-mode="compact">This publication exceeds accepted accessibility
+								standards</p>
+							<p data-localization-id="conformance-aaa"
+								data-localization-mode="descriptive">The publication contains a conformance
+								statement that it meets the EPUB Accessibility and WCAG 2 Level AAA standard</p>
 						</dd>
-
-						<dt data-localization-id="conformance-no"
-							data-localization-mode="compact">No information is available</dt>
-						<dd >
-							<p>The conformance metadata is missing and
-								conformity to a standard of this publication
-								is
-								unknown</p>
+	
+						<dt>If no metadata is provided:</dt>
+						<dd>
+							<p data-localization-id="conformance-no"
+								data-localization-mode="compact">No information is available</p>
+							<p data-localization-id="conformance-no"
+								data-localization-mode="descriptive">No information is available</p>
 						</dd>
-
-						<dt>Certifier's name</dt>
-						<dd>Identifies the organization providing the
-							certification review or process for
-							certification. </dd>
-
-						<dt>Certifier's Credentials </dt>
-						<dd>If the certifier has a badge or a credential,
-							then the text is provided. If there is a link
-							to their credential, then this can be provided
-							as a link. If the certifier has a logo or
-							badge, this can be displayed. The display of the
-							logo or badge can be arranged between the
-							certifier and the distributor showing the
-							accessibility metadata.</dd>
-
+	
+						<dt>If a certifier name is provided:</dt>
+						<dd>
+							<p><span
+									data-localization-id="conformance-certifier"
+									data-localization-mode="compact">The
+									publication was certified by</span>
+								<span class="placeholder">&lt;certifier name&gt;</span></p>
+						</dd>
+	
+						<dt>If the certifier has a credential:</dt>
+						<dd>
+							<p><span
+									data-localization-id="conformance-certifier-credentials"
+									data-localization-mode="compact">The certifier's credential is </span>
+								<span class="placeholder">&lt;certifier credential&gt;</span></p>
+						</dd>
+					</dl>
+				</section>
+	
+				<section id="detailed-conformance-information">
+					<h4>Detailed conformance</h4>
+		
+					<p>The following information can be placed in a section
+						that shows the details of the conformance
+						information.</p>
+					
+					<dl>
+						<dt>If the publication meets:</dt>
+						<dd>
+							<dl>
+								<dt>EPUB Accessibility 1.0 WCAG 2.0 Level A</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-0"
+											data-localization-mode="compact"> EPUB Accessibility 1.0</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="compact"> WCAG 2.0</span>
+										
+										<span data-localization-id="conformance-level-a"
+											data-localization-mode="compact"> Level A</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-0"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+										
+										<span data-localization-id="conformance-level-a"
+											data-localization-mode="descriptive"> Level A</span>
+									</p>
+								</dd>
+								<dt>EPUB Accessibility 1.0 WCAG 2.0 Level AA</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-0"
+											data-localization-mode="compact"> EPUB Accessibility 1.0</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="compact"> WCAG 2.0</span>
+										
+										<span data-localization-id="conformance-level-aa"
+											data-localization-mode="compact"> Level AA</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-0"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+										
+										<span data-localization-id="conformance-level-aa"
+											data-localization-mode="descriptive"> Level AA</span>
+									</p>
+								</dd>
+								<dt>EPUB Accessibility 1.0 WCAG 2.0 Level AAA</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-0"
+											data-localization-mode="compact"> EPUB Accessibility 1.0</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="compact"> WCAG 2.0</span>
+										
+										<span data-localization-id="conformance-level-aaa"
+											data-localization-mode="compact"> Level AAA</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-0"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.0</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+										
+										<span data-localization-id="conformance-level-aaa"
+											data-localization-mode="descriptive"> Level AAA</span>
+									</p>
+								</dd>
+								<dt>EPUB Accessibility 1.1 WCAG 2.0 Level A</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="compact"> WCAG 2.0</span>
+										
+										<span data-localization-id="conformance-level-a"
+											data-localization-mode="compact"> Level A</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+										
+										<span data-localization-id="conformance-level-a"
+											data-localization-mode="descriptive"> Level A</span>
+									</p>
+								</dd>
+								<dt>EPUB Accessibility 1.1 WCAG 2.0 Level AA</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="compact"> WCAG 2.0</span>
+										
+										<span data-localization-id="conformance-level-aa"
+											data-localization-mode="compact"> Level AA</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+										
+										<span data-localization-id="conformance-level-aa"
+											data-localization-mode="descriptive"> Level AA</span>
+									</p>
+								</dd>
+								<dt>EPUB Accessibility 1.1 WCAG 2.0 Level AAA</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="compact"> WCAG 2.0</span>
+										
+										<span data-localization-id="conformance-level-aaa"
+											data-localization-mode="compact"> Level AAA</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-0"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</span>
+										
+										<span data-localization-id="conformance-level-aaa"
+											data-localization-mode="descriptive"> Level AAA</span>
+									</p>
+								</dd>
+								<dt>EPUB Accessibility 1.1 WCAG 2.1 Level A</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-1"
+											data-localization-mode="compact"> WCAG 2.1</span>
+										
+										<span data-localization-id="conformance-level-a"
+											data-localization-mode="compact"> Level A</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-1"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
+										
+										<span data-localization-id="conformance-level-a"
+											data-localization-mode="descriptive"> Level A</span>
+									</p>
+								</dd>
+								<dt>EPUB Accessibility 1.1 WCAG 2.1 Level AA</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-1"
+											data-localization-mode="compact"> WCAG 2.1</span>
+										
+										<span data-localization-id="conformance-level-aa"
+											data-localization-mode="compact"> Level AA</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-1"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
+										
+										<span data-localization-id="conformance-level-aa"
+											data-localization-mode="descriptive"> Level AA</span>
+									</p>
+								</dd>
+								<dt>EPUB Accessibility 1.1 WCAG 2.1 Level AAA</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-1"
+											data-localization-mode="compact"> WCAG 2.1</span>
+										
+										<span data-localization-id="conformance-level-aaa"
+											data-localization-mode="compact"> Level AAA</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-1"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</span>
+										
+										<span data-localization-id="conformance-level-aaa"
+											data-localization-mode="descriptive"> Level AAA</span>
+									</p>
+								</dd>
+								<dt>EPUB Accessibility 1.1 WCAG 2.2 Level A</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-2"
+											data-localization-mode="compact"> WCAG 2.2</span>
+										
+										<span data-localization-id="conformance-level-a"
+											data-localization-mode="compact"> Level A</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-2"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
+										
+										<span data-localization-id="conformance-level-a"
+											data-localization-mode="descriptive"> Level A</span>
+									</p>
+								</dd>
+								<dt>EPUB Accessibility 1.1 WCAG 2.2 Level AA</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-2"
+											data-localization-mode="compact"> WCAG 2.2</span>
+										
+										<span data-localization-id="conformance-level-aa"
+											data-localization-mode="compact"> Level AA</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-2"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
+										
+										<span data-localization-id="conformance-level-aa"
+											data-localization-mode="descriptive"> Level AA</span>
+									</p>
+								</dd>
+								<dt>EPUB Accessibility 1.1 WCAG 2.2 Level AAA</dt>
+								<dd>
+									<p data-localization-mode="compact">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="compact">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="compact"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-2"
+											data-localization-mode="compact"> WCAG 2.2</span>
+										
+										<span data-localization-id="conformance-level-aaa"
+											data-localization-mode="compact"> Level AAA</span>
+									</p>
+									<p data-localization-mode="descriptive">
+										<span data-localization-id="conformance-claim"
+											data-localization-mode="descriptive">This
+											publication claims to meet</span>
+										
+										<span data-localization-id="conformance-epub-accessibility-1-1"
+											data-localization-mode="descriptive"> EPUB Accessibility 1.1</span>
+										
+										<span data-localization-id="conformance-wcag-2-2"
+											data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</span>
+										
+										<span data-localization-id="conformance-level-aaa"
+											data-localization-mode="descriptive"> Level AAA</span>
+									</p>
+								</dd>
+							</dl>
+						</dd>
+	
+						<dt>If the certification date is provided:</dt>
+						<dd>
+							<p>
+								<span data-localization-id="conformance-certification-info"
+									data-localization-mode="compact">The
+									publication was certified on </span>
+								<span class="placeholder">&lt;certification date&gt;</span></p>
+						</dd>
+	
+						<dt>If the certifier provides an accessibility report:</dt>
+						<dd>
+							<p><span data-localization-id="conformance-certifier-report"
+									data-localization-mode="compact">For
+									more information refer to the
+									certifier's report</span></p>
+						</dd>
 					</dl>
 				</section>
 			</section>


### PR DESCRIPTION
I think it would be helpful to separate the general conformance statements that are recommended from the detailed conformance statements, especially since the latter go under a separate heading.

This PR builds on #629 by moving the statements under either a general or detailed conformance subsection of the conformance statements section.

It also gets rid of the explainer subsection as I noticed it was just repeating the compact and descriptive statements and not adding anything new to them. Only the certifier name and credential had any kind of explanation, but I don't think people will get confused by either of those fields.

It also removes the detailed conformance section that was listing the three properties that would go under that heading, since that becomes redundant info when the statements are separated into their own section.

If this is okay, it should not be merged until after #629.

***

[Preview](https://raw.githack.com/w3c/publ-a11y/fix/conf-structure/a11y-meta-display-guide/2.0/draft/guidelines/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/conf-structure/a11y-meta-display-guide/2.0/draft/guidelines/index.html)
