### PR TITLE
Update the metadata testing for nonvisual content display

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -764,14 +764,6 @@
 								data-localization-mode="descriptive">Not all of the content will be readable as read aloud speech or dynamic braille</p>
 						</dd>
 						
-						<dt>If the content is only readable as dynamic braille:</dt>
-						<dd>
-							<p data-localization-id="ways-of-reading-nonvisual-reading-braille-only"
-								data-localization-mode="compact">Readable in dynamic braille</p>
-							<p data-localization-id="ways-of-reading-nonvisual-reading-braille-only"
-								data-localization-mode="descriptive">All content can be read as dynamic braille</p>
-						</dd>
-						
 						<dt>If the content cannot be read in text form:</dt>
 						<dd>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-none"

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -764,6 +764,14 @@
 								data-localization-mode="descriptive">All content can be read as dynamic braille</p>
 						</dd>
 						
+						<dt>If not all content is readable in text form:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
+								data-localization-mode="compact">Not fully readable in read aloud or dynamic braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
+								data-localization-mode="descriptive">Not all of the content will be readable as read aloud speech or dynamic braille</p>
+						</dd>
+						
 						<dt>If the content cannot be read in text form:</dt>
 						<dd>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-none"
@@ -772,13 +780,14 @@
 								data-localization-mode="descriptive">The content is not readable as read aloud speech or dynamic braille</p>
 						</dd>
 						
-						<dt>If not all content is readable in text form:</dt>
+						<dt>If no metadata is provided:</dt>
 						<dd>
-							<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
-								data-localization-mode="compact">Not fully readable in read aloud or dynamic braille</p>
-							<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
-								data-localization-mode="descriptive">Not all of the content will be readable as read aloud speech or dynamic braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-no-metadata"
+								data-localization-mode="compact">No information about nonvisual reading is available</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-no-metadata"
+								data-localization-mode="descriptive">No information about nonvisual reading is available</p>
 						</dd>
+						
 						<dt>If text alternatives are provided:</dt>
 						<dd>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -756,20 +756,20 @@
 								data-localization-mode="descriptive">All content can be read as read aloud speech or dynamic braille</p>
 						</dd>
 
-						<dt>If the content is only readable as dynamic braille:</dt>
-						<dd>
-							<p data-localization-id="ways-of-reading-nonvisual-reading-braille-only"
-								data-localization-mode="compact">Readable in dynamic braille</p>
-							<p data-localization-id="ways-of-reading-nonvisual-reading-braille-only"
-								data-localization-mode="descriptive">All content can be read as dynamic braille</p>
-						</dd>
-						
 						<dt>If not all content is readable in text form:</dt>
 						<dd>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
 								data-localization-mode="compact">Not fully readable in read aloud or dynamic braille</p>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
 								data-localization-mode="descriptive">Not all of the content will be readable as read aloud speech or dynamic braille</p>
+						</dd>
+						
+						<dt>If the content is only readable as dynamic braille:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-braille-only"
+								data-localization-mode="compact">Readable in dynamic braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-braille-only"
+								data-localization-mode="descriptive">All content can be read as dynamic braille</p>
 						</dd>
 						
 						<dt>If the content cannot be read in text form:</dt>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -758,36 +758,33 @@
 						<dt>If all content is readable in text form:</dt>
 						<dd>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
-								data-localization-mode="compact">Readable in
-								read aloud or dynamic braille</p>
+								data-localization-mode="compact">Readable in read aloud or dynamic braille</p>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
-								data-localization-mode="descriptive">All
-								content can be read as read aloud speech or
-								dynamic braille</p>
+								data-localization-mode="descriptive">All content can be read as read aloud speech or dynamic braille</p>
 						</dd>
 
-						<dt>If not all content may be readable in text form:</dt>
+						<dt>If the content is only readable as dynamic braille:</dt>
 						<dd>
-							<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
-								data-localization-mode="compact">May not be
-								fully readable in read aloud or dynamic
-								braille</p>
-							<p data-localization-id="ways-of-reading-nonvisual-reading-may-not-fully"
-								data-localization-mode="descriptive">
-								Portions of the content may not be readable
-								as read aloud speech or dynamic braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-braille-only"
+								data-localization-mode="compact">Readable in dynamic braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-braille-only"
+								data-localization-mode="descriptive">All content can be read as dynamic braille</p>
 						</dd>
-
+						
+						<dt>If the content cannot be read in text form:</dt>
+						<dd>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-none"
+								data-localization-mode="compact">Not readable in read aloud or dynamic braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-none"
+								data-localization-mode="descriptive">The content is not readable as read aloud speech or dynamic braille</p>
+						</dd>
+						
 						<dt>If not all content is readable in text form:</dt>
 						<dd>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
-								data-localization-mode="compact">Not
-								fully readable in read aloud or dynamic
-								braille</p>
+								data-localization-mode="compact">Not fully readable in read aloud or dynamic braille</p>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
-								data-localization-mode="descriptive">Not all
-								of the content will be readable as read
-								aloud speech or dynamic braille</p>
+								data-localization-mode="descriptive">Not all of the content will be readable as read aloud speech or dynamic braille</p>
 						</dd>
 					</dl>
 				</section>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -254,7 +254,12 @@
                             <p>If true it indicates that there is only a single access mode of textual or <i>accessModeSufficient="textual"</i> (all main content is provided in textual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
                             <p><i>All non-decorative content supports reading without sight</i> means that all contents of the digital publication necessary to use and understanding, including text, images (via their alternative descriptions), audio and video material (via their transcripts, descriptions, captions or subtitles) are fully accessible via suitable reading devices, for example text-to-speech screen readers or tactile reading devices (‘Braille displays’), and nothing in the digital publication prevents or blocks the use of alternative reading modes. The entire publication can be navigated and ‘read’ using only text rendered via sound or touch, and does not require visual perception.</p>
                         </dd>
-                        <dt><var>non_textual_content</var></dt>
+                    	<dt><var>has_nonvisual_metadata</var></dt>
+                    	<dd>
+                    		<p>If true it indicates that the publisher has stated a least one access mode or sufficient access mode.</p>
+                    		<p>If this metadata is not set, it is not possible to determine whether or not the content will be readable nonvisually.</p>
+                    	</dd>
+                    	<dt><var>non_textual_content</var></dt>
                         <dd>
                             <p>If true it indicates that there is non-textual content such as images, audio, or video in the publication.</p>
                         </dd>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -335,13 +335,7 @@
                         <dd>
                             <p>If true it indicates that the <i>accessModeSufficient="auditory"</i> (all main content is provided in audio form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
                         </dd>
-                        <dt><var>synchronised_pre_recorded_audio</var></dt>
-                        <dd>
-                            <p>If true it indicates that the <i>accessibilityFeature="sychronizedAudioText"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
-
-                            <p>This indicates that text-synchronised prerecorded audio narration (natural or synthesized voice) is included for substantially all textual matter, including all alternative descriptions, e.g. via a SMIL media overlay.</p>
-                        </dd>
-
+                        
                         <dt><var>audio_content</var></dt>
                         <dd>
                             <p>If true it indicates that the <i>accessMode="auditory"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
@@ -349,7 +343,12 @@
                             <p>This indicates that prerecorded audio content is included as part of the work.</p>
                         </dd>
 
+                        <dt><var>synchronised_pre_recorded_audio</var></dt>
+                        <dd>
+                            <p>If true it indicates that the <i>accessibilityFeature="sychronizedAudioText"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
 
+                            <p>This indicates that text-synchronised prerecorded audio narration (natural or synthesized voice) is included for substantially all textual matter, including all alternative descriptions, e.g. via a SMIL media overlay.</p>
+                        </dd>
                     </dl>
                     <h5>Variables setup</h5>
                     <ol class="condition">
@@ -357,9 +356,9 @@
 
                         <li><b>LET</b> <var>all_content_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessModeSufficient</i>" and normalize-space()="<i>auditory</i>"]</code>.</li>
 
-                        <li><b>LET</b> <var>synchronised_pre_recorded_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>sychronizedAudioText</i>"]</code>.</li>
-
                         <li><b>LET</b> <var>audio_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>auditory</i>"]</code>.</li>
+
+                        <li><b>LET</b> <var>synchronised_pre_recorded_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>sychronizedAudioText</i>"]</code>.</li>
 
                     </ol>
                     <h5>Instructions</h5>
@@ -374,7 +373,7 @@
                         </li>
                         <li>
                             <span><b>ELSE IF</b> <var>audio_content</var>:</span>
-                            <span><b>THEN</b> display <code id="ways-of-reading-prerecorded-audio-complementary">"Complementary audio and text"</code>.</span>
+                            <span><b>THEN</b> display <code id="ways-of-reading-prerecorded-audio-complementary">"Prerecorded audio clips"</code>.</span>
                         </li>
 
                         <li>
@@ -393,19 +392,6 @@
 
 				<h4>Understanding the variables</h4>
 				<dl>
-					<dt><var>epub_version</var></dt>
-					<dd>
-                        <p>If set, provides the version of the EPUB Accessibility specification the
-                        	publication conforms to.</p>
-					</dd>
-					<dt><var>wcag_version</var></dt>
-					<dd>
-						<p>If set, provides the version of WCAG 2 the publication conforms to.</p>
-					</dd>
-					<dt><var>wcag_version</var></dt>
-					<dd>
-                        <p>If set, provides the WCAG 2 conformance level claimed.</p>
-					</dd>
 					<dt><var>certifier</var></dt>
 					<dd>
 						<p>Returns the description of <i>a11y:certifiedBy</i> (Compliance certification by (name)) if present in the package document, otherwise if false it means that the metadata is not present.</p>
@@ -431,7 +417,15 @@
 						<p>If true it indicates that the <i>conformsTo</i> is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that the publication conforms to some specification.</p>
 					</dd>
-
+					<dt><var>epub_version</var></dt>
+					<dd>
+                        <p>If set, provides the version of the EPUB Accessibility specification the
+                        	publication conforms to.</p>
+					</dd>
+					<dt><var>wcag_version</var></dt>
+					<dd>
+                        <p>If set, provides the WCAG 2 conformance level claimed.</p>
+					</dd>
 				</dl>
 
 				<h4>Variables setup</h4>
@@ -594,41 +588,41 @@
 
 				<h4>Understanding the variables</h4>
 				<dl>
-					<dt><var>table_of_contents_navigation</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="tableOfContents"</i> (Table of contents navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-
-						<p>This means that the resource includes a table of contents that provides links to the major sections of the content.</p>
-					</dd>
 					<dt><var>index_navigation</var></dt>
 					<dd>
                         <p>If true it indicates that the <i>accessibilityFeature="index"</i> (Index navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 
                         <p>This means that there is an index that provides direct (eg hyperlinked) access to uses of the index terms in the document body.</p>
 					</dd>
-                    <dt><var>page_navigation</var></dt>
+ 					<dt><var>next_previous_structural_navigation</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityFeature="structuralNavigation"</i> (Next / Previous structural navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that all levels of heading and other structural elements of the content are correctly marked up and (if applicable) numbered, to enable fast next heading / previous heading, next chapter / previous chapter navigation without returning to the table of contents.</p>
+					</dd>
+                   <dt><var>page_navigation</var></dt>
                     <dd>
                         <p>If true it indicates that the <i>accessibilityFeature="pageNavigation"</i> (Page Navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
                         <p>This means that the e-publication includes a means of navigating to static page break locations.</p>
                     </dd>
-					<dt><var>next_previous_structural_navigation</var></dt>
+					<dt><var>table_of_contents_navigation</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="structuralNavigation"</i> (Next / Previous structural navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that all levels of heading and other structural elements of the content are correctly marked up and (if applicable) numbered, to enable fast next heading / previous heading, next chapter / previous chapter navigation without returning to the table of contents.</p>
+                        <p>If true it indicates that the <i>accessibilityFeature="tableOfContents"</i> (Table of contents navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+
+						<p>This means that the resource includes a table of contents that provides links to the major sections of the content.</p>
 					</dd>
 				</dl>
 				<h4>Variables setup</h4>
 				<ol class="condition">
 
-					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
-
-                    <li><b>LET</b> <var>table_of_contents_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tableOfContents</i>"]</code>.</li>
+ 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
                     <li><b>LET</b> <var>index_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>index</i>"]</code>.</li>
 
+                    <li><b>LET</b> <var>next_previous_structural_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>structuralNavigation</i>"]</code>.</li>
+                    
                     <li><b>LET</b> <var>page_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>pageNavigation</i>"]</code>.</li>
 
-                    <li><b>LET</b> <var>next_previous_structural_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>structuralNavigation</i>"]</code>.</li>
+                    <li><b>LET</b> <var>table_of_contents_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tableOfContents</i>"]</code>.</li>
 
   				</ol>
 				<h4 id="navigation-instructions">Instructions</h4>
@@ -637,23 +631,24 @@
 						<span><b>IF</b> <var>table_of_contents_navigation</var> <b>OR</b> <var>index_navigation</var> <b>OR</b> <var>page_navigation</var> <b>OR</b> <var>next_previous_structural_navigation</var>:</span>
 
 						<ol class="condition">
+                            <li>
+							    <span><b>IF</b> <var>page_navigation</var>:</span>
+				                <span><b>THEN</b> display <code id="navigation-page-navigation">"Go to page"</code>.</span>
+							</li>
 							<li>
-								<span><b>IF</b> <var>table_of_contents_navigation</var>:</span>
-								<span><b>THEN</b> display <code id="navigation-toc">"Table of contents"</code>.</span>
+ 							<span><b>IF</b> <var>next_previous_structural_navigation</var>:</span>
+								<span><b>THEN</b> display <code id="navigation-structural">"Headings"</code>.</span>
 							</li>
 							<li>
 								<span><b>IF</b> <var>index_navigation</var>:</span>
 								<span><b>THEN</b> display <code id="navigation-index">"Index"</code>.</span>
 							</li>
                             <li>
-							     <span><b>IF</b> <var>page_navigation</var>:</span>
-								<span><b>THEN</b> display <code id="navigation-page-navigation">"Go to page"</code>.</span>
+								<span><b>IF</b> <var>table_of_contents_navigation</var>:</span>
+								<span><b>THEN</b> display <code id="navigation-toc">"Table of contents"</code>.</span>
 							</li>
-							<li>
- 							<span><b>IF</b> <var>next_previous_structural_navigation</var>:</span>
-								<span><b>THEN</b> display <code id="navigation-structural">"Headings"</code>.</span>
-							</li></ol>
-							</li>
+                        </ol>
+				    </li>
 
 
 
@@ -670,30 +665,31 @@
                 <p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
-					<dt><var>contains_charts_diagrams</var></dt>
+                    <dt><var>chemical_formula_as_latex</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessMode="chartOnVisual"</i> (charts encoded in visual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that the product has some information conveyed via some form of illustration, such as a graph, a chart, a diagram, a figure, etc).</p>
-					</dd>
-					<dt><var>long_text_descriptions</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="longDescriptions"</i> (Full alternative textual description) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that a full alternative textual description has been supplied for all of the graphs, charts, diagrams, or figures necessary to understand the content.</p>
-					</dd>
-					<dt><var>contains_chemical_formula</var></dt>
-					<dd>
-						<p>If true it indicates that the <i>accessMode="chemOnVisual"</i> (Chemical content) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that the publication contains chemical notations, formulae.</p>
+						<p>If true it indicates that the <i>accessibilityFeature="latex-chemistry"</i> (Accessible chemistry content as Latex) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that the chemical formulae are presented using Latex and works with compatible assistive technology.</p>
 					</dd>
 					<dt><var>chemical_formula_as_mathml</var></dt>
 					<dd>
 						<p>If true it indicates that the <i>accessibilityFeature="MathML-chemistry"</i> (Accessible chemistry content as MathML) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the chemical formulae are presented using MathML and works with compatible assistive technology.</p>
 					</dd>
-<dt><var>chemical_formula_as_latex</var></dt>
+                    <dt><var>closed_captions</var></dt>
+                        <dd>
+                        <p>If true it indicates that the <i>accessibilityFeature="closedCaptions"</i> (Closed captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>This means that the audio content of a video can be seen via closed captions that can be turned on or off  by the viewer and which will be a separate file from the video itself.</p>
+                    </dd>
+
+					<dt><var>contains_charts_diagrams</var></dt>
 					<dd>
-						<p>If true it indicates that the <i>accessibilityFeature="latex-chemistry"</i> (Accessible chemistry content as Latex) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that the chemical formulae are presented using Latex and works with compatible assistive technology.</p>
+                        <p>If true it indicates that the <i>accessMode="chartOnVisual"</i> (charts encoded in visual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that the product has some information conveyed via some form of illustration, such as a graph, a chart, a diagram, a figure, etc).</p>
+					</dd>
+					<dt><var>contains_chemical_formula</var></dt>
+					<dd>
+						<p>If true it indicates that the <i>accessMode="chemOnVisual"</i> (Chemical content) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that the publication contains chemical notations, formulae.</p>
 					</dd>
 
 					<dt><var>contains_math_formula</var></dt>
@@ -701,6 +697,12 @@
 						<p>If true it indicates that the <i>accessibilityFeature="describedMath"</i> (Mathematical content) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the publication contains mathematical notation, equations, formulae.</p>
 					</dd>
+					<dt><var>long_text_descriptions</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityFeature="longDescriptions"</i> (Full alternative textual description) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that a full alternative textual description has been supplied for all of the graphs, charts, diagrams, or figures necessary to understand the content.</p>
+					</dd>
+                    
 					<dt><var>math_formula_as_latex</var></dt>
 					<dd>
 						<p>If true it indicates that the <i>accessibilityFeature="latex"</i> (Accessible math content as LaTeX) is present in the package document, otherwise if false it means that the metadata is not present.</p>
@@ -711,17 +713,12 @@
 						<p>If true it indicates that the <i>accessibilityFeature="MathML"</i> (Accessible math content as MathML) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that all mathematical content is presented using MathML and works with compatible assistive technology.</p>
 					</dd>
-						<dt><var>closed_captions</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="closedCaptions"</i> (Closed captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that the audio content of a video can be seen via closed captions that can be turned on or off  by the viewer and which will be a separate file from the video itself.</p>
-						</dd>
-						<dt><var>open_captions</var></dt>
+                    <dt><var>open_captions</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="openCaptions"</i> (Open captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 							<p>This means that the audio content of a video can be seen via open captions, which means they cannot be turned off and are always visible when the video plays.</p>
 						</dd>
-<dt><var>transcript</var></dt>
+                    <dt><var>transcript</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="transcript"</i> (transcript) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 							<p>This means that a transcript of the audio content of the product is supplied with it.</p>
@@ -731,58 +728,61 @@
 				<ol class="condition">
 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
-                    <li><b>LET</b> <var>contains_charts_diagrams</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>chartOnVisual</i>"]</code>.</li>
-
-                    <li><b>LET</b> <var>long_text_descriptions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>longDescriptions</i>"]</code>.</li>
-
-                    <li><b>LET</b> <var>contains_chemical_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>chemOnVisual</i>"]</code>.</li>
-
-
-                    <li><b>LET</b> <var>chemical_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>latex-chemistry</i>"]</code>.</li>
+                   <li><b>LET</b> <var>chemical_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>latex-chemistry</i>"]</code>.</li>
                     
                     <li><b>LET</b> <var>chemical_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>MathML-chemistry</i>"]</code>.</li>
 
-	                <li><b>LET</b> <var>contains_math_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>describedMath</i>"]</code>.</li>
+  	                <li><b>LET</b> <var>closed_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>closedCaptions</i>"]</code>.</li>
 
-	                <li><b>LET</b> <var>math_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>latex</i>"]</code>.</li>
+                    <li><b>LET</b> <var>contains_charts_diagrams</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>chartOnVisual</i>"]</code>.</li>
+                    
+                    <li><b>LET</b> <var>contains_chemical_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>chemOnVisual</i>"]</code>.</li>                    
+
+ 	                <li><b>LET</b> <var>contains_math_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>describedMath</i>"]</code>.</li>
+
+                    <li><b>LET</b> <var>long_text_descriptions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>longDescriptions</i>"]</code>.</li>
+
+ 	                <li><b>LET</b> <var>math_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>latex</i>"]</code>.</li>
 
 	                <li><b>LET</b> <var>math_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>MathML</i>"]</code>.</li>
 
-	                <li><b>LET</b> <var>closed_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>closedCaptions</i>"]</code>.</li>
-<li><b>LET</b> <var>open_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>openCaptions</i>"]</code>.</li>
-<li><b>LET</b> <var>transcript</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>transcript</i>"]</code>.</li>
+                    <li><b>LET</b> <var>open_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>openCaptions</i>"]</code>.</li>
+                    
+                    <li><b>LET</b> <var>transcript</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>transcript</i>"]</code>.</li>
 				</ol>
 				<h4 id="rich-content-instructions">Instructions</h4>
 				<ol class="condition">
-<li>
-						<span><b>IF</b> <var>math_formula_as_mathml</var>:</span>
-						<span><b>THEN</b> display <code id="rich-content-accessible-math-as-mathml">"Math as MathML"</code>.</span>
+                    <li>
+						<span><b>IF</b> <var>long_text_descriptions</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-extended">"Information-rich images are described by extended descriptions"</code>.</span>
 					</li>
-					<li>
-						<span><b>IF</b> <var>math_formula_as_latex</var>:</span>
-						<span><b>THEN</b> display <code id="rich-content-accessible-math-as-latex">"Math as LaTeX"</code>.</span>
+                   <li>
+						<span><b>IF</b> <var>chemical_formula_as_latex</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-accessible-chemistry-as-latex">"Chemical formulas in LaTeX"</code>.</span>
+					</li>
+   					<li>
+						<span><b>IF</b> <var>chemical_formula_as_mathml</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-accessible-chemistry-as-mathml">"Chemical formulas in MathML"</code>.</span>
 					</li>
 					<li>
 						<span><b>IF</b> <var>contains_math_formula</var>:</span>
 						<span><b>THEN</b> display <code id="rich-content-accessible-math-described">"Text descriptions of math are provided"</code>.</span>
 					</li>
 					<li>
-						<span><b>IF</b> <var>chemical_formula_as_mathml</var>:</span>
-						<span><b>THEN</b> display <code id="rich-content-accessible-chemistry-as-mathml">"Chemical formulas in MathML"</code>.</span>
+						<span><b>IF</b> <var>math_formula_as_latex</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-accessible-math-as-latex">"Math as LaTeX"</code>.</span>
 					</li>
-<li>
-						<span><b>IF</b> <var>chemical_formula_as_latex</var>:</span>
-						<span><b>THEN</b> display <code id="rich-content-accessible-chemistry-as-latex">"Chemical formulas in LaTeX"</code>.</span>
+
+                    <li>
+						<span><b>IF</b> <var>math_formula_as_mathml</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-accessible-math-as-mathml">"Math as MathML"</code>.</span>
 					</li>
-				<li>
-						<span><b>IF</b> <var>long_text_descriptions</var>:</span>
-						<span><b>THEN</b> display <code id="rich-content-extended">"Information-rich images are described by extended descriptions"</code>.</span>
-					</li>
-					<li>
+                    
+ 					<li>
 						<span><b>IF</b> <var>closed_captions</var>:</span>
 						<span><b>THEN</b> display <code id="rich-content-closed-captions">"Videos have closed captions"</code>.</span>
 					</li>
-					<li>
+ 					<li>
 						<span><b>IF</b> <var>open_captions</var>:</span>
 						<span><b>THEN</b> display <code id="rich-content-open-captions">"Videos have open captions"</code>.</span>
 					</li>
@@ -790,6 +790,7 @@
 						<span><b>IF</b> <var>transcript</var>:</span>
 						<span><b>THEN</b> display <code id="rich-content-transcript">"Transcript(s) provided"</code>.</span>
 					</li>
+                                        
 					<li>
 						<span><b>IF</b> <b>NOT</b> (<var>math_formula_as_mathml</var> <b>OR</b> <var>math_formula_as_latex</var> <b>OR</b> (<var>contains_math_formula</var> <b>AND</b> <var>long_text_descriptions</var>) <b>OR</b> <var>chemical_formula_as_mathml</var> <b>OR</b> <var>long_text_descriptions</var> <b>OR</b> <var>closed_captions</var> <b>OR</b> <var>open_captions</var> <b>OR</b> <var>transcript</var>):</span>
 						<span><b>THEN</b> either omit this display field if metadata is missing or display <code id="rich-content-unknown">"No information is available"</code>.</span>
@@ -804,39 +805,39 @@
 
         <h4>Understanding the variables</h4>
 				<dl>
-					<dt><var>no_hazards_or_warnings_confirmed</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="none"</i> (no accessibility hazards) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no associated hazard warnings with this product.</p>
-					</dd>
 					<dt><var>flashing_hazard</var></dt>
 					<dd>
                         <p>If true it indicates that the <i>accessibilityHazard="flashing"</i> (WARNING - Flashing hazards) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication in the accessibility metadata within the EPUB confirming that the product has a flashing hazard which must be displayed.</p>
-					</dd>
-					<dt><var>no_flashing_hazards</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="noFlashingHazard"</i> (No flashing hazard warning necessary) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no flashing hazards associated with this product.</p>
 					</dd>
 					<dt><var>motion_simulation_hazard</var></dt>
 					<dd>
                         <p>If true it indicates that the <i>accessibilityHazard="motionSimulation"</i> (WARNING - Motion simulation hazard) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication in the accessibility metadata within the EPUB confirming that the product has a motion simulation hazard which must be displayed.</p>
 					</dd>
+					<dt><var>no_flashing_hazards</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityHazard="noFlashingHazard"</i> (No flashing hazard warning necessary) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no flashing hazards associated with this product.</p>
+					</dd>
+					<dt><var>no_hazards_or_warnings_confirmed</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityHazard="none"</i> (no accessibility hazards) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no associated hazard warnings with this product.</p>
+					</dd>
 					<dt><var>no_motion_hazards</var></dt>
 					<dd>
                         <p>If true it indicates that the <i>accessibilityHazard="noMotionSimulationHazard"</i> (No motion simulation hazard warning necessary) is present in the package document, otherwise if false it means that the metadata is not present.</p> 		<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no motion simulation hazards associated with this product.</p>
-					</dd>
-					<dt><var>sound_hazard</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="Sound"</i> (WARNING - Sound hazard) is present in the package document, otherwise if false it means that the metadata is not present.</p>
- 						<p>This means that there is a positive indication in the accessibility metadata within the EPUB confirming that the product has a sound hazard which must be displayed.</p>
 					</dd>
 					<dt><var>no_sound_hazards</var></dt>
 					<dd>
                         <p>If true it indicates that the <i>accessibilityHazard="noSoundHazard"</i> (No sound hazard warning necessary) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no sound hazards associated with this product.</p>
+					</dd>
+					<dt><var>sound_hazard</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityHazard="Sound"</i> (WARNING - Sound hazard) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+ 						<p>This means that there is a positive indication in the accessibility metadata within the EPUB confirming that the product has a sound hazard which must be displayed.</p>
 					</dd>
 					<dt><var>unknown_if_contains_hazards</var></dt>
 					<dd>
@@ -850,27 +851,20 @@
 				<ol class="condition">
 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
-                    <li><b>LET</b> <var>no_hazards_or_warnings_confirmed</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>none</i>"]</code>.</li>
-
                     <li><b>LET</b> <var>flashing_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>flashing</i>"]</code>.</li>
-
-
-                    <li><b>LET</b> <var>no_flashing_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>noFlashingHazard</i>"]</code>.</li>
-
 
                     <li><b>LET</b> <var>motion_simulation_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>motionSimulation</i>"]</code>.</li>
 
+                    <li><b>LET</b> <var>no_flashing_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>noFlashingHazard</i>"]</code>.</li>
+                    
+                    <li><b>LET</b> <var>no_hazards_or_warnings_confirmed</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>none</i>"]</code>.</li>
 
                     <li><b>LET</b> <var>no_motion_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>noMotionSimulationHazard</i>"]</code>.</li>
 
-
-                    <li><b>LET</b> <var>sound_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>sound</i>"]</code>.</li>
-
-
-
                     <li><b>LET</b> <var>no_sound_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>noSoundHazard</i>"]</code>.</li>
 
-
+                    <li><b>LET</b> <var>sound_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>sound</i>"]</code>.</li>
+  
                     <li><b>LET</b> <var>unknown_if_contains_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>unknown</i>"]</code>.</li>
 
 				</ol>
@@ -977,11 +971,7 @@
 
 				<h4>Understanding the variables</h4>
 				<dl>
-					<dt><var>eaa_exemption_micro_enterprises</var></dt>
-					<dd>
-						<p>If true it indicates that the <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa-microenterprise</a>"</i> (EEA exception 1 – Micro-enterprises) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that the digital product falls under European Accessibility Act exemption for Micro-enterprises (as defined by current regulations). The product may not have to comply with requirements of the EAA if the publisher is a micro-enterprise.</p>
-					</dd>
+
 					<dt><var>eaa_exception_disproportionate_burden</var></dt>
 					<dd>
 						<p>If true it indicates that the <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa_disproportionate_burden</a>"</i> (EAA exception 2 – Disproportionate burden) is present in the package document, otherwise if false it means that the metadata is not present.</p>
@@ -992,13 +982,19 @@
 						<p>If true it indicates that the <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa_fundamental_modification</a>"</i> (EAA exception 3 – Fundamental modification) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that the digital product falls under European Accessibility Act exception for Fundamental modification (as defined by current regulations). The product may not have to comply with requirements of the EAA if doing so requires a fundamental modification of the nature of the product or service.</p>
 					</dd>
-				</dl>
+					<dt><var>eaa_exemption_micro_enterprises</var></dt>
+					<dd>
+						<p>If true it indicates that the <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa-microenterprise</a>"</i> (EEA exception 1 – Micro-enterprises) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that the digital product falls under European Accessibility Act exemption for Micro-enterprises (as defined by current regulations). The product may not have to comply with requirements of the EAA if the publisher is a micro-enterprise.</p>
+					</dd>
+                </dl>
 				<h4>Variables setup</h4>
 				<ol class="condition">
 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
-					<li><b>LET</b> <var>eaa_exemption_micro_enterprises</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="a11y:<i>exemption</i>" and normalize-space()="<i>eaa-microenterprise</i>"]</code>.</li>
 					<li><b>LET</b> <var>eaa_exception_disproportionate_burden</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="a11y:<i>exemption</i>" and normalize-space()="<i>eaa-disproportionate-burden</i>"]</code>.</li>
 					<li><b>LET</b> <var>eaa_exception_fundamental_modification</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="a11y:<i>exemption</i>" and normalize-space()="<i>eaa-fundamental-alteration</i>"]</code>.</li>
+					<li><b>LET</b> <var>eaa_exemption_micro_enterprises</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="a11y:<i>exemption</i>" and normalize-space()="<i>eaa-microenterprise</i>"]</code>.</li>
+
 				</ol>
 				<h4 id="legal-considerations-instructions">Instructions</h4>
 				<ol class="condition">
@@ -1021,6 +1017,12 @@
 
                     <h4>Understanding the variables</h4>
 					<dl>
+						<dt><var>aria</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="aria"</i>  (ARIA roles - semantic markup) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that the use of ARIA, including <a href="https://w3c.github.io/dpub-aria/">DPUB ARIA</a> is used to improve the semantic markup of the publication.</p>
+						</dd>
+                        
 						<dt><var>audio_descriptions</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="audioDescriptions"</i> (Audio Descriptions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
@@ -1033,42 +1035,11 @@
 							<p>This means that there is braille available within the publication.</p>
 						</dd>
 
-						<dt><var>tactile_graphic</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="tactileGraphic"</i> (tactile 2D graphic) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that there is tactile graphic(s) contained within this publication.</p>
-						</dd>
-                        
-						<dt><var>tactile_object</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="tactileObject"</i> (tactile 3D object) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that there is tactile 3D object(s) contained within this publication.</p>
-						</dd>
-
-						<dt><var>sign_language</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="signLanguage"</i> (Sign language interpretation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that a full signing of audio content of the product is supplied with the video file.</p>
-						</dd>
-
-						<dt><var>aria</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="aria"</i>  (ARIA roles - semantic markup) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that the use of ARIA, including <a href="https://w3c.github.io/dpub-aria/">DPUB ARIA</a> is used to improve the semantic markup of the publication.</p>
-						</dd>
-                        
-  						<dt><var>full_ruby_annotations</var></dt>
+                        <dt><var>full_ruby_annotations</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="fullRubyAnnotations"</i> (Full Ruby Annotations) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 							<p>This means that ruby annotations are attached to every CJK ideographic character in the content. Ruby annotations are used as pronunciation guides for the logographic characters for languages like Chinese or Japanese. They make difficult CJK ideographic characters more accessible.</p>
 						</dd>
-
-						<dt><var>text_to_speech_hinting</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="ttsMarkup"</i>  (Text-to-speech markup provided) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that text-to-speech has been optimized through provision of PLS lexicons, SSML or CSS Speech synthesis hints or other speech synthesis markup languages or hinting.</p>
-						</dd>
-                        
 						<dt><var>high_contrast_between_foreground_and_background_audio</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="highContrastAudio"</i> (Use of high contrast between foreground and background audio) is present in the package document, otherwise if false it means that the metadata is not present.</p>
@@ -1092,34 +1063,51 @@
                             <p>If true it indicates that the <i>accessibilityFeature="pageBreakMarkers"</i> (Print-equivalent page numbering) is present in the package document, otherwise if false it means that the metadata is not present.</p>
                             <p>This means that the publication contains references to the page numbering.</p>
                         </dd>
-                        
- 						<dt><var>ruby_annotations</var></dt>
+
+						<dt><var>ruby_annotations</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="rubyAnnotations"</i> (Ruby Annotations) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 							<p>This means that ruby annotations are attached to some but not all CJK ideographic characters in the content.</p>
 						</dd>
-					</dl>
+                        
+						<dt><var>sign_language</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="signLanguage"</i> (Sign language interpretation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that a full signing of audio content of the product is supplied with the video file.</p>
+						</dd>
+
+
+						<dt><var>tactile_graphic</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="tactileGraphic"</i> (tactile 2D graphic) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that there is tactile graphic(s) contained within this publication.</p>
+						</dd>
+                        
+						<dt><var>tactile_object</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="tactileObject"</i> (tactile 3D object) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that there is tactile 3D object(s) contained within this publication.</p>
+						</dd>
+
+ 						<dt><var>text_to_speech_hinting</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="ttsMarkup"</i>  (Text-to-speech markup provided) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that text-to-speech has been optimized through provision of PLS lexicons, SSML or CSS Speech synthesis hints or other speech synthesis markup languages or hinting.</p>
+						</dd>
+                        
+ 					</dl>
 
 					<h4>Variables setup</h4>
 					<ol class="condition">
                         <li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
                         
+						<li><b>LET</b> <var>aria</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>aria</i>"]</code>.</li>
+                        
 						<li><b>LET</b> <var>audio_descriptions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>audioDescription</i>"]</code>.</li>
 						
                         <li><b>LET</b> <var>braille</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>braille</i>"]</code>.</li>
-                        
-                        <li><b>LET</b> <var>tactile_graphic</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tactileGraphic</i>"]</code>.</li>
-                        
-                        <li><b>LET</b> <var>tactile_object</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tactileObject</i>"]</code>.</li>
-                        
-                        <li><b>LET</b> <var>sign_language</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>signLanguage</i>"]</code>.</li>
-                        
 
-						<li><b>LET</b> <var>aria</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>aria</i>"]</code>.</li>
-                        
 						<li><b>LET</b> <var>full_ruby_annotations</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>fullRubyAnnotations</i>"]</code>.</li>
-                        
-						<li><b>LET</b> <var>text_to_speech_hinting</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>ttsMarkup</i>"]</code>.</li>
                         
     				    <li><b>LET</b> <var>high_contrast_between_foreground_and_background_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>highContrastAudio</i>"]</code>.</li>
                         
@@ -1130,10 +1118,26 @@
                         <li><b>LET</b> <var>page_break_markers</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>pageBreakMarkers</i>"]</code>.</li>
                         
 						<li><b>LET</b> <var>ruby_annotations</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>rubyAnnotations</i>"]</code>.</li>
-    				</ol>
+                        
+                        <li><b>LET</b> <var>sign_language</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>signLanguage</i>"]</code>.</li>
 
+                       <li><b>LET</b> <var>tactile_graphic</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tactileGraphic</i>"]</code>.</li>
+                        
+                        <li><b>LET</b> <var>tactile_object</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tactileObject</i>"]</code>.</li>
+                        
+ 						<li><b>LET</b> <var>text_to_speech_hinting</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>ttsMarkup</i>"]</code>.</li>
+    				</ol>
+                        
 					<h4 id="additional-accessibility-information-instructions">Instructions</h4>
 					<ol class="condition">
+                        <li>
+                            <span><b>IF</b> <var>page_break_markers</var>:</span>
+                            <span><b>THEN</b> display <code id="additional-accessibility-information-page-breaks">"Page breaks"</code>.</span>
+                        </li>
+						<li>
+							<span><b>IF</b> <var>aria</var>:</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-aria">"ARIA"</code>.</span>
+						</li>
 						<li>
 							<span><b>IF</b> <var>audio_descriptions</var>:</span>
 							<span><b>THEN</b> display <code id="additional-accessibility-information-audio-descriptions">"Audio descriptions"</code>.</span></li>
@@ -1142,28 +1146,8 @@
 							<span><b>THEN</b> display <code id="additional-accessibility-information-braille">"Braille"</code>.</span>
 						</li>
 						<li>
-							<span><b>IF</b> <var>tactile_graphic</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-graphics">"Tactile graphics"</code>.</span>
-						</li>
-						<li>
-							<span><b>IF</b> <var>tactile_object</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-objects">"Tactile 3D objects"</code>.</span>
-						</li>
-						<li>
-							<span><b>IF</b> <var>sign_language</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-sign-language">"Sign language"</code>.</span>
-						</li>
-						<li>
-							<span><b>IF</b> <var>aria</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-aria">"ARIA"</code>.</span>
-						</li>
-						<li>
 							<span><b>IF</b> <var>full_ruby_annotations</var>:</span>
 							<span><b>THEN</b> display <code id="additional-accessibility-information-full-ruby-annotations">"Full ruby annotations"</code>.</span>
-						</li>
-						<li>
-							<span><b>IF</b> <var>text_to_speech_hinting</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-text-to-speech-hinting">"Text-to-speech hinting provided"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>high_contrast_between_foreground_and_background_audio</var>:</span>
@@ -1177,13 +1161,26 @@
 							<span><b>IF</b> <var>large_print</var>:</span>
 							<span><b>THEN</b> display <code id="additional-accessibility-information-large-print">"Large print"</code>.</span>
 						</li>
-                        <li>
-                            <span><b>IF</b> <var>page_break_markers</var>:</span>
-                            <span><b>THEN</b> display <code id="additional-accessibility-information-page-breaks">"Page breaks"</code>.</span>
-                        </li>
 						<li>
 							<span><b>IF</b> <var>ruby_annotations</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-ruby-annotations">"Some Ruby annotations"</code>.</span></li>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-ruby-annotations">"Some Ruby annotations"</code>.</span>
+                        </li>
+						<li>
+							<span><b>IF</b> <var>sign_language</var>:</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-sign-language">"Sign language"</code>.</span>
+						</li>
+						<li>
+							<span><b>IF</b> <var>tactile_graphic</var>:</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-graphics">"Tactile graphics"</code>.</span>
+						</li>
+						<li>
+							<span><b>IF</b> <var>tactile_object</var>:</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-objects">"Tactile 3D objects"</code>.</span>
+						</li>
+						<li>
+							<span><b>IF</b> <var>text_to_speech_hinting</var>:</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-text-to-speech-hinting">"Text-to-speech hinting provided"</code>.</span>
+						</li>
 					</ol>
 			</section>
 

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -286,34 +286,48 @@
                         </li>
                     	
                     	<li>
-                    		<b>LET</b> <var>has_nonvisual_metadata</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property=("<i>schema:accessMode</i>", "<i>schema:accessModeSufficient</i>")]</code>.
+                    		<b>LET</b> <var>audio_only_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space() = "auditory" and count(//meta[@property="schema:<i>accessMode</i>"]) = 1]</code>.
                     	</li>
                     	
-                        <li>
+                    	<li>
+                    		<b>LET</b> <var>braille_only_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space() = "tactile" and count(//meta[@property="schema:<i>accessMode</i>"]) = 1]</code>.
+                    	</li>
+                    	
+                    	<li>
                             <b>LET</b> <var>non_textual_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessMode</i>" and not(normalize-space() = "textual")]</code>.
                         </li>
 
                         <li>
                             <b>LET</b> <var>textual_alternatives</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessibilityFeature</i>" and normalize-space()=("<i>longDescription</i>", "<i>alternativeText</i>", "<i>describedMath"</i>, "<i>transcript</i>")]</code>.
                         </li>
+                    	
+                    	<li>
+                    		<b>LET</b> <var>visual_only_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space() = "visual" and count(//meta[@property="schema:<i>accessMode</i>"]) = 1]</code>.
+                    	</li>
                     </ol>
                     <h5>Instructions</h5>
                     <ol class="condition">
-                    	<li>
-                    		<span><b>IF</b> <b>NOT</b> <var>has_nonvisual_metadata</var>:</span>
-                    		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-no-metadata">"No information about nonvisual reading is available"</code>.</span>
-                    	</li>
-
                         <li>
-                            <span><b>ELSE IF</b> <var>all_necessary_content_textual</var>:</span>
+                            <span><b>IF</b> <var>all_necessary_content_textual</var>:</span>
                             <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-readable">"Readable in read aloud or dynamic braille"</code>.</span>
                         </li>
-                        <li>
+                    	
+                    	<li>
+                    		<span><b>ELSE IF</b> <var>audio_only_content</var> or <var>visual_only_content</var>:</span>
+                    		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-audio-only">"Not readable in read aloud or dynamic braille"</code>.</span>
+                    	</li>
+                    	
+                    	<li>
+                    		<span><b>ELSE IF</b> <var>braille_only_content</var>:</span>
+                    		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-braille-only">"Readable in dynamic braille"</code>.</span>
+                    	</li>
+                    	
+                    	<li>
                             <span><b>ELSE IF</b> <var>non_textual_content</var> <b>AND</b> <b>NOT</b> <var>textual_alternative_images</var>:</span>
                             <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-not-fully">"Not fully readable in read aloud or dynamic braille"</code>.</span>
                         </li>
                     	
-                        <li><b>ELSE</b> display <code id="ways-of-reading-nonvisual-reading-may-not-fully">"May not be fully readable in read aloud or dynamic braille"</code>.</li>
+                    	<li><b>ELSE</b> display <code id="ways-of-reading-nonvisual-no-metadata">"No information about nonvisual reading is available"</code>.</li>
                     	
                     	<li>
                     		<span><b>IF</b> <var>textual_alternatives</var>:</span>
@@ -874,7 +888,7 @@
 						<span><b>THEN</b> display <code id="hazards-none">"No hazards"</code>.</span>
 					</li>
 					<li>
-						<span><b>ELSE IF</b> <var>flashing_hazard</var> <b>OR</b> <var>motion_simulation_hazard</var> <b>OR</b> <var>sound_hazard</var>:</span></li>
+						<span><b>ELSE IF</b> <var>flashing_hazard</var> <b>OR</b> <var>motion_simulation_hazard</var> <b>OR</b> <var>sound_hazard</var>:</span>
 						<b>THEN</b> <ul class="condition">
 							<li>
 								<span><b>IF</b> <var>flashing_hazard</var>:</span>
@@ -889,7 +903,7 @@
 								<span><b>THEN</b> display <code id="hazards-sound">"Sounds"</code>.</span>
 							</li>
 						</ul>
-
+					</li>
                     <li>
 						<span><b>ELSE IF</b> <var>unknown_if_contains_hazards</var>:</span>
 						<span><b>THEN</b> display <code id="hazards-unknown">"The presence of hazards is unknown"</code>.</span>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -257,10 +257,6 @@
                     	<dd>
                     		<p>If true it indicates that there is only a single access mode of auditory (an audiobook).</p>
                     	</dd>
-                    	<dt><var>braille_only_content</var></dt>
-                    	<dd>
-                    		<p>If true it indicates that there is only a single access mode of tactile (a digital braille publication).</p>
-                    	</dd>
                     	<dt><var>non_textual_content</var></dt>
                         <dd>
                             <p>If true it indicates that there is non-textual content such as images, audio, or video in the publication.</p>
@@ -297,10 +293,6 @@
                     	</li>
                     	
                     	<li>
-                    		<b>LET</b> <var>braille_only_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space() = "tactile" and count(//meta[@property="schema:<i>accessMode</i>"]) = 1]</code>.
-                    	</li>
-                    	
-                    	<li>
                             <b>LET</b> <var>non_textual_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessMode</i>" and not(normalize-space() = "textual")]</code>.
                         </li>
 
@@ -322,11 +314,6 @@
                             <span><b>IF</b> <var>all_necessary_content_textual</var>:</span>
                             <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-readable">"Readable in read aloud or dynamic braille"</code>.</span>
                         </li>
-                    	
-                    	<li>
-                    		<span><b>ELSE IF</b> <var>braille_only_content</var>:</span>
-                    		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-braille-only">"Readable in dynamic braille"</code>.</span>
-                    	</li>
                     	
                     	<li>
                             <span><b>ELSE IF</b> <var>non_textual_content</var> <b>AND</b> (<var>some_sufficient_text</var> <b>OR</b> <var>textual_alternatives</var>):</span>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -251,12 +251,15 @@
                     <dl>
                         <dt><var>all_necessary_content_textual</var></dt>
                         <dd>
-                            <p>If true it indicates that there is only a single access mode of textual or <i>accessModeSufficient="textual"</i> (all main content is provided in textual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                            <p>If true it indicates that there is only a single access mode of textual or <i>accessModeSufficient="textual"</i> (all main content is provided in textual form) is present in the package document.</p>
                         </dd>
-                    	<dt><var>has_nonvisual_metadata</var></dt>
+                    	<dt><var>audio_only_content</var></dt>
                     	<dd>
-                    		<p>If true it indicates that the publisher has stated a least one access mode or sufficient access mode.</p>
-                    		<p>If this metadata is not set, it is not possible to determine whether or not the content will be readable nonvisually.</p>
+                    		<p>If true it indicates that there is only a single access mode of auditory (an audiobook).</p>
+                    	</dd>
+                    	<dt><var>braille_only_content</var></dt>
+                    	<dd>
+                    		<p>If true it indicates that there is only a single access mode of tactile (a digital braille publication).</p>
                     	</dd>
                     	<dt><var>non_textual_content</var></dt>
                         <dd>
@@ -274,6 +277,10 @@
                             </ul>
                             <p>This means that there are textual alternatives for the non-textual content.</p>
                         </dd>
+                    	<dt><var>visual_only_content</var></dt>
+                    	<dd>
+                    		<p>If true it indicates that there is only a single access mode of visual and there are no sufficient access modes that include textual (e.g., comics and manga with no alternative text).</p>
+                    	</dd>
                     </dl>
                     <h5>Variables setup</h5>
                     <ol class="condition">
@@ -298,7 +305,7 @@
                         </li>
 
                         <li>
-                            <b>LET</b> <var>textual_alternatives</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessibilityFeature</i>" and normalize-space()=("<i>longDescription</i>", "<i>alternativeText</i>", "<i>describedMath"</i>, "<i>transcript</i>")]</code>.
+                            <b>LET</b> <var>textual_alternatives</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessModeSufficient</i>" and contains(normalize-space() = "textual") and string-length(normalize-space()) &gt; 7]</code>.
                         </li>
                     	
                     	<li>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -305,7 +305,7 @@
                         </li>
 
                         <li>
-                            <b>LET</b> <var>some_sufficient_text</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessModeSufficient</i>" and contains(normalize-space() = "textual") and string-length(normalize-space()) &gt; 7]</code>.
+                        	<b>LET</b> <var>some_sufficient_text</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[(@property="schema:accessMode" and contains(normalize-space(), "textual")) or (/package/metadata/meta[@property="schema:accessModeSufficient" and contains(normalize-space(), "textual") and string-length(normalize-space()) > 7)]</code>.
                         </li>
                     	
                     	<li>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -324,11 +324,6 @@
                         </li>
                     	
                     	<li>
-                    		<span><b>ELSE IF</b> <var>audio_only_content</var> or <var>visual_only_content</var>:</span>
-                    		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-audio-only">"Not readable in read aloud or dynamic braille"</code>.</span>
-                    	</li>
-                    	
-                    	<li>
                     		<span><b>ELSE IF</b> <var>braille_only_content</var>:</span>
                     		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-braille-only">"Readable in dynamic braille"</code>.</span>
                     	</li>
@@ -337,6 +332,11 @@
                             <span><b>ELSE IF</b> <var>non_textual_content</var> <b>AND</b> (<var>some_sufficient_text</var> <b>OR</b> <var>textual_alternatives</var>):</span>
                             <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-not-fully">"Not fully readable in read aloud or dynamic braille"</code>.</span>
                         </li>
+                    	
+                    	<li>
+                    		<span><b>ELSE IF</b> <var>audio_only_content</var> or <var>visual_only_content</var>:</span>
+                    		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-audio-only">"Not readable in read aloud or dynamic braille"</code>.</span>
+                    	</li>
                     	
                     	<li><b>ELSE</b> display <code id="ways-of-reading-nonvisual-no-metadata">"No information about nonvisual reading is available"</code>.</li>
                     	

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -305,7 +305,7 @@
                         </li>
 
                         <li>
-                        	<b>LET</b> <var>some_sufficient_text</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[(@property="schema:accessMode" and contains(normalize-space(), "textual")) or (/package/metadata/meta[@property="schema:accessModeSufficient" and contains(normalize-space(), "textual") and string-length(normalize-space()) > 7)]</code>.
+                        	<b>LET</b> <var>some_sufficient_text</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[(@property="schema:accessMode" and contains(normalize-space(), "textual")) or (@property="schema:accessModeSufficient" and contains(normalize-space(), "textual") and string-length(normalize-space()) > 7)]</code>.
                         </li>
                     	
                     	<li>
@@ -313,7 +313,7 @@
                     	</li>
                     	
                     	<li>
-                    		<b>LET</b> <var>visual_only_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[(@property="schema:<i>accessMode</i>" and normalize-space() = "visual" and count(//meta[@property="schema:<i>accessMode</i>"]) = 1) and not(@property="schema:<i>accessModeSufficient</i>" and contains(normalize-space(), "<i>textual</i>"))]</code>.
+                    		<b>LET</b> <var>visual_only_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[(@property="schema:<i>accessMode</i>" and normalize-space() = "visual" and count(//meta[@property="schema:<i>accessMode</i>"]) = 1) and not(//meta[@property="schema:<i>accessModeSufficient</i>" and contains(normalize-space(), "<i>textual</i>")])]</code>.
                     	</li>
                     </ol>
                     <h5>Instructions</h5>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -335,7 +335,7 @@
                     	
                     	<li>
                     		<span><b>ELSE IF</b> <var>audio_only_content</var> or <var>visual_only_content</var>:</span>
-                    		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-audio-only">"Not readable in read aloud or dynamic braille"</code>.</span>
+                    		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-none">"Not readable in read aloud or dynamic braille"</code>.</span>
                     	</li>
                     	
                     	<li><b>ELSE</b> display <code id="ways-of-reading-nonvisual-no-metadata">"No information about nonvisual reading is available"</code>.</li>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -302,7 +302,7 @@
                         </li>
                     	
                     	<li>
-                    		<b>LET</b> <var>visual_only_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space() = "visual" and count(//meta[@property="schema:<i>accessMode</i>"]) = 1]</code>.
+                    		<b>LET</b> <var>visual_only_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[(@property="schema:<i>accessMode</i>" and normalize-space() = "visual" and count(//meta[@property="schema:<i>accessMode</i>"]) = 1) and not(@property="schema:<i>accessModeSufficient</i>" and contains(normalize-space(), "<i>textual</i>"))]</code>.
                     	</li>
                     </ol>
                     <h5>Instructions</h5>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -290,7 +290,7 @@
                         </li>
 
                         <li>
-                            <b>LET</b> <var>textual_alternative</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessibilityFeature</i>" and normalize-space()=("<i>longDescription</i>", "<i>alternativeText</i>", "<i>describedMath"</i>, "<i>transcripts</i>")]</code>.
+                            <b>LET</b> <var>textual_alternatives</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessibilityFeature</i>" and normalize-space()=("<i>longDescription</i>", "<i>alternativeText</i>", "<i>describedMath"</i>, "<i>transcript</i>")]</code>.
                         </li>
                     </ol>
                     <h5>Instructions</h5>
@@ -312,7 +312,7 @@
                         <li><b>ELSE</b> display <code id="ways-of-reading-nonvisual-reading-may-not-fully">"May not be fully readable in read aloud or dynamic braille"</code>.</li>
                     	
                     	<li>
-                    		<span><b>IF</b> <var>textual_alternative_images</var>:</span>
+                    		<span><b>IF</b> <var>textual_alternatives</var>:</span>
                     		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-alt-text">"Has alternative text"</code>.</span>
                     	</li>
                     </ol>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -297,7 +297,7 @@
                         </li>
 
                         <li>
-                        	<b>LET</b> <var>some_sufficient_text</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[(@property="schema:accessMode" and contains(normalize-space(), "textual")) or (@property="schema:accessModeSufficient" and contains(normalize-space(), "textual") and string-length(normalize-space()) > 7)]</code>.
+                        	<b>LET</b> <var>some_sufficient_text</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[(@property="schema:accessMode" and contains(normalize-space(), "textual")) or (@property="schema:accessModeSufficient" and contains(normalize-space(), "textual"))]</code>.
                         </li>
                     	
                     	<li>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -252,7 +252,6 @@
                         <dt><var>all_necessary_content_textual</var></dt>
                         <dd>
                             <p>If true it indicates that there is only a single access mode of textual or <i>accessModeSufficient="textual"</i> (all main content is provided in textual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-                            <p><i>All non-decorative content supports reading without sight</i> means that all contents of the digital publication necessary to use and understanding, including text, images (via their alternative descriptions), audio and video material (via their transcripts, descriptions, captions or subtitles) are fully accessible via suitable reading devices, for example text-to-speech screen readers or tactile reading devices (‘Braille displays’), and nothing in the digital publication prevents or blocks the use of alternative reading modes. The entire publication can be navigated and ‘read’ using only text rendered via sound or touch, and does not require visual perception.</p>
                         </dd>
                     	<dt><var>has_nonvisual_metadata</var></dt>
                     	<dd>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -251,65 +251,70 @@
                     <dl>
                         <dt><var>all_necessary_content_textual</var></dt>
                         <dd>
-                            <p>If true it indicates that the <i>accessModeSufficient="textual"</i> (all main content is provided in textual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                            <p>If true it indicates that there is only a single access mode of textual or <i>accessModeSufficient="textual"</i> (all main content is provided in textual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
                             <p><i>All non-decorative content supports reading without sight</i> means that all contents of the digital publication necessary to use and understanding, including text, images (via their alternative descriptions), audio and video material (via their transcripts, descriptions, captions or subtitles) are fully accessible via suitable reading devices, for example text-to-speech screen readers or tactile reading devices (‘Braille displays’), and nothing in the digital publication prevents or blocks the use of alternative reading modes. The entire publication can be navigated and ‘read’ using only text rendered via sound or touch, and does not require visual perception.</p>
                         </dd>
-                        <dt><var>non_textual_content_images</var></dt>
+                        <dt><var>non_textual_content</var></dt>
                         <dd>
-                            <p>If true it indicates that at least one of the following is present in the package document:</p>
-                            <ul>
-                                <li><i>accessMode="chartOnVisual"</i> (Charts and Graphs);</li>
-                                <li><i>accessMode="chemOnVisual"</i> (Chemistry);</li>
-                                <li><i>accessMode="diagramOnVisual"</i> (Diagrams);</li>
-                                <li><i>accessMode="mathOnVisual"</i> (Math);</li>
-                                <li><i>accessMode="musicOnVisual"</i> (Music);</li>
-                                <li><i>accessMode="textOnVisual"</i> (Images of text);</li>
-                                <li>otherwise if false it means that this metadata is not present.</li>
-                            </ul>
-                            <p>This means that the content contains images of any type.</p>
+                            <p>If true it indicates that there is non-textual content such as images, audio, or video in the publication.</p>
                         </dd>
-                        <dt><var>textual_alternative_images</var></dt>
+                        <dt><var>textual_alternatives</var></dt>
                         <dd>
                             <p>If true it indicates that at least one of the following is present in the package document:</p>
                             <ul>
                                 <li><i>accessibilityFeature="alternativeText"</i> (Short alternative textual descriptions);</li>
                                 <li><i>accessibilityFeature="longDescription"</i> (Full alternative textual descriptions);</li>
                                 <li><i>accessibilityFeature="describedMath"</i> (Visual of math fully described));</li>
-                                <li>otherwise if false it means that this metadata is not present.</li>
+                            	<li><i>accessibilityFeature="transcript"</i> (Transcripts for audio and visual content));</li>
+                            	<li>otherwise if false it means that this metadata is not present.</li>
                             </ul>
-                            <p>This means that there are textual alternatives for images.</p>
+                            <p>This means that there are textual alternatives for the non-textual content.</p>
                         </dd>
                     </dl>
                     <h5>Variables setup</h5>
                     <ol class="condition">
-                        <li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
-
-                        <li><b>LET</b> <var>all_necessary_content_textual</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessModeSufficient</i>" and normalize-space()="<i>textual</i>"]</code>.</li>
-
                         <li>
-                            <b>LET</b> <var>non_textual_content_images</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessMode</i>" and normalize-space() = ("chartOnVisual", "chemOnVisual", "diagramOnVisual", "mathOnVisual", "musicOnVisual", "textOnVisual")]</code>.
+                        	<b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.
                         </li>
 
                         <li>
-                            <b>LET</b> <var>textual_alternative_images</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessibilityFeature</i>" and normalize-space()=("<i>longDescription</i>", "<i>alternativeText</i>","<i>describedMath"</i>)]</code>.
+                        	<b>LET</b> <var>all_necessary_content_textual</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[(@property="schema:<i>accessMode</i>" and normalize-space() = "textual" and count(//meta[@property="schema:<i>accessMode</i>"]) = 1) or (@property="schema:<i>accessModeSufficient</i>" and normalize-space()="<i>textual</i>")]</code>.
+                        </li>
+                    	
+                    	<li>
+                    		<b>LET</b> <var>has_nonvisual_metadata</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property=("<i>schema:accessMode</i>", "<i>schema:accessModeSufficient</i>")]</code>.
+                    	</li>
+                    	
+                        <li>
+                            <b>LET</b> <var>non_textual_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessMode</i>" and not(normalize-space() = "textual")]</code>.
+                        </li>
+
+                        <li>
+                            <b>LET</b> <var>textual_alternative</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessibilityFeature</i>" and normalize-space()=("<i>longDescription</i>", "<i>alternativeText</i>", "<i>describedMath"</i>, "<i>transcripts</i>")]</code>.
                         </li>
                     </ol>
                     <h5>Instructions</h5>
                     <ol class="condition">
+                    	<li>
+                    		<span><b>IF</b> <b>NOT</b> <var>has_nonvisual_metadata</var>:</span>
+                    		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-no-metadata">"No information about nonvisual reading is available"</code>.</span>
+                    	</li>
+
                         <li>
                             <span><b>IF</b> <var>all_necessary_content_textual</var>:</span>
                             <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-readable">"Readable in read aloud or dynamic braille"</code>.</span>
                         </li>
                         <li>
-                            <span><b>ELSE IF</b> <var>non_textual_content_images</var> <b>AND</b> <b>NOT</b> <var>textual_alternative_images</var>:</span>
+                            <span><b>ELSE IF</b> <var>non_textual_content</var> <b>AND</b> <b>NOT</b> <var>textual_alternative_images</var>:</span>
                             <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-not-fully">"Not fully readable in read aloud or dynamic braille"</code>.</span>
                         </li>
+                    	
                         <li><b>ELSE</b> display <code id="ways-of-reading-nonvisual-reading-may-not-fully">"May not be fully readable in read aloud or dynamic braille"</code>.</li>
-                        <li>
-                            <span><b>IF</b> <var>textual_alternative_images</var>:</span>
-                            <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-alt-text">"Has alternative text"</code>.</span>
-                        </li>
-
+                    	
+                    	<li>
+                    		<span><b>IF</b> <var>textual_alternative_images</var>:</span>
+                    		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-alt-text">"Has alternative text"</code>.</span>
+                    	</li>
                     </ol>
 
 
@@ -325,7 +330,13 @@
                         <dd>
                             <p>If true it indicates that the <i>accessModeSufficient="auditory"</i> (all main content is provided in audio form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
                         </dd>
-                        
+                        <dt><var>synchronised_pre_recorded_audio</var></dt>
+                        <dd>
+                            <p>If true it indicates that the <i>accessibilityFeature="sychronizedAudioText"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
+
+                            <p>This indicates that text-synchronised prerecorded audio narration (natural or synthesized voice) is included for substantially all textual matter, including all alternative descriptions, e.g. via a SMIL media overlay.</p>
+                        </dd>
+
                         <dt><var>audio_content</var></dt>
                         <dd>
                             <p>If true it indicates that the <i>accessMode="auditory"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
@@ -333,12 +344,7 @@
                             <p>This indicates that prerecorded audio content is included as part of the work.</p>
                         </dd>
 
-                        <dt><var>synchronised_pre_recorded_audio</var></dt>
-                        <dd>
-                            <p>If true it indicates that the <i>accessibilityFeature="sychronizedAudioText"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
 
-                            <p>This indicates that text-synchronised prerecorded audio narration (natural or synthesized voice) is included for substantially all textual matter, including all alternative descriptions, e.g. via a SMIL media overlay.</p>
-                        </dd>
                     </dl>
                     <h5>Variables setup</h5>
                     <ol class="condition">
@@ -346,9 +352,9 @@
 
                         <li><b>LET</b> <var>all_content_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessModeSufficient</i>" and normalize-space()="<i>auditory</i>"]</code>.</li>
 
-                        <li><b>LET</b> <var>audio_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>auditory</i>"]</code>.</li>
-
                         <li><b>LET</b> <var>synchronised_pre_recorded_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>sychronizedAudioText</i>"]</code>.</li>
+
+                        <li><b>LET</b> <var>audio_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>auditory</i>"]</code>.</li>
 
                     </ol>
                     <h5>Instructions</h5>
@@ -363,7 +369,7 @@
                         </li>
                         <li>
                             <span><b>ELSE IF</b> <var>audio_content</var>:</span>
-                            <span><b>THEN</b> display <code id="ways-of-reading-prerecorded-audio-complementary">"Prerecorded audio clips"</code>.</span>
+                            <span><b>THEN</b> display <code id="ways-of-reading-prerecorded-audio-complementary">"Complementary audio and text"</code>.</span>
                         </li>
 
                         <li>
@@ -382,6 +388,19 @@
 
 				<h4>Understanding the variables</h4>
 				<dl>
+					<dt><var>epub_version</var></dt>
+					<dd>
+                        <p>If set, provides the version of the EPUB Accessibility specification the
+                        	publication conforms to.</p>
+					</dd>
+					<dt><var>wcag_version</var></dt>
+					<dd>
+						<p>If set, provides the version of WCAG 2 the publication conforms to.</p>
+					</dd>
+					<dt><var>wcag_version</var></dt>
+					<dd>
+                        <p>If set, provides the WCAG 2 conformance level claimed.</p>
+					</dd>
 					<dt><var>certifier</var></dt>
 					<dd>
 						<p>Returns the description of <i>a11y:certifiedBy</i> (Compliance certification by (name)) if present in the package document, otherwise if false it means that the metadata is not present.</p>
@@ -407,15 +426,7 @@
 						<p>If true it indicates that the <i>conformsTo</i> is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that the publication conforms to some specification.</p>
 					</dd>
-					<dt><var>epub_version</var></dt>
-					<dd>
-                        <p>If set, provides the version of the EPUB Accessibility specification the
-                        	publication conforms to.</p>
-					</dd>
-					<dt><var>wcag_version</var></dt>
-					<dd>
-                        <p>If set, provides the WCAG 2 conformance level claimed.</p>
-					</dd>
+
 				</dl>
 
 				<h4>Variables setup</h4>
@@ -578,41 +589,41 @@
 
 				<h4>Understanding the variables</h4>
 				<dl>
-					<dt><var>index_navigation</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="index"</i> (Index navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-
-                        <p>This means that there is an index that provides direct (eg hyperlinked) access to uses of the index terms in the document body.</p>
-					</dd>
- 					<dt><var>next_previous_structural_navigation</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="structuralNavigation"</i> (Next / Previous structural navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that all levels of heading and other structural elements of the content are correctly marked up and (if applicable) numbered, to enable fast next heading / previous heading, next chapter / previous chapter navigation without returning to the table of contents.</p>
-					</dd>
-                   <dt><var>page_navigation</var></dt>
-                    <dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="pageNavigation"</i> (Page Navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-                        <p>This means that the e-publication includes a means of navigating to static page break locations.</p>
-                    </dd>
 					<dt><var>table_of_contents_navigation</var></dt>
 					<dd>
                         <p>If true it indicates that the <i>accessibilityFeature="tableOfContents"</i> (Table of contents navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 
 						<p>This means that the resource includes a table of contents that provides links to the major sections of the content.</p>
 					</dd>
+					<dt><var>index_navigation</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityFeature="index"</i> (Index navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+
+                        <p>This means that there is an index that provides direct (eg hyperlinked) access to uses of the index terms in the document body.</p>
+					</dd>
+                    <dt><var>page_navigation</var></dt>
+                    <dd>
+                        <p>If true it indicates that the <i>accessibilityFeature="pageNavigation"</i> (Page Navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>This means that the e-publication includes a means of navigating to static page break locations.</p>
+                    </dd>
+					<dt><var>next_previous_structural_navigation</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityFeature="structuralNavigation"</i> (Next / Previous structural navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that all levels of heading and other structural elements of the content are correctly marked up and (if applicable) numbered, to enable fast next heading / previous heading, next chapter / previous chapter navigation without returning to the table of contents.</p>
+					</dd>
 				</dl>
 				<h4>Variables setup</h4>
 				<ol class="condition">
 
- 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
+					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
+
+                    <li><b>LET</b> <var>table_of_contents_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tableOfContents</i>"]</code>.</li>
 
                     <li><b>LET</b> <var>index_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>index</i>"]</code>.</li>
 
-                    <li><b>LET</b> <var>next_previous_structural_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>structuralNavigation</i>"]</code>.</li>
-                    
                     <li><b>LET</b> <var>page_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>pageNavigation</i>"]</code>.</li>
 
-                    <li><b>LET</b> <var>table_of_contents_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tableOfContents</i>"]</code>.</li>
+                    <li><b>LET</b> <var>next_previous_structural_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>structuralNavigation</i>"]</code>.</li>
 
   				</ol>
 				<h4 id="navigation-instructions">Instructions</h4>
@@ -621,24 +632,23 @@
 						<span><b>IF</b> <var>table_of_contents_navigation</var> <b>OR</b> <var>index_navigation</var> <b>OR</b> <var>page_navigation</var> <b>OR</b> <var>next_previous_structural_navigation</var>:</span>
 
 						<ol class="condition">
-                            <li>
-							    <span><b>IF</b> <var>page_navigation</var>:</span>
-				                <span><b>THEN</b> display <code id="navigation-page-navigation">"Go to page"</code>.</span>
-							</li>
 							<li>
- 							<span><b>IF</b> <var>next_previous_structural_navigation</var>:</span>
-								<span><b>THEN</b> display <code id="navigation-structural">"Headings"</code>.</span>
+								<span><b>IF</b> <var>table_of_contents_navigation</var>:</span>
+								<span><b>THEN</b> display <code id="navigation-toc">"Table of contents"</code>.</span>
 							</li>
 							<li>
 								<span><b>IF</b> <var>index_navigation</var>:</span>
 								<span><b>THEN</b> display <code id="navigation-index">"Index"</code>.</span>
 							</li>
                             <li>
-								<span><b>IF</b> <var>table_of_contents_navigation</var>:</span>
-								<span><b>THEN</b> display <code id="navigation-toc">"Table of contents"</code>.</span>
+							     <span><b>IF</b> <var>page_navigation</var>:</span>
+								<span><b>THEN</b> display <code id="navigation-page-navigation">"Go to page"</code>.</span>
 							</li>
-                        </ol>
-				    </li>
+							<li>
+ 							<span><b>IF</b> <var>next_previous_structural_navigation</var>:</span>
+								<span><b>THEN</b> display <code id="navigation-structural">"Headings"</code>.</span>
+							</li></ol>
+							</li>
 
 
 
@@ -655,31 +665,30 @@
                 <p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
-                    <dt><var>chemical_formula_as_latex</var></dt>
+					<dt><var>contains_charts_diagrams</var></dt>
 					<dd>
-						<p>If true it indicates that the <i>accessibilityFeature="latex-chemistry"</i> (Accessible chemistry content as Latex) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that the chemical formulae are presented using Latex and works with compatible assistive technology.</p>
+                        <p>If true it indicates that the <i>accessMode="chartOnVisual"</i> (charts encoded in visual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that the product has some information conveyed via some form of illustration, such as a graph, a chart, a diagram, a figure, etc).</p>
+					</dd>
+					<dt><var>long_text_descriptions</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityFeature="longDescriptions"</i> (Full alternative textual description) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that a full alternative textual description has been supplied for all of the graphs, charts, diagrams, or figures necessary to understand the content.</p>
+					</dd>
+					<dt><var>contains_chemical_formula</var></dt>
+					<dd>
+						<p>If true it indicates that the <i>accessMode="chemOnVisual"</i> (Chemical content) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that the publication contains chemical notations, formulae.</p>
 					</dd>
 					<dt><var>chemical_formula_as_mathml</var></dt>
 					<dd>
 						<p>If true it indicates that the <i>accessibilityFeature="MathML-chemistry"</i> (Accessible chemistry content as MathML) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the chemical formulae are presented using MathML and works with compatible assistive technology.</p>
 					</dd>
-                    <dt><var>closed_captions</var></dt>
-                        <dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="closedCaptions"</i> (Closed captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-                        <p>This means that the audio content of a video can be seen via closed captions that can be turned on or off  by the viewer and which will be a separate file from the video itself.</p>
-                    </dd>
-
-					<dt><var>contains_charts_diagrams</var></dt>
+<dt><var>chemical_formula_as_latex</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessMode="chartOnVisual"</i> (charts encoded in visual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that the product has some information conveyed via some form of illustration, such as a graph, a chart, a diagram, a figure, etc).</p>
-					</dd>
-					<dt><var>contains_chemical_formula</var></dt>
-					<dd>
-						<p>If true it indicates that the <i>accessMode="chemOnVisual"</i> (Chemical content) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that the publication contains chemical notations, formulae.</p>
+						<p>If true it indicates that the <i>accessibilityFeature="latex-chemistry"</i> (Accessible chemistry content as Latex) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication that the chemical formulae are presented using Latex and works with compatible assistive technology.</p>
 					</dd>
 
 					<dt><var>contains_math_formula</var></dt>
@@ -687,12 +696,6 @@
 						<p>If true it indicates that the <i>accessibilityFeature="describedMath"</i> (Mathematical content) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the publication contains mathematical notation, equations, formulae.</p>
 					</dd>
-					<dt><var>long_text_descriptions</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="longDescriptions"</i> (Full alternative textual description) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication that a full alternative textual description has been supplied for all of the graphs, charts, diagrams, or figures necessary to understand the content.</p>
-					</dd>
-                    
 					<dt><var>math_formula_as_latex</var></dt>
 					<dd>
 						<p>If true it indicates that the <i>accessibilityFeature="latex"</i> (Accessible math content as LaTeX) is present in the package document, otherwise if false it means that the metadata is not present.</p>
@@ -703,12 +706,17 @@
 						<p>If true it indicates that the <i>accessibilityFeature="MathML"</i> (Accessible math content as MathML) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that all mathematical content is presented using MathML and works with compatible assistive technology.</p>
 					</dd>
-                    <dt><var>open_captions</var></dt>
+						<dt><var>closed_captions</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="closedCaptions"</i> (Closed captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that the audio content of a video can be seen via closed captions that can be turned on or off  by the viewer and which will be a separate file from the video itself.</p>
+						</dd>
+						<dt><var>open_captions</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="openCaptions"</i> (Open captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 							<p>This means that the audio content of a video can be seen via open captions, which means they cannot be turned off and are always visible when the video plays.</p>
 						</dd>
-                    <dt><var>transcript</var></dt>
+<dt><var>transcript</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="transcript"</i> (transcript) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 							<p>This means that a transcript of the audio content of the product is supplied with it.</p>
@@ -718,61 +726,58 @@
 				<ol class="condition">
 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
-                   <li><b>LET</b> <var>chemical_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>latex-chemistry</i>"]</code>.</li>
-                    
-                    <li><b>LET</b> <var>chemical_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>MathML-chemistry</i>"]</code>.</li>
-
-  	                <li><b>LET</b> <var>closed_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>closedCaptions</i>"]</code>.</li>
-
                     <li><b>LET</b> <var>contains_charts_diagrams</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>chartOnVisual</i>"]</code>.</li>
-                    
-                    <li><b>LET</b> <var>contains_chemical_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>chemOnVisual</i>"]</code>.</li>                    
-
- 	                <li><b>LET</b> <var>contains_math_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>describedMath</i>"]</code>.</li>
 
                     <li><b>LET</b> <var>long_text_descriptions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>longDescriptions</i>"]</code>.</li>
 
- 	                <li><b>LET</b> <var>math_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>latex</i>"]</code>.</li>
+                    <li><b>LET</b> <var>contains_chemical_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessMode</i>" and normalize-space()="<i>chemOnVisual</i>"]</code>.</li>
+
+
+                    <li><b>LET</b> <var>chemical_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>latex-chemistry</i>"]</code>.</li>
+                    
+                    <li><b>LET</b> <var>chemical_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>MathML-chemistry</i>"]</code>.</li>
+
+	                <li><b>LET</b> <var>contains_math_formula</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>describedMath</i>"]</code>.</li>
+
+	                <li><b>LET</b> <var>math_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>latex</i>"]</code>.</li>
 
 	                <li><b>LET</b> <var>math_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>MathML</i>"]</code>.</li>
 
-                    <li><b>LET</b> <var>open_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>openCaptions</i>"]</code>.</li>
-                    
-                    <li><b>LET</b> <var>transcript</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>transcript</i>"]</code>.</li>
+	                <li><b>LET</b> <var>closed_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>closedCaptions</i>"]</code>.</li>
+<li><b>LET</b> <var>open_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>openCaptions</i>"]</code>.</li>
+<li><b>LET</b> <var>transcript</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>transcript</i>"]</code>.</li>
 				</ol>
 				<h4 id="rich-content-instructions">Instructions</h4>
 				<ol class="condition">
-                    <li>
-						<span><b>IF</b> <var>long_text_descriptions</var>:</span>
-						<span><b>THEN</b> display <code id="rich-content-extended">"Information-rich images are described by extended descriptions"</code>.</span>
+<li>
+						<span><b>IF</b> <var>math_formula_as_mathml</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-accessible-math-as-mathml">"Math as MathML"</code>.</span>
 					</li>
-                   <li>
-						<span><b>IF</b> <var>chemical_formula_as_latex</var>:</span>
-						<span><b>THEN</b> display <code id="rich-content-accessible-chemistry-as-latex">"Chemical formulas in LaTeX"</code>.</span>
-					</li>
-   					<li>
-						<span><b>IF</b> <var>chemical_formula_as_mathml</var>:</span>
-						<span><b>THEN</b> display <code id="rich-content-accessible-chemistry-as-mathml">"Chemical formulas in MathML"</code>.</span>
+					<li>
+						<span><b>IF</b> <var>math_formula_as_latex</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-accessible-math-as-latex">"Math as LaTeX"</code>.</span>
 					</li>
 					<li>
 						<span><b>IF</b> <var>contains_math_formula</var>:</span>
 						<span><b>THEN</b> display <code id="rich-content-accessible-math-described">"Text descriptions of math are provided"</code>.</span>
 					</li>
 					<li>
-						<span><b>IF</b> <var>math_formula_as_latex</var>:</span>
-						<span><b>THEN</b> display <code id="rich-content-accessible-math-as-latex">"Math as LaTeX"</code>.</span>
+						<span><b>IF</b> <var>chemical_formula_as_mathml</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-accessible-chemistry-as-mathml">"Chemical formulas in MathML"</code>.</span>
 					</li>
-
-                    <li>
-						<span><b>IF</b> <var>math_formula_as_mathml</var>:</span>
-						<span><b>THEN</b> display <code id="rich-content-accessible-math-as-mathml">"Math as MathML"</code>.</span>
+<li>
+						<span><b>IF</b> <var>chemical_formula_as_latex</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-accessible-chemistry-as-latex">"Chemical formulas in LaTeX"</code>.</span>
 					</li>
-                    
- 					<li>
+				<li>
+						<span><b>IF</b> <var>long_text_descriptions</var>:</span>
+						<span><b>THEN</b> display <code id="rich-content-extended">"Information-rich images are described by extended descriptions"</code>.</span>
+					</li>
+					<li>
 						<span><b>IF</b> <var>closed_captions</var>:</span>
 						<span><b>THEN</b> display <code id="rich-content-closed-captions">"Videos have closed captions"</code>.</span>
 					</li>
- 					<li>
+					<li>
 						<span><b>IF</b> <var>open_captions</var>:</span>
 						<span><b>THEN</b> display <code id="rich-content-open-captions">"Videos have open captions"</code>.</span>
 					</li>
@@ -780,7 +785,6 @@
 						<span><b>IF</b> <var>transcript</var>:</span>
 						<span><b>THEN</b> display <code id="rich-content-transcript">"Transcript(s) provided"</code>.</span>
 					</li>
-                                        
 					<li>
 						<span><b>IF</b> <b>NOT</b> (<var>math_formula_as_mathml</var> <b>OR</b> <var>math_formula_as_latex</var> <b>OR</b> (<var>contains_math_formula</var> <b>AND</b> <var>long_text_descriptions</var>) <b>OR</b> <var>chemical_formula_as_mathml</var> <b>OR</b> <var>long_text_descriptions</var> <b>OR</b> <var>closed_captions</var> <b>OR</b> <var>open_captions</var> <b>OR</b> <var>transcript</var>):</span>
 						<span><b>THEN</b> either omit this display field if metadata is missing or display <code id="rich-content-unknown">"No information is available"</code>.</span>
@@ -795,39 +799,39 @@
 
         <h4>Understanding the variables</h4>
 				<dl>
+					<dt><var>no_hazards_or_warnings_confirmed</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityHazard="none"</i> (no accessibility hazards) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no associated hazard warnings with this product.</p>
+					</dd>
 					<dt><var>flashing_hazard</var></dt>
 					<dd>
                         <p>If true it indicates that the <i>accessibilityHazard="flashing"</i> (WARNING - Flashing hazards) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication in the accessibility metadata within the EPUB confirming that the product has a flashing hazard which must be displayed.</p>
-					</dd>
-					<dt><var>motion_simulation_hazard</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="motionSimulation"</i> (WARNING - Motion simulation hazard) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that there is a positive indication in the accessibility metadata within the EPUB confirming that the product has a motion simulation hazard which must be displayed.</p>
 					</dd>
 					<dt><var>no_flashing_hazards</var></dt>
 					<dd>
                         <p>If true it indicates that the <i>accessibilityHazard="noFlashingHazard"</i> (No flashing hazard warning necessary) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no flashing hazards associated with this product.</p>
 					</dd>
-					<dt><var>no_hazards_or_warnings_confirmed</var></dt>
+					<dt><var>motion_simulation_hazard</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="none"</i> (no accessibility hazards) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no associated hazard warnings with this product.</p>
+                        <p>If true it indicates that the <i>accessibilityHazard="motionSimulation"</i> (WARNING - Motion simulation hazard) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that there is a positive indication in the accessibility metadata within the EPUB confirming that the product has a motion simulation hazard which must be displayed.</p>
 					</dd>
 					<dt><var>no_motion_hazards</var></dt>
 					<dd>
                         <p>If true it indicates that the <i>accessibilityHazard="noMotionSimulationHazard"</i> (No motion simulation hazard warning necessary) is present in the package document, otherwise if false it means that the metadata is not present.</p> 		<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no motion simulation hazards associated with this product.</p>
 					</dd>
-					<dt><var>no_sound_hazards</var></dt>
-					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="noSoundHazard"</i> (No sound hazard warning necessary) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no sound hazards associated with this product.</p>
-					</dd>
 					<dt><var>sound_hazard</var></dt>
 					<dd>
                         <p>If true it indicates that the <i>accessibilityHazard="Sound"</i> (WARNING - Sound hazard) is present in the package document, otherwise if false it means that the metadata is not present.</p>
  						<p>This means that there is a positive indication in the accessibility metadata within the EPUB confirming that the product has a sound hazard which must be displayed.</p>
+					</dd>
+					<dt><var>no_sound_hazards</var></dt>
+					<dd>
+                        <p>If true it indicates that the <i>accessibilityHazard="noSoundHazard"</i> (No sound hazard warning necessary) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no sound hazards associated with this product.</p>
 					</dd>
 					<dt><var>unknown_if_contains_hazards</var></dt>
 					<dd>
@@ -841,20 +845,27 @@
 				<ol class="condition">
 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
+                    <li><b>LET</b> <var>no_hazards_or_warnings_confirmed</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>none</i>"]</code>.</li>
+
                     <li><b>LET</b> <var>flashing_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>flashing</i>"]</code>.</li>
+
+
+                    <li><b>LET</b> <var>no_flashing_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>noFlashingHazard</i>"]</code>.</li>
+
 
                     <li><b>LET</b> <var>motion_simulation_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>motionSimulation</i>"]</code>.</li>
 
-                    <li><b>LET</b> <var>no_flashing_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>noFlashingHazard</i>"]</code>.</li>
-                    
-                    <li><b>LET</b> <var>no_hazards_or_warnings_confirmed</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>none</i>"]</code>.</li>
 
                     <li><b>LET</b> <var>no_motion_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>noMotionSimulationHazard</i>"]</code>.</li>
 
-                    <li><b>LET</b> <var>no_sound_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>noSoundHazard</i>"]</code>.</li>
 
                     <li><b>LET</b> <var>sound_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>sound</i>"]</code>.</li>
-  
+
+
+
+                    <li><b>LET</b> <var>no_sound_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>noSoundHazard</i>"]</code>.</li>
+
+
                     <li><b>LET</b> <var>unknown_if_contains_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>unknown</i>"]</code>.</li>
 
 				</ol>
@@ -961,7 +972,11 @@
 
 				<h4>Understanding the variables</h4>
 				<dl>
-
+					<dt><var>eaa_exemption_micro_enterprises</var></dt>
+					<dd>
+						<p>If true it indicates that the <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa-microenterprise</a>"</i> (EEA exception 1 – Micro-enterprises) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>This means that the digital product falls under European Accessibility Act exemption for Micro-enterprises (as defined by current regulations). The product may not have to comply with requirements of the EAA if the publisher is a micro-enterprise.</p>
+					</dd>
 					<dt><var>eaa_exception_disproportionate_burden</var></dt>
 					<dd>
 						<p>If true it indicates that the <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa_disproportionate_burden</a>"</i> (EAA exception 2 – Disproportionate burden) is present in the package document, otherwise if false it means that the metadata is not present.</p>
@@ -972,19 +987,13 @@
 						<p>If true it indicates that the <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa_fundamental_modification</a>"</i> (EAA exception 3 – Fundamental modification) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that the digital product falls under European Accessibility Act exception for Fundamental modification (as defined by current regulations). The product may not have to comply with requirements of the EAA if doing so requires a fundamental modification of the nature of the product or service.</p>
 					</dd>
-					<dt><var>eaa_exemption_micro_enterprises</var></dt>
-					<dd>
-						<p>If true it indicates that the <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa-microenterprise</a>"</i> (EEA exception 1 – Micro-enterprises) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that the digital product falls under European Accessibility Act exemption for Micro-enterprises (as defined by current regulations). The product may not have to comply with requirements of the EAA if the publisher is a micro-enterprise.</p>
-					</dd>
-                </dl>
+				</dl>
 				<h4>Variables setup</h4>
 				<ol class="condition">
 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
+					<li><b>LET</b> <var>eaa_exemption_micro_enterprises</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="a11y:<i>exemption</i>" and normalize-space()="<i>eaa-microenterprise</i>"]</code>.</li>
 					<li><b>LET</b> <var>eaa_exception_disproportionate_burden</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="a11y:<i>exemption</i>" and normalize-space()="<i>eaa-disproportionate-burden</i>"]</code>.</li>
 					<li><b>LET</b> <var>eaa_exception_fundamental_modification</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="a11y:<i>exemption</i>" and normalize-space()="<i>eaa-fundamental-alteration</i>"]</code>.</li>
-					<li><b>LET</b> <var>eaa_exemption_micro_enterprises</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="a11y:<i>exemption</i>" and normalize-space()="<i>eaa-microenterprise</i>"]</code>.</li>
-
 				</ol>
 				<h4 id="legal-considerations-instructions">Instructions</h4>
 				<ol class="condition">
@@ -1007,12 +1016,6 @@
 
                     <h4>Understanding the variables</h4>
 					<dl>
-						<dt><var>aria</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="aria"</i>  (ARIA roles - semantic markup) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that the use of ARIA, including <a href="https://w3c.github.io/dpub-aria/">DPUB ARIA</a> is used to improve the semantic markup of the publication.</p>
-						</dd>
-                        
 						<dt><var>audio_descriptions</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="audioDescriptions"</i> (Audio Descriptions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
@@ -1025,11 +1028,42 @@
 							<p>This means that there is braille available within the publication.</p>
 						</dd>
 
-                        <dt><var>full_ruby_annotations</var></dt>
+						<dt><var>tactile_graphic</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="tactileGraphic"</i> (tactile 2D graphic) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that there is tactile graphic(s) contained within this publication.</p>
+						</dd>
+                        
+						<dt><var>tactile_object</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="tactileObject"</i> (tactile 3D object) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that there is tactile 3D object(s) contained within this publication.</p>
+						</dd>
+
+						<dt><var>sign_language</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="signLanguage"</i> (Sign language interpretation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that a full signing of audio content of the product is supplied with the video file.</p>
+						</dd>
+
+						<dt><var>aria</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="aria"</i>  (ARIA roles - semantic markup) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that the use of ARIA, including <a href="https://w3c.github.io/dpub-aria/">DPUB ARIA</a> is used to improve the semantic markup of the publication.</p>
+						</dd>
+                        
+  						<dt><var>full_ruby_annotations</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="fullRubyAnnotations"</i> (Full Ruby Annotations) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 							<p>This means that ruby annotations are attached to every CJK ideographic character in the content. Ruby annotations are used as pronunciation guides for the logographic characters for languages like Chinese or Japanese. They make difficult CJK ideographic characters more accessible.</p>
 						</dd>
+
+						<dt><var>text_to_speech_hinting</var></dt>
+						<dd>
+							<p>If true it indicates that the <i>accessibilityFeature="ttsMarkup"</i>  (Text-to-speech markup provided) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>This means that text-to-speech has been optimized through provision of PLS lexicons, SSML or CSS Speech synthesis hints or other speech synthesis markup languages or hinting.</p>
+						</dd>
+                        
 						<dt><var>high_contrast_between_foreground_and_background_audio</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="highContrastAudio"</i> (Use of high contrast between foreground and background audio) is present in the package document, otherwise if false it means that the metadata is not present.</p>
@@ -1053,51 +1087,34 @@
                             <p>If true it indicates that the <i>accessibilityFeature="pageBreakMarkers"</i> (Print-equivalent page numbering) is present in the package document, otherwise if false it means that the metadata is not present.</p>
                             <p>This means that the publication contains references to the page numbering.</p>
                         </dd>
-
-						<dt><var>ruby_annotations</var></dt>
+                        
+ 						<dt><var>ruby_annotations</var></dt>
 						<dd>
 							<p>If true it indicates that the <i>accessibilityFeature="rubyAnnotations"</i> (Ruby Annotations) is present in the package document, otherwise if false it means that the metadata is not present.</p>
 							<p>This means that ruby annotations are attached to some but not all CJK ideographic characters in the content.</p>
 						</dd>
-                        
-						<dt><var>sign_language</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="signLanguage"</i> (Sign language interpretation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that a full signing of audio content of the product is supplied with the video file.</p>
-						</dd>
-
-
-						<dt><var>tactile_graphic</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="tactileGraphic"</i> (tactile 2D graphic) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that there is tactile graphic(s) contained within this publication.</p>
-						</dd>
-                        
-						<dt><var>tactile_object</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="tactileObject"</i> (tactile 3D object) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that there is tactile 3D object(s) contained within this publication.</p>
-						</dd>
-
- 						<dt><var>text_to_speech_hinting</var></dt>
-						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="ttsMarkup"</i>  (Text-to-speech markup provided) is present in the package document, otherwise if false it means that the metadata is not present.</p>
-							<p>This means that text-to-speech has been optimized through provision of PLS lexicons, SSML or CSS Speech synthesis hints or other speech synthesis markup languages or hinting.</p>
-						</dd>
-                        
- 					</dl>
+					</dl>
 
 					<h4>Variables setup</h4>
 					<ol class="condition">
                         <li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
                         
-						<li><b>LET</b> <var>aria</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>aria</i>"]</code>.</li>
-                        
 						<li><b>LET</b> <var>audio_descriptions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>audioDescription</i>"]</code>.</li>
 						
                         <li><b>LET</b> <var>braille</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>braille</i>"]</code>.</li>
+                        
+                        <li><b>LET</b> <var>tactile_graphic</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tactileGraphic</i>"]</code>.</li>
+                        
+                        <li><b>LET</b> <var>tactile_object</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tactileObject</i>"]</code>.</li>
+                        
+                        <li><b>LET</b> <var>sign_language</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>signLanguage</i>"]</code>.</li>
+                        
 
+						<li><b>LET</b> <var>aria</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>aria</i>"]</code>.</li>
+                        
 						<li><b>LET</b> <var>full_ruby_annotations</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>fullRubyAnnotations</i>"]</code>.</li>
+                        
+						<li><b>LET</b> <var>text_to_speech_hinting</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>ttsMarkup</i>"]</code>.</li>
                         
     				    <li><b>LET</b> <var>high_contrast_between_foreground_and_background_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>highContrastAudio</i>"]</code>.</li>
                         
@@ -1108,26 +1125,10 @@
                         <li><b>LET</b> <var>page_break_markers</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>pageBreakMarkers</i>"]</code>.</li>
                         
 						<li><b>LET</b> <var>ruby_annotations</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>rubyAnnotations</i>"]</code>.</li>
-                        
-                        <li><b>LET</b> <var>sign_language</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>signLanguage</i>"]</code>.</li>
-
-                       <li><b>LET</b> <var>tactile_graphic</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tactileGraphic</i>"]</code>.</li>
-                        
-                        <li><b>LET</b> <var>tactile_object</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tactileObject</i>"]</code>.</li>
-                        
- 						<li><b>LET</b> <var>text_to_speech_hinting</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>ttsMarkup</i>"]</code>.</li>
     				</ol>
-                        
+
 					<h4 id="additional-accessibility-information-instructions">Instructions</h4>
 					<ol class="condition">
-                        <li>
-                            <span><b>IF</b> <var>page_break_markers</var>:</span>
-                            <span><b>THEN</b> display <code id="additional-accessibility-information-page-breaks">"Page breaks"</code>.</span>
-                        </li>
-						<li>
-							<span><b>IF</b> <var>aria</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-aria">"ARIA"</code>.</span>
-						</li>
 						<li>
 							<span><b>IF</b> <var>audio_descriptions</var>:</span>
 							<span><b>THEN</b> display <code id="additional-accessibility-information-audio-descriptions">"Audio descriptions"</code>.</span></li>
@@ -1136,8 +1137,28 @@
 							<span><b>THEN</b> display <code id="additional-accessibility-information-braille">"Braille"</code>.</span>
 						</li>
 						<li>
+							<span><b>IF</b> <var>tactile_graphic</var>:</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-graphics">"Tactile graphics"</code>.</span>
+						</li>
+						<li>
+							<span><b>IF</b> <var>tactile_object</var>:</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-objects">"Tactile 3D objects"</code>.</span>
+						</li>
+						<li>
+							<span><b>IF</b> <var>sign_language</var>:</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-sign-language">"Sign language"</code>.</span>
+						</li>
+						<li>
+							<span><b>IF</b> <var>aria</var>:</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-aria">"ARIA"</code>.</span>
+						</li>
+						<li>
 							<span><b>IF</b> <var>full_ruby_annotations</var>:</span>
 							<span><b>THEN</b> display <code id="additional-accessibility-information-full-ruby-annotations">"Full ruby annotations"</code>.</span>
+						</li>
+						<li>
+							<span><b>IF</b> <var>text_to_speech_hinting</var>:</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-text-to-speech-hinting">"Text-to-speech hinting provided"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>high_contrast_between_foreground_and_background_audio</var>:</span>
@@ -1151,26 +1172,13 @@
 							<span><b>IF</b> <var>large_print</var>:</span>
 							<span><b>THEN</b> display <code id="additional-accessibility-information-large-print">"Large print"</code>.</span>
 						</li>
-						<li>
-							<span><b>IF</b> <var>ruby_annotations</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-ruby-annotations">"Some Ruby annotations"</code>.</span>
+                        <li>
+                            <span><b>IF</b> <var>page_break_markers</var>:</span>
+                            <span><b>THEN</b> display <code id="additional-accessibility-information-page-breaks">"Page breaks"</code>.</span>
                         </li>
 						<li>
-							<span><b>IF</b> <var>sign_language</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-sign-language">"Sign language"</code>.</span>
-						</li>
-						<li>
-							<span><b>IF</b> <var>tactile_graphic</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-graphics">"Tactile graphics"</code>.</span>
-						</li>
-						<li>
-							<span><b>IF</b> <var>tactile_object</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-objects">"Tactile 3D objects"</code>.</span>
-						</li>
-						<li>
-							<span><b>IF</b> <var>text_to_speech_hinting</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-text-to-speech-hinting">"Text-to-speech hinting provided"</code>.</span>
-						</li>
+							<span><b>IF</b> <var>ruby_annotations</var>:</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-ruby-annotations">"Some Ruby annotations"</code>.</span></li>
 					</ol>
 			</section>
 

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -305,8 +305,12 @@
                         </li>
 
                         <li>
-                            <b>LET</b> <var>textual_alternatives</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessModeSufficient</i>" and contains(normalize-space() = "textual") and string-length(normalize-space()) &gt; 7]</code>.
+                            <b>LET</b> <var>some_sufficient_text</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessModeSufficient</i>" and contains(normalize-space() = "textual") and string-length(normalize-space()) &gt; 7]</code>.
                         </li>
+                    	
+                    	<li>
+                    		<b>LET</b> <var>textual_alternatives</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessibilityFeature</i>" and normalize-space()=("<i>longDescription</i>", "<i>alternativeText</i>", "<i>describedMath"</i>, "<i>transcript</i>")]</code>.
+                    	</li>
                     	
                     	<li>
                     		<b>LET</b> <var>visual_only_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[(@property="schema:<i>accessMode</i>" and normalize-space() = "visual" and count(//meta[@property="schema:<i>accessMode</i>"]) = 1) and not(@property="schema:<i>accessModeSufficient</i>" and contains(normalize-space(), "<i>textual</i>"))]</code>.
@@ -330,7 +334,7 @@
                     	</li>
                     	
                     	<li>
-                            <span><b>ELSE IF</b> <var>non_textual_content</var> <b>AND</b> <b>NOT</b> <var>textual_alternative_images</var>:</span>
+                            <span><b>ELSE IF</b> <var>non_textual_content</var> <b>AND</b> (<var>some_sufficient_text</var> <b>OR</b> <var>textual_alternatives</var>):</span>
                             <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-not-fully">"Not fully readable in read aloud or dynamic braille"</code>.</span>
                         </li>
                     	

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -306,7 +306,7 @@
                     	</li>
 
                         <li>
-                            <span><b>IF</b> <var>all_necessary_content_textual</var>:</span>
+                            <span><b>ELSE IF</b> <var>all_necessary_content_textual</var>:</span>
                             <span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-readable">"Readable in read aloud or dynamic braille"</code>.</span>
                         </li>
                         <li>


### PR DESCRIPTION
This is my best effort to capture as much as we can about nonvisual reading ability, not accounting for the various edge cases we discussed in the last editor's call.

I've changed the existing variables follows:

- I added a `has_nonvisual_metadata` variable that checks if any accessMode or accessModeSufficient properties are set. If not, then we don't know anything about the content and this triggers the no information available message.
- I modified `all_necessary_content_textual` to add a check that there is only one accessMode property and it has the value textual. This fills in the gap of accessModeSufficient not being required metadata
- I changed the variable `non_textual_content_images` to `non_textual_content` and updated it to check for any accessMode that is not textual so we capture audio and video in addition to images.
- I added a check for transcripts to `textual_alternatives` variable since these could be used for audio or video with images of text.

With those changes, the only major modification I had to make to the instructions is to put the "if" check that has_nonvisual_metadata is not true first. This stops us from commenting on any publications for which the publisher hasn't said anything about the access modes and lets the final else capture the ambiguous cases where they have.

The check on `all_necessary_content_textual` will now better capture all books we know have full text alternatives.

The check on `non_textual_content` without `textual_alternatives` will capture the case that some non-textual content is not going to be accessible. (There are ways this can fail, of course, but it relies on the publisher having only provided partial metadata.)

And finally is the catch-all case where we just don't know. There's non-textual content with some kinds of text alternatives, but for whatever reason the publisher isn't claiming the text is fully readable as text.

But if you spot anything that doesn't seem right, let me know.

Note that I added the new ID `ways-of-reading-nonvisual-no-metadata` for the new "No information about nonvisual reading is available" string. I didn't modify the guidelines to add this.

***

[Preview](https://raw.githack.com/w3c/publ-a11y/fix/epub-nonvis/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/epub-nonvis/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html)
