### PR TITLE
Clarifications to ways of reading and conformance

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -911,7 +911,7 @@
 			<section id="wr-examples">
 				<h4>Examples</h4>
 
-				<aside class="example" title="Publication with text and imges">
+				<aside class="example" title="Publication with text and images">
 					<p>The following example shows the descriptive and compact statements that would display
 						for a typical text-based publication with images that have text alternatives.</p>
 					
@@ -940,6 +940,8 @@
 								and text)</p>
 							<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
 								data-localization-mode="descriptive">All content can be read as read aloud speech or dynamic braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
+								data-localization-mode="descriptive">Has alternative text descriptions for images</p>
 						</dd>
 					</dl>
 				</aside>
@@ -1173,6 +1175,9 @@
 
 				<aside class="example"
 					title="Conformance statement that claims to meet accepted accessibility standards followed by detailed conformance information">
+					
+					<p>In this example, the detailed conformance information is minimized by default in the compact display and
+						expanded for the descriptive.</p>
 
 					<dl>
 						<dt>Compact display</dt>
@@ -1195,7 +1200,7 @@
 								Accessibility Rating"
 							</p>
 
-							<details open="">
+							<details>
 								<summary data-localization-id="conformance-details-title">Detailed conformance information</summary>
 								
 								<p>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -123,6 +123,9 @@
 		dt {
 			margin-bottom: 1rem;
 		}
+		div.head dt {
+			margin-bottom: 0;
+		}
 		p[data-localization-mode="descriptive"]:before {
 			content: 'Descriptive: ';
 			font-style: italic;
@@ -655,7 +658,7 @@
 					and the page layout according to the
 					possibilities offered by the reading system.</p>
 
-				<p>This display answers whether visual adjustments are
+				<p>These display strings answer whether visual adjustments are
 					possible, not possible, or unknown.</p>
 
 				<p>Readers with visual impairments or cognitive disabilities
@@ -746,7 +749,7 @@
 					available to reading systems with [=read aloud speech=]
 					or [=dynamic braille=] capabilities.</p>
 
-				<p>This display answers whether nonvisual reading is possible,
+				<p>These display strings answers whether nonvisual reading is possible,
 					not possible, or unknown.</p>
 
 				<p>Digital publications with essential content included in

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -615,19 +615,41 @@
 		<section id="ways-of-reading">
 			<h3 data-localization-id="ways-of-reading-title">Ways of reading</h3>
 
+			<div class="note">
+				<p>This display field should be rendered even
+					if there is no metadata. </p>
+			</div>
+			
+			<p>The ways of reading display field is a banner heading that groups together the following
+				information about how the content facilitates access:</p>
+			
+			<ul>
+				<li><a href="#visual-adjustments">visual adjustments</a> &#8212; whether users can control the 
+					text and page layout (e.g., to increase font sizes, line spacing, and foreground and
+					background colors).</li>
+				<li><a href="#supports-nonvisual-reading">nonvisual reading</a> &#8212; whether all of the
+					content of the publication is available as text, for playback using a reading system's
+					read aloud functionality or via rendering as dynamic braille on a refreshable braille
+					display.</li>
+				<li><a href="#prerecorded-audio">prerecorded audio</a> &#8212; whether the publication includes
+					prerecorded narration (audiobooks or text and audio synchronized publications) or
+					embedded audio (standalone audio clips or audio tracks in a video).</li>
+			</ul>
+			
+			<p>This section is divided into subsections to explain each of the display outputs for each characteristic,
+				but this separation is only for ease of reading. The subsections do not represent new display fields
+				or have titles associated with them. All of the information is expected to be displayed under the 
+				"<span data-localization-id="ways-of-reading-title">Ways of reading</span>" title, as depicted in 
+				the <a href="#wr-examples">ways of reading examples</a>.</p>
+			
 			<section id="visual-adjustments">
 				<h4>Visual adjustments</h4>
-
-				<div class="note">
-					<p>This display field should be rendered even
-						if there is no metadata. </p>
-				</div>
 
 				<p>Indicates if users can modify the appearance of the text
 					and the page layout according to the
 					possibilities offered by the reading system.</p>
 
-				<p>This display field answers whether visual adjustments are
+				<p>This display answers whether visual adjustments are
 					possible, not possible, or unknown.</p>
 
 				<p>Readers with visual impairments or cognitive disabilities
@@ -713,17 +735,12 @@
 			<section id="supports-nonvisual-reading">
 				<h4>Support for nonvisual reading</h4>
 
-				<div class="note">
-					<p>This display field should be rendered even
-						if there is no metadata. </p>
-				</div>
-
 				<p>Indicates whether all content required for comprehension
 					can be consumed in text and therefore is
 					available to reading systems with [=read aloud speech=]
 					or [=dynamic braille=] capabilities.</p>
 
-				<p>This display field answers whether nonvisual reading is possible,
+				<p>This display answers whether nonvisual reading is possible,
 					not possible, or unknown.</p>
 
 				<p>Digital publications with essential content included in
@@ -811,7 +828,7 @@
 				<h4>Prerecorded audio</h4>
 
 				<div class="note">
-					<p>This display field can be hidden if metadata is
+					<p>The prerecorded audio display strings can be hidden if metadata is
 						missing. Alternatively it can be stated that
 						<span
 							data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
@@ -894,7 +911,40 @@
 			<section id="wr-examples">
 				<h4>Examples</h4>
 
-				<aside class="example" title="Publication with accessible ways of reading">
+				<aside class="example" title="Publication with text and imges">
+					<p>The following example shows the descriptive and compact statements that would display
+						for a typical text-based publication with images that have text alternatives.</p>
+					
+					<dl>
+						<dt>Compact display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="ways-of-reading-title">Ways of reading</p>
+							<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
+								data-localization-mode="compact">Appearance can be modified</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
+								data-localization-mode="compact">Readable in
+								read aloud or dynamic braille</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-alt-text"
+								data-localization-mode="compact">Has alternative text</p>
+						</dd>
+						
+						<dt>Descriptive display</dt>
+						<dd>
+							<p class="ex-hd" data-localization-id="ways-of-reading-title">Ways of reading</p>
+							<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
+								data-localization-mode="descriptive">Appearance of the text and page layout can be
+								modified according to the capabilities of
+								the reading system (font family and font size,
+								spaces between paragraphs, sentences, words,
+								and letters, as well as color of background
+								and text)</p>
+							<p data-localization-id="ways-of-reading-nonvisual-reading-readable"
+								data-localization-mode="descriptive">All content can be read as read aloud speech or dynamic braille</p>
+						</dd>
+					</dl>
+				</aside>
+				
+				<aside class="example" title="Publication with synchronized text and audio">
 					<p>The following example shows the descriptive and compact statements that would display
 						for a publication with a modifiable display, that is compatible with nonvisual reading,
 						and that has synchronized prerecorded audio with the text.</p>
@@ -1044,9 +1094,13 @@
 				<section id="detailed-conformance-information">
 					<h5>Detailed conformance</h5>
 
-					<p>The following information can be placed in a section
-						that shows the details of the conformance
-						information.</p>
+					<p>The following detailed information may be too technical for the average reader,
+						which is why it is separated from the general conformance information. Implementors
+						may opt to include it without distinction from the general information, but it may
+						be more helpful to users if it is clearly separated, such as by including it in an
+						expandable display box (see the <a href="#conf-examples">conformance examples</a>) 
+						or adding a heading before it. Implementors may also choose not to display this 
+						information if it is too technical for their target audience.</p>
 
 					<dl>
 						<dt>If a detailed conformance claim is made:</dt>
@@ -1141,34 +1195,36 @@
 								Accessibility Rating"
 							</p>
 
-							<p class="ex-hd" data-localization-id="conformance-details-title">
-								Detailed conformance information</p>
-							<p>
-								<span
-									data-localization-id="conformance-claim">This
-									publication claims to meet</span>
-								<span
-									data-localization-id="conformance-epub-accessibility-1-1">EPUB
-									Accessibility
-									1.1</span>
-								<span
-									data-localization-id="conformance-wcag-2-1"
-									data-localization-mode="descriptive">Web
-									Accessibility Content Guidelines (WCAG)
-									2.1</span>
-								<span
-									data-localization-id="conformance-level-aa">Level
-									AA</span>
-							</p>
-							<p><span data-localization-id="conformance-certification-info">The
-									publication was certified on</span>
-								2021-09-07</p>
-							<p><span data-localization-id="conformance-certifier-report">For
-									more information refer to the
-									<a
-										href="http://www.example.com/a11y/report/9780000000001">certifier's
-										report</a></span>
-							</p>
+							<details open="">
+								<summary data-localization-id="conformance-details-title">Detailed conformance information</summary>
+								
+								<p>
+									<span
+										data-localization-id="conformance-details-claim">This
+										publication claims to meet</span>
+									<span
+										data-localization-id="conformance-details-epub-accessibility-1-1">EPUB
+										Accessibility
+										1.1</span>
+									<span
+										data-localization-id="conformance-details-wcag-2-1"
+										data-localization-mode="descriptive">Web
+										Accessibility Content Guidelines (WCAG)
+										2.1</span>
+									<span
+										data-localization-id="conformance-details-level-aa">Level
+										AA</span>
+								</p>
+								<p><span data-localization-id="conformance-details-certification-info">The
+										publication was certified on</span>
+									2021-09-07</p>
+								<p><span data-localization-id="conformance-details-certifier-report">For
+										more information refer to the
+										<a
+											href="http://www.example.com/a11y/report/9780000000001">certifier's
+											report</a></span>
+								</p>
+							</details>
 						</dd>
 
 						<dt>Descriptive display</dt>
@@ -1191,34 +1247,36 @@
 								Accessibility Rating"
 							</p>
 
-							<p class="ex-hd" data-localization-id="conformance-details-title">
-								Detailed conformance information</p>
-							<p>
-								<span
-									data-localization-id="conformance-claim">This
-									publication claims to meet</span>
-								<span
-									data-localization-id="conformance-epub-accessibility-1-1">EPUB
-									Accessibility
-									1.1</span>
-								<span
-									data-localization-id="conformance-wcag-2-1"
-									data-localization-mode="descriptive">Web
-									Accessibility Content Guidelines (WCAG)
-									2.1</span>
-								<span
-									data-localization-id="conformance-level-aa">Level
-									AA</span>
-							</p>
-							<p><span data-localization-id="conformance-certification-info">The
-									publication was certified on</span>
-								2021-09-07</p>
-							<p><span data-localization-id="conformance-certifier-report">For
-									more information refer to the
-									<a
-										href="http://www.example.com/a11y/report/9780000000001">certifier's
-										report</a></span>
-							</p>
+							<details open="">
+								<summary data-localization-id="conformance-details-title">Detailed conformance information</summary>
+								
+								<p>
+									<span
+										data-localization-id="conformance-details-claim">This
+										publication claims to meet</span>
+									<span
+										data-localization-id="conformance-details-epub-accessibility-1-1">EPUB
+										Accessibility
+										1.1</span>
+									<span
+										data-localization-id="conformance-details-wcag-2-1"
+										data-localization-mode="descriptive">Web
+										Accessibility Content Guidelines (WCAG)
+										2.1</span>
+									<span
+										data-localization-id="conformance-details-level-aa">Level
+										AA</span>
+								</p>
+								<p><span data-localization-id="conformance-details-certification-info">The
+										publication was certified on</span>
+									2021-09-07</p>
+								<p><span data-localization-id="conformance-details-certifier-report">For
+										more information refer to the
+										<a
+											href="http://www.example.com/a11y/report/9780000000001">certifier's
+											report</a></span>
+								</p>
+							</details>
 						</dd>
 					</dl>
 				</aside>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -148,6 +148,12 @@
 			padding: 0;
 			font-variant: small-caps
 		}
+		aside.example > dl > dt:nth-child(1) {
+			margin-top: 2rem;
+		}
+		aside.example > dl > dt:nth-child(n+2) {
+			margin-top: 3rem;
+		}
 	</style>
 </head>
 

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -529,42 +529,46 @@
 								</ul>
 							</li>
 							<li>
-								<span>Display <code id="conformance-details-title">"Detailed conformance information"</code> as heading.</span>
-							</li>
-							<li>
-								<span>Display <code id="conformance-claim">"This publication claims to meet"</code>.</span>
+								<div class="note">
+									<p>The instructions from here on define the output for the detailed conformance
+										information. Refer to the 
+										<a href="../../guidelines/#detailed-conformance-information">Detailed Conformance section</a>
+										in the guidelines for more information on how to present these strings.</p>
+								</div>
+								
+								<span>Display <code id="conformance-details-claim">"This publication claims to meet"</code>.</span>
 								<ul>
 									<li>
 										<span><b>IF</b> <var>epub_version</var> == '<code>1.0</code>':</span>
-										<span><b>THEN</b> display <code id="conformance-epub-accessibility-1-0">" EPUB Accessibility 1.0"</code>.</span>
+										<span><b>THEN</b> display <code id="conformance-details-epub-accessibility-1-0">" EPUB Accessibility 1.0"</code>.</span>
 									</li>
 									<li>
 										<span><b>ELSE IF</b>  <var>epub_version</var> == '<code>1.1</code>':</span>
-										<span><b>THEN</b> display <code id="conformance-epub-accessibility-1-1">" EPUB Accessibility 1.1"</code>.</span>
+										<span><b>THEN</b> display <code id="conformance-details-epub-accessibility-1-1">" EPUB Accessibility 1.1"</code>.</span>
 									</li>
 									<li>
 										<span><b>IF</b> <var>wcag_version</var> == '<code>2.2</code>':</span>
-										<span><b>THEN</b> display <code id="conformance-wcag-2-2">" WCAG 2.2"</code>.</span>
+										<span><b>THEN</b> display <code id="conformance-details-wcag-2-2">" WCAG 2.2"</code>.</span>
 									</li>
 									<li>
 										<span><b>ELSE IF</b> <var>wcag_version</var> == '<code>2.1</code>':</span>
-										<span><b>THEN</b> display <code id="conformance-wcag-2-1">" WCAG 2.1"</code>.</span>
+										<span><b>THEN</b> display <code id="conformance-details-wcag-2-1">" WCAG 2.1"</code>.</span>
 									</li>
 									<li>
 										<span><b>ELSE IF</b> <var>wcag_version</var> == '<code>2.0</code>':</span>
-										<span><b>THEN</b> display <code id="conformance-wcag-2-0">" WCAG 2.0"</code>.</span>
+										<span><b>THEN</b> display <code id="conformance-details-wcag-2-0">" WCAG 2.0"</code>.</span>
 									</li>
 									<li>
 										<span><b>IF</b> <var>wcag_level</var> == '<code>AAA</code>':</span>
-										<span><b>THEN</b> display <code id="conformance-level-aaa">" Level AAA"</code>.</span>
+										<span><b>THEN</b> display <code id="conformance-details-level-aaa">" Level AAA"</code>.</span>
 									</li>
 									<li>
 										<span><b>ELSE IF</b> <var>wcag_level</var> == '<code>AA</code>':</span>
-										<span><b>THEN</b> display <code id="conformance-level-aa">" Level AA"</code>.</span>
+										<span><b>THEN</b> display <code id="conformance-details-level-aa">" Level AA"</code>.</span>
 									</li>
 									<li>
 										<span><b>ELSE IF</b> <var>wcag_level</var> == '<code>A</code>':</span>
-										<span><b>THEN</b> display <code id="conformance-level-a">" Level A"</code>.</span>
+										<span><b>THEN</b> display <code id="conformance-details-level-a">" Level A"</code>.</span>
 									</li>
 								</ul>
 							</li>
@@ -572,7 +576,7 @@
 								<span><b>IF</b> <var>certification_date</var> <b>THEN</b>:</span>
                                 <ul class="condition">
 
-									<li>display <code id="conformance-certification-info">"The publication was certified on "</code></li>
+                                	<li>display <code id="conformance-details-certification-info">"The publication was certified on "</code></li>
 									<li>display <var>certification_date</var>.</li>
 								</ul>
 							</li>
@@ -580,7 +584,7 @@
 								<span><b>IF</b> <var>certifier_report</var>:</span>
 								<span><b>THEN</b></span>
 								<ul class="condition">
-									<li>display <code id="conformance-certifier-report">"For more information refer to the certifier's report"</code> as a named link with <var>certifier_report</var> as the URL used.</li>
+									<li>display <code id="conformance-details-certifier-report">"For more information refer to the certifier's report"</code> as a named link with <var>certifier_report</var> as the URL used.</li>
 								</ul>
 							</li>
 						</ul>

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -538,49 +538,53 @@
 						</ul>
 					</li>
 					<li>
-						<span>display <code id="conformance-details-title">"Detailed conformance information"</code> as heading.</span>
-					</li>
-					<li>
+						<div class="note">
+							<p>The instructions from here on define the output for the detailed conformance
+								information. Refer to the 
+								<a href="../../guidelines/#detailed-conformance-information">Detailed Conformance section</a>
+								in the guidelines for more information on how to present these strings.</p>
+						</div>
+						
 						<span><b>IF</b> <var>epub_accessibility_10</var> <b>OR</b> <var>epub_accessibility_11</var> <b>OR</b> <var>wcag_20</var> <b>OR</b> <var>wcag_21</var> <b>OR</b> <var>wcag_22</var> <b>OR</b> <var>level_aaa</var> <b>OR</b> <var>level_aa</var> <b>OR</b> <var>level_a</var>:</span>
-						<span><b>THEN</b> display <code id="conformance-claim">"This publication claims to meet"</code>.</span>
+						<span><b>THEN</b> display <code id="conformance-details-claim">"This publication claims to meet"</code>.</span>
 					</li>
 					<li>
 						<span><b>IF</b> <var>epub_accessibility_10</var>:</span>
-						<span><b>THEN</b> display <code id="conformance-epub-accessibility-1-0">" EPUB Accessibility 1.0"</code>.</span>
+						<span><b>THEN</b> display <code id="conformance-details-epub-accessibility-1-0">" EPUB Accessibility 1.0"</code>.</span>
 					</li>
 					<li>
 						<span><b>ELSE IF</b> <var>epub_accessibility_11</var>:</span>
-						<span><b>THEN</b> display <code id="conformance-epub-accessibility-1-1">" EPUB Accessibility 1.1"</code>.</span>
+						<span><b>THEN</b> display <code id="conformance-details-epub-accessibility-1-1">" EPUB Accessibility 1.1"</code>.</span>
 					</li>
 					<li>
 						<span><b>IF</b> <var>wcag_22</var>:</span>
-						<span><b>THEN</b> display <code id="conformance-wcag-2-2">" WCAG 2.2"</code>.</span>
+						<span><b>THEN</b> display <code id="conformance-details-wcag-2-2">" WCAG 2.2"</code>.</span>
 					</li>
 					<li>
 						<span><b>ELSE IF</b> <var>wcag_21</var>:</span>
-						<span><b>THEN</b> display <code id="conformance-wcag-2-1">" WCAG 2.1"</code>.</span>
+						<span><b>THEN</b> display <code id="conformance-details-wcag-2-1">" WCAG 2.1"</code>.</span>
 					</li>
 					<li>
 						<span><b>ELSE IF</b> <var>wcag_20</var>:</span>
-						<span><b>THEN</b> display <code id="conformance-wcag-2-0">" WCAG 2.0"</code>.</span>
+						<span><b>THEN</b> display <code id="conformance-details-wcag-2-0">" WCAG 2.0"</code>.</span>
 					</li>
 					<li>
 						<span><b>IF</b> <var>level_aaa</var>:</span>
-						<span><b>THEN</b> display <code id="conformance-level-aaa">" Level AAA"</code>.</span>
+						<span><b>THEN</b> display <code id="conformance-details-level-aaa">" Level AAA"</code>.</span>
 					</li>
 					<li>
 						<span><b>ELSE IF</b> <var>level_aa</var>:</span>
-						<span><b>THEN</b> display <code id="conformance-level-aa">" Level AA"</code>.</span>
+						<span><b>THEN</b> display <code id="conformance-details-level-aa">" Level AA"</code>.</span>
 					</li>
 					<li>
 						<span><b>ELSE IF</b> <var>level_a</var>:</span>
-						<span><b>THEN</b> display <code id="conformance-level-a">" Level A"</code>.</span>
+						<span><b>THEN</b> display <code id="conformance-details-level-a">" Level A"</code>.</span>
 					</li>
 					<li>
 						<span><b>IF</b> <var>certification_date</var>:</span>
 						<span><b>THEN</b></span>
 						<ul class="condition">
-							<li>display <code id="conformance-certification-info">"The publication was certified on"</code></li>
+							<li>display <code id="conformance-details-certification-info">"The publication was certified on"</code></li>
 							<li>display <var>certification_date</var>.</li>
 						</ul>
 					</li>
@@ -588,11 +592,10 @@
 						<span><b>IF</b> <var>certifier_report</var>:</span>
 						<span><b>THEN</b></span>
 						<ul class="condition">
-							<li>display <code id="conformance-certifier-report">"For more information refer to the certifier's report"</code> as a named link with <var>certifier_report</var> as the URL used.</li>
+							<li>display <code id="conformance-details-certifier-report">"For more information refer to the certifier's report"</code> as a named link with <var>certifier_report</var> as the URL used.</li>
 						</ul>
 					</li>
 				</ol>
-
 			</section>
 
 			<section id="navigation">


### PR DESCRIPTION
This pull request implements the clarifications that we discussed on the last editor's call.

For ways to read, those were:

- adding a new introduction to 3.1 Ways of reading. It gives a quick overview of the subsections and then explains that they are not treated as separate display fields. I also moved the note about always displaying the field up here.
- modifying the note for prerecorded audio to explain that it doesn't always have to be shown.
- adding a basic example of ways to read metadata for a book with text and images. Note that this will also output "Has alternative text". I could go even more basic to text only, if we don't want that output.

For conformance they were:

- explaining more clearly that detailed conformance is technical information that may not be for the average user, and detailing options for how it can be separated from the information that comes before
- adding "-details" to the IDs for all the strings that are output under detailed conformance
- changing the examples to use an open details element to show how the info can be collapsed. Maybe one could be collapsed if we want a bit of variety?

In addition, I removed the instruction to output the detailed conformance information heading from the epub and onix techniques. I replaced it with a note in the first output instruction that all the following steps are for detailed conformance and linked to the new text in the detailed conformance section for how to handle them. I also added "-details" to all the IDs in these documents, too.

I think that covers everything we discussed, but if I've forgotten anything let me know.

***

[Guidelines Preview](https://raw.githack.com/w3c/publ-a11y/update/field-defs/a11y-meta-display-guide/2.0/draft/guidelines/index.html) | [Guidelines Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/update/field-defs/a11y-meta-display-guide/2.0/draft/guidelines/index.html)
[EPUB Preview](https://raw.githack.com/w3c/publ-a11y/update/field-defs/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html) | [EPUB Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/update/field-defs/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html)
[ONIX Preview](https://raw.githack.com/w3c/publ-a11y/update/field-defs/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html) | [ONIX Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/update/field-defs/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html)

