### PR TITLE
fix string and id differences

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -544,7 +544,7 @@
 					avoid making a negative statement that could be attributed to them (e.g., stating
 					it is not known if a feature is available could be misconstrued as the publisher
 					saying they are unsure). The neutral statement "No information is available" is
-					shown in the examples for this case.</p>
+					displayed for this case.</p>
 
 				<p>In some cases, the distributer may not be allowed to show statements the publisher did not make.
 					Hiding such sections is acceptable in these cases.</p>
@@ -620,8 +620,7 @@
 
 				<div class="note">
 					<p>This display field should be rendered even
-						if there is no metadata (See the examples
-						where "No information is available"). </p>
+						if there is no metadata. </p>
 				</div>
 
 				<p>Indicates if users can modify the appearance of the text
@@ -716,8 +715,7 @@
 
 				<div class="note">
 					<p>This display field should be rendered even
-						if there is no metadata (See the examples
-						where "No information is available"). </p>
+						if there is no metadata. </p>
 				</div>
 
 				<p>Indicates whether all content required for comprehension
@@ -944,8 +942,7 @@
 
 			<div class="note">
 				<p>This display field should be rendered even
-					if there is no metadata (See the examples
-					where "No information is available"). </p>
+					if there is no metadata. </p>
 			</div>
 
 			<p>Identifies whether the digital publication claims to meet

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -322,7 +322,7 @@
                     		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-none">"Not readable in read aloud or dynamic braille"</code>.</span>
                     	</li>
                     	
-                    	<li><b>ELSE</b> display <code id="ways-of-reading-nonvisual-no-metadata">"No information about nonvisual reading is available"</code>.</li>
+                    	<li><b>ELSE</b> display <code id="ways-of-reading-nonvisual-reading-no-metadata">"No information about nonvisual reading is available"</code>.</li>
                     	
                     	<li>
                     		<span><b>IF</b> <var>textual_alternatives</var>:</span>
@@ -1140,11 +1140,11 @@
 					<ol class="condition">
                         <li>
                             <span><b>IF</b> <var>page_break_markers</var>:</span>
-                            <span><b>THEN</b> display <code id="additional-accessibility-information-page-breaks">"Page breaks"</code>.</span>
+                        	<span><b>THEN</b> display <code id="additional-accessibility-information-page-breaks">"Page breaks included"</code>.</span>
                         </li>
 						<li>
 							<span><b>IF</b> <var>aria</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-aria">"ARIA"</code>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-aria">"ARIA roles included"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>audio_descriptions</var>:</span>
@@ -1179,11 +1179,11 @@
 						</li>
 						<li>
 							<span><b>IF</b> <var>tactile_graphic</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-graphics">"Tactile graphics"</code>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-graphics">"Tactile graphics included"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>tactile_object</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-objects">"Tactile 3D objects"</code>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-objects">"Tactile 3D objects included"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>text_to_speech_hinting</var>:</span>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -1183,7 +1183,7 @@
 						</li>
 						<li>
 							<span><b>IF</b> <var>tactile_object</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-objects">"Tactile 3D objects included"</code>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-tactile-objects">"Tactile 3D objects"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>text_to_speech_hinting</var>:</span>

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -311,7 +311,7 @@
                     		<span><b>ELSE IF</b> <var>audio_only_content</var>:</span>
                     		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-none">"Not readable in read aloud or dynamic braille"</code>.</span>
                     	</li>
-                    	<li><b>ELSE</b> display <code id="ways-of-reading-nonvisual-no-metadata">"No information about nonvisual reading is available"</code>.</li>
+                    	<li><b>ELSE</b> display <code id="ways-of-reading-nonvisual-reading-no-metadata">"No information about nonvisual reading is available"</code>.</li>
                     	<li>
                     		<span><b>IF</b> <var>textual_alternatives</var>:</span>
                     		<span><b>THEN</b> display <code id="ways-of-reading-nonvisual-reading-alt-text">"Has alternative text"</code>.</span>


### PR DESCRIPTION
Updates discrepancies in the strings between the guidelines and epub techniques for some of the additional information values.

Shouldn't tactile 3d objects have "included" at the end if tactile graphics has it? It's not in the guidelines so wasn't flagged as being inconsistent between the docs, but seems inconsistent within the output. I was going to update it but wanted to check first.

I've also added -reading to the ID for the nonvisual no metadata string in epub and onix techniques to make the ID consistent with all the others in that category.