### PR TITLE
Add spaces to example strings

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1153,11 +1153,11 @@
 									respective standard. For example, the descriptive statements for WCAG 2 would be:</p>
 								<ul>
 									<li data-localization-id="conformance-details-wcag-2-0"
-										data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG) 2.0</li>
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.0</li>
 									<li data-localization-id="conformance-details-wcag-2-1"
-										data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG) 2.1</li>
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.1</li>
 									<li data-localization-id="conformance-details-wcag-2-2"
-										data-localization-mode="descriptive">Web Content Accessibility Guidelines (WCAG) 2.2</li>
+										data-localization-mode="descriptive"> Web Content Accessibility Guidelines (WCAG) 2.2</li>
 								</ul>
 							</div>
 						</dd>
@@ -1202,13 +1202,13 @@
 								<span
 									data-localization-id="conformance-certifier"
 									data-localization-mode="compact">The
-									publication was certified by</span>
+									publication was certified by </span>
 								Foo's Accessibility Testing
 							</p>
 							<p>
 								<span
 									data-localization-id="conformance-certifier-credentials"
-									data-localization-mode="compact">The certifier's credential is</span> "Enterprise
+									data-localization-mode="compact">The certifier's credential is </span> "Enterprise
 								Accessibility Rating"
 							</p>
 
@@ -1222,21 +1222,21 @@
 										publication claims to meet</span>
 									<span
 										data-localization-id="conformance-details-epub-accessibility-1-1"
-										data-localization-mode="compact">EPUB
+										data-localization-mode="compact"> EPUB
 										Accessibility
 										1.1</span>
 									<span
 										data-localization-id="conformance-details-wcag-2-1"
-										data-localization-mode="compact">WCAG
+										data-localization-mode="compact"> WCAG
 										2.1</span>
 									<span
 										data-localization-id="conformance-details-level-aa"
-										data-localization-mode="compact">Level
+										data-localization-mode="compact"> Level
 										AA</span>
 								</p>
 								<p><span data-localization-id="conformance-details-certification-info"
 										data-localization-mode="compact">The
-										publication was certified on</span>
+										publication was certified on </span>
 									2021-09-07</p>
 								<p><span data-localization-id="conformance-details-certifier-report"
 										data-localization-mode="compact">For
@@ -1258,13 +1258,13 @@
 								<span
 									data-localization-id="conformance-certifier"
 									data-localization-mode="descriptive">The
-									publication was certified by</span>
+									publication was certified by </span>
 								Foo's Accessibility Testing
 							</p>
 							<p>
 								<span
 									data-localization-id="conformance-certifier-credentials"
-									data-localization-mode="descriptive">The certifier's credential is</span> "Enterprise
+									data-localization-mode="descriptive">The certifier's credential is </span> "Enterprise
 								Accessibility Rating"
 							</p>
 
@@ -1278,22 +1278,22 @@
 										publication claims to meet</span>
 									<span
 										data-localization-id="conformance-details-epub-accessibility-1-1"
-										data-localization-mode="descriptive">EPUB
+										data-localization-mode="descriptive"> EPUB
 										Accessibility
 										1.1</span>
 									<span
 										data-localization-id="conformance-details-wcag-2-1"
-										data-localization-mode="descriptive">Web
+										data-localization-mode="descriptive"> Web
 										Accessibility Content Guidelines (WCAG)
 										2.1</span>
 									<span
 										data-localization-id="conformance-details-level-aa"
-										data-localization-mode="descriptive">Level
+										data-localization-mode="descriptive"> Level
 										AA</span>
 								</p>
 								<p><span data-localization-id="conformance-details-certification-info"
 										data-localization-mode="descriptive">The
-										publication was certified on</span>
+										publication was certified on </span>
 									2021-09-07</p>
 								<p><span data-localization-id="conformance-details-certifier-report"
 										data-localization-mode="descriptive">For


### PR DESCRIPTION
This captures all the missing spaces I spotted in the guidelines, as noted in #659 . I think that's the only place the problem arises.