### PR TITLE
Removed ways-of-reading-nonvisual-reading-no-metadata

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -716,8 +716,7 @@
 
 				<div class="note">
 					<p>This display field should be rendered even
-						if there is no metadata (See the examples
-						where "No information is available"). </p>
+						if there is no metadata provided.</p>
 				</div>
 
 				<p>Indicates whether all content required for comprehension
@@ -763,7 +762,7 @@
 							<p data-localization-id="ways-of-reading-nonvisual-reading-not-fully"
 								data-localization-mode="descriptive">Not all of the content will be readable as read aloud speech or dynamic braille</p>
 						</dd>
-						
+
 						<dt>If the content cannot be read in text form:</dt>
 						<dd>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-none"
@@ -771,15 +770,7 @@
 							<p data-localization-id="ways-of-reading-nonvisual-reading-none"
 								data-localization-mode="descriptive">The content is not readable as read aloud speech or dynamic braille</p>
 						</dd>
-						
-						<dt>If no metadata is provided:</dt>
-						<dd>
-							<p data-localization-id="ways-of-reading-nonvisual-reading-no-metadata"
-								data-localization-mode="compact">No information about nonvisual reading is available</p>
-							<p data-localization-id="ways-of-reading-nonvisual-reading-no-metadata"
-								data-localization-mode="descriptive">No information about nonvisual reading is available</p>
-						</dd>
-						
+
 						<dt>If text alternatives are provided:</dt>
 						<dd>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"


### PR DESCRIPTION
I found the ID in the definition list and removed the descriptive and compact.

In the note, I removed the (see examples). It did not make sense  to mee to have people  go looking for an example that does not exist.

Not sure how often I will be checking email. Go ahead and merge, unless you see problems.