### PR TITLE
Updating canonical JSON

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/localizations/en-US/display_guide_vocabulary_w3c_en-US.json
+++ b/a11y-meta-display-guide/2.0/draft/localizations/en-US/display_guide_vocabulary_w3c_en-US.json
@@ -75,15 +75,15 @@
         },
         "conformance-certifier": {
             "compact": "The publication was certified by",
-            "descriptive": "The publication was certified by"
+            "descriptive": "The publication was certified by "
         },
         "conformance-certifier-credentials": {
             "compact": "The certifier's credential is ",
-            "descriptive": "The certifier's credential is"
+            "descriptive": "The certifier's credential is "
         },
         "conformance-details-certification-info": {
             "compact": "The publication was certified on ",
-            "descriptive": "The publication was certified on"
+            "descriptive": "The publication was certified on "
         },
         "conformance-details-certifier-report": {
             "compact": "For more information refer to the certifier's report",
@@ -98,16 +98,16 @@
             "descriptive": " EPUB Accessibility 1.0"
         },
         "conformance-details-epub-accessibility-1-1": {
-            "compact": "EPUB Accessibility 1.1",
-            "descriptive": "EPUB Accessibility 1.1"
+            "compact": " EPUB Accessibility 1.1",
+            "descriptive": " EPUB Accessibility 1.1"
         },
         "conformance-details-level-a": {
             "compact": " Level A",
             "descriptive": " Level A"
         },
         "conformance-details-level-aa": {
-            "compact": "Level AA",
-            "descriptive": "Level AA"
+            "compact": " Level AA",
+            "descriptive": " Level AA"
         },
         "conformance-details-level-aaa": {
             "compact": " Level AAA",
@@ -115,15 +115,15 @@
         },
         "conformance-details-wcag-2-0": {
             "compact": " WCAG 2.0",
-            "descriptive": "Web Content Accessibility Guidelines (WCAG) 2.0"
+            "descriptive": " Web Content Accessibility Guidelines (WCAG) 2.0"
         },
         "conformance-details-wcag-2-1": {
-            "compact": "WCAG 2.1",
-            "descriptive": "Web Content Accessibility Guidelines (WCAG) 2.1"
+            "compact": " WCAG 2.1",
+            "descriptive": " Web Content Accessibility Guidelines (WCAG) 2.1"
         },
         "conformance-details-wcag-2-2": {
             "compact": " WCAG 2.2",
-            "descriptive": "Web Content Accessibility Guidelines (WCAG) 2.2"
+            "descriptive": " Web Content Accessibility Guidelines (WCAG) 2.2"
         },
         "conformance-no": {
             "compact": "No information is available",

--- a/a11y-meta-display-guide/2.0/draft/localizations/en-US/display_guide_vocabulary_w3c_en-US.json
+++ b/a11y-meta-display-guide/2.0/draft/localizations/en-US/display_guide_vocabulary_w3c_en-US.json
@@ -3,7 +3,7 @@
         "author": "W3C Publishing Community Group Accessibility Task Force",
         "language": "en-US",
         "variant": "canonical",
-        "version": "2.0.a",
+        "version": "2.0.b",
         "audience": "general",
         "description": "Original wording discussed by a large group representing different actors of the English-speaking geographies. It has been improved after proof of concept implementations and panel testers"
     },
@@ -73,45 +73,57 @@
             "compact": "This publication exceeds accepted accessibility standards",
             "descriptive": "The publication contains a conformance statement that it meets the EPUB Accessibility and WCAG 2 Level AAA standard"
         },
-        "conformance-certification-info": {
-            "compact": "The publication was certified on ",
-            "descriptive": "The publication was certified on "
-        },
         "conformance-certifier": {
             "compact": "The publication was certified by",
-            "descriptive": "The publication was certified by "
+            "descriptive": "The publication was certified by"
         },
         "conformance-certifier-credentials": {
             "compact": "The certifier's credential is ",
-            "descriptive": "The certifier's credential is "
+            "descriptive": "The certifier's credential is"
         },
-        "conformance-certifier-report": {
+        "conformance-details-certification-info": {
+            "compact": "The publication was certified on ",
+            "descriptive": "The publication was certified on"
+        },
+        "conformance-details-certifier-report": {
             "compact": "For more information refer to the certifier's report",
             "descriptive": "For more information refer to the certifier's report"
         },
-        "conformance-claim": {
+        "conformance-details-claim": {
             "compact": "This publication claims to meet",
             "descriptive": "This publication claims to meet"
         },
-        "conformance-epub-accessibility-1-0": {
+        "conformance-details-epub-accessibility-1-0": {
             "compact": " EPUB Accessibility 1.0",
             "descriptive": " EPUB Accessibility 1.0"
         },
-        "conformance-epub-accessibility-1-1": {
-            "compact": " EPUB Accessibility 1.1",
-            "descriptive": " EPUB Accessibility 1.1"
+        "conformance-details-epub-accessibility-1-1": {
+            "compact": "EPUB Accessibility 1.1",
+            "descriptive": "EPUB Accessibility 1.1"
         },
-        "conformance-level-a": {
+        "conformance-details-level-a": {
             "compact": " Level A",
             "descriptive": " Level A"
         },
-        "conformance-level-aa": {
-            "compact": " Level AA",
-            "descriptive": " Level AA"
+        "conformance-details-level-aa": {
+            "compact": "Level AA",
+            "descriptive": "Level AA"
         },
-        "conformance-level-aaa": {
+        "conformance-details-level-aaa": {
             "compact": " Level AAA",
             "descriptive": " Level AAA"
+        },
+        "conformance-details-wcag-2-0": {
+            "compact": " WCAG 2.0",
+            "descriptive": "Web Content Accessibility Guidelines (WCAG) 2.0"
+        },
+        "conformance-details-wcag-2-1": {
+            "compact": "WCAG 2.1",
+            "descriptive": "Web Content Accessibility Guidelines (WCAG) 2.1"
+        },
+        "conformance-details-wcag-2-2": {
+            "compact": " WCAG 2.2",
+            "descriptive": "Web Content Accessibility Guidelines (WCAG) 2.2"
         },
         "conformance-no": {
             "compact": "No information is available",
@@ -120,18 +132,6 @@
         "conformance-unknown-standard": {
             "compact": "Conformance to accepted standards for accessibility of this publication cannot be determined",
             "descriptive": "Conformance to accepted standards for accessibility of this publication cannot be determined"
-        },
-        "conformance-wcag-2-0": {
-            "compact": " WCAG 2.0",
-            "descriptive": "Web Content Accessibility Guidelines (WCAG ) 2.0"
-        },
-        "conformance-wcag-2-1": {
-            "compact": " WCAG 2.1",
-            "descriptive": "Web Content Accessibility Guidelines (WCAG ) 2.1"
-        },
-        "conformance-wcag-2-2": {
-            "compact": " WCAG 2.2",
-            "descriptive": "Web Content Accessibility Guidelines (WCAG ) 2.2"
         }
     },
     "navigation": {

--- a/a11y-meta-display-guide/bin/canonical-json-extract-strings.xsl
+++ b/a11y-meta-display-guide/bin/canonical-json-extract-strings.xsl
@@ -6,6 +6,7 @@
     <xsl:param name="onix"/>
     <xsl:param name="epub"/>
     <xsl:param name="ids-file"/>
+    <xsl:param name="version"/>
     
     <xsl:key name="id-lookup" match="/ids/group/id" use="."/>
     
@@ -15,6 +16,7 @@
                 <author>W3C Publishing Community Group Accessibility Task Force</author>
                 <language>en-US</language>
                 <variant>canonical</variant>
+                <version><xsl:value-of select="$version"/></version>
                 <audience>general</audience>
                 <description>Original wording discussed by a large group representing different actors of the English-speaking geographies. It has been improved after proof of concept implementations and panel testers</description>
             </metadata>

--- a/a11y-meta-display-guide/bin/update-canonical-json.sh
+++ b/a11y-meta-display-guide/bin/update-canonical-json.sh
@@ -21,6 +21,9 @@ basedir=$(dirname "$basedir")
 tmpdir=$(mktemp -d)
 output_dir="$basedir/../2.0/draft/localizations"
 
+# Input
+read -p 'JSON version: ' jsonVersion
+
 # Input files
 guidelines="$basedir/../2.0/draft/guidelines/index.html"
 epub_techniques="$basedir/../2.0/draft/techniques/epub-metadata/index.html"
@@ -41,6 +44,7 @@ xsltproc --stringparam guidelines "$guidelines" \
          --stringparam onix "$onix_techniques" \
          --stringparam epub "$epub_techniques" \
          --stringparam ids-file "$tmpdir/ids.xml" \
+         --stringparam version "$jsonVersion" \
          "$xslt_extract_strings" "$tmpdir/ids.xml" > "$tmpdir/strings.xml"
 
 # Convert to JSON


### PR DESCRIPTION
In updating I realized that leading or trailing spaces were skipped, particularly for strings:
- conformance-certifier
- conformance-certifier-credentials
- conformance-epub-accessibility-1-1
- conformance-details-level-aa
- conformance-details-wcag-2-1

cc @mattgarrish 

Caution: do not merge until we have fixed the spaces.