### PR TITLE
Fix detailed conformance IDs

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1120,7 +1120,7 @@
 						<dt>If a detailed conformance claim is made:</dt>
 						<dd>
 							<p data-localization-mode="compact">
-								<span data-localization-id="conformance-claim"
+								<span data-localization-id="conformance-details-claim"
 									data-localization-mode="compact">This
 									publication claims to meet</span>
 
@@ -1134,7 +1134,7 @@
 								<span class="placeholder">&lt;A or AA or AAA&gt;</span>
 							</p>
 							<p data-localization-mode="descriptive">
-								<span data-localization-id="conformance-claim"
+								<span data-localization-id="conformance-details-claim"
 									data-localization-mode="descriptive">This
 									publication claims to meet</span>
 
@@ -1152,12 +1152,12 @@
 								<p>The placeholders in these strings allow the display of each version of the
 									respective standard. For example, the descriptive statements for WCAG 2 would be:</p>
 								<ul>
-									<li data-localization-id="conformance-wcag-2-0"
-										data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG ) 2.0</li>
-									<li data-localization-id="conformance-wcag-2-1"
-										data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG ) 2.1</li>
-									<li data-localization-id="conformance-wcag-2-2"
-										data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG ) 2.2</li>
+									<li data-localization-id="conformance-details-wcag-2-0"
+										data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG) 2.0</li>
+									<li data-localization-id="conformance-details-wcag-2-1"
+										data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG) 2.1</li>
+									<li data-localization-id="conformance-details-wcag-2-2"
+										data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG) 2.2</li>
 								</ul>
 							</div>
 						</dd>
@@ -1165,7 +1165,7 @@
 						<dt>If the certification date is provided:</dt>
 						<dd>
 							<p>
-								<span data-localization-id="conformance-certification-info"
+								<span data-localization-id="conformance-details-certification-info"
 									data-localization-mode="compact">The
 									publication was certified on </span>
 								<span class="placeholder">&lt;certification date&gt;</span></p>
@@ -1173,7 +1173,7 @@
 
 						<dt>If the certifier provides an accessibility report:</dt>
 						<dd>
-							<p><span data-localization-id="conformance-certifier-report"
+							<p><span data-localization-id="conformance-details-certifier-report"
 									data-localization-mode="compact">For
 									more information refer to the
 									certifier's report</span></p>
@@ -1217,25 +1217,29 @@
 								
 								<p>
 									<span
-										data-localization-id="conformance-details-claim">This
+										data-localization-id="conformance-details-claim"
+										data-localization-mode="compact">This
 										publication claims to meet</span>
 									<span
-										data-localization-id="conformance-details-epub-accessibility-1-1">EPUB
+										data-localization-id="conformance-details-epub-accessibility-1-1"
+										data-localization-mode="compact">EPUB
 										Accessibility
 										1.1</span>
 									<span
 										data-localization-id="conformance-details-wcag-2-1"
-										data-localization-mode="descriptive">Web
-										Accessibility Content Guidelines (WCAG)
+										data-localization-mode="compact">WCAG
 										2.1</span>
 									<span
-										data-localization-id="conformance-details-level-aa">Level
+										data-localization-id="conformance-details-level-aa"
+										data-localization-mode="compact">Level
 										AA</span>
 								</p>
-								<p><span data-localization-id="conformance-details-certification-info">The
+								<p><span data-localization-id="conformance-details-certification-info"
+										data-localization-mode="compact">The
 										publication was certified on</span>
 									2021-09-07</p>
-								<p><span data-localization-id="conformance-details-certifier-report">For
+								<p><span data-localization-id="conformance-details-certifier-report"
+										data-localization-mode="compact">For
 										more information refer to the
 										<a
 											href="http://www.example.com/a11y/report/9780000000001">certifier's
@@ -1248,19 +1252,19 @@
 						<dd>
 							<p class="ex-hd" data-localization-id="conformance-title">Conformance</p>
 							<p data-localization-id="conformance-aa"
-								data-localization-mode="compact">The publication contains a conformance statement
+								data-localization-mode="descriptive">The publication contains a conformance statement
 								that it meets the EPUB Accessibility and WCAG 2 Level AA standard.</p>
 							<p>
 								<span
 									data-localization-id="conformance-certifier"
-									data-localization-mode="compact">The
+									data-localization-mode="descriptive">The
 									publication was certified by</span>
 								Foo's Accessibility Testing
 							</p>
 							<p>
 								<span
 									data-localization-id="conformance-certifier-credentials"
-									data-localization-mode="compact">The certifier's credential is</span> "Enterprise
+									data-localization-mode="descriptive">The certifier's credential is</span> "Enterprise
 								Accessibility Rating"
 							</p>
 
@@ -1269,10 +1273,12 @@
 								
 								<p>
 									<span
-										data-localization-id="conformance-details-claim">This
+										data-localization-id="conformance-details-claim"
+										data-localization-mode="descriptive">This
 										publication claims to meet</span>
 									<span
-										data-localization-id="conformance-details-epub-accessibility-1-1">EPUB
+										data-localization-id="conformance-details-epub-accessibility-1-1"
+										data-localization-mode="descriptive">EPUB
 										Accessibility
 										1.1</span>
 									<span
@@ -1281,13 +1287,16 @@
 										Accessibility Content Guidelines (WCAG)
 										2.1</span>
 									<span
-										data-localization-id="conformance-details-level-aa">Level
+										data-localization-id="conformance-details-level-aa"
+										data-localization-mode="descriptive">Level
 										AA</span>
 								</p>
-								<p><span data-localization-id="conformance-details-certification-info">The
+								<p><span data-localization-id="conformance-details-certification-info"
+										data-localization-mode="descriptive">The
 										publication was certified on</span>
 									2021-09-07</p>
-								<p><span data-localization-id="conformance-details-certifier-report">For
+								<p><span data-localization-id="conformance-details-certifier-report"
+										data-localization-mode="descriptive">For
 										more information refer to the
 										<a
 											href="http://www.example.com/a11y/report/9780000000001">certifier's


### PR DESCRIPTION
I went through the detailed conformance info section and made a number of fixes to correct the IDs. Some were missing -details, some were missing the data-localization-mode attribute, and a few in the examples had been reversed (compact string was in descriptive example and vice versa).

I think this catches everything but let me know if your testing still comes up with errors @gregoriopellegrino 