### PR TITLE
Add missing space to end of conformance-certifier string

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1088,7 +1088,7 @@
 							<p><span
 									data-localization-id="conformance-certifier"
 									data-localization-mode="compact">The
-									publication was certified by</span>
+									publication was certified by </span>
 								<span class="placeholder">&lt;certifier name&gt;</span></p>
 						</dd>
 
@@ -2410,6 +2410,24 @@
 			accessibility metadata.</p>
 
 		<p>Links TBD</p>
+	</section>
+	<section id="change-log" class="informative">
+		<h2>Change log</h2>
+		
+		<div class="note">
+			<p>This section identifies substantive changes between versions. For a list of all changes, refer to 
+				the <a
+					href="https://github.com/w3c/publ-a11y/issues?q=is%3Aissue%20state%3Aclosed%20label%3Aa11y-display-guide">issue tracker</a>.</p>
+		</div>
+		
+		<details open="">
+			<summary>Changes since the <a 
+					href="https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/guidelines/guidelines-draft-note-20250220.html">2025-02-20
+					Draft Community Group Report</a></summary>
+			<ul>
+				<li>No substantive changes have been made.</li>
+			</ul>
+		</details>
 	</section>
 	<div data-include="../common/acknowledgements.html"
 		data-include-replace="true"></div>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -2425,7 +2425,7 @@
 					href="https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/guidelines/guidelines-draft-note-20250220.html">2025-02-20
 					Draft Community Group Report</a></summary>
 			<ul>
-				<li>No substantive changes have been made.</li>
+				<li>2025-02-28: Fixed missing space at the end of the <code>conformance-certifier</code> string.</li>
 			</ul>
 		</details>
 	</section>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -417,18 +417,28 @@
 					</dd>
 					<dt><var>certifier_report</var></dt>
 					<dd>
-						<p>Returns the description of <i>a11y:certifierReport</i> (Compliance web page for detailed accessibility information) if present in the OPF, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <i>a11y:certifierReport</i> (Compliance web page for detailed accessibility information) if present in the package document, otherwise if false it means that the metadata is not present.</p>
 						<p>This means that is present the URL of a compliance web page for detailed accessibility information. The web page should be maintained by an independent compliance scheme or testing organization. Note the web page may include information about specific national requirements or voluntary conformance reports.</p>
-					</dd>
-                    <dt><var>conformance-claimed</var></dt>
-					<dd>
-						<p>If true it indicates that the <i>conformsTo</i> is present in the package document, otherwise if false it means that the metadata is not present.</p>
-						<p>This means that the publication conforms to some specification.</p>
 					</dd>
 					<dt><var>epub_version</var></dt>
 					<dd>
                         <p>If set, provides the version of the EPUB Accessibility specification the
                         	publication conforms to.</p>
+					</dd>
+					<dt><var>epub10_wcag20a</var></dt>
+					<dd>
+						<p>If set, indicates that a conformance claim to the EPUB Accessibility 1.0 specification
+							at WCAG 2.0 Level A.</p>
+					</dd>
+					<dt><var>epub10_wcag20aa</var></dt>
+					<dd>
+						<p>If set, indicates that a conformance claim to the EPUB Accessibility 1.0 specification
+							at WCAG 2.0 Level AA.</p>
+					</dd>
+					<dt><var>epub10_wcag20aaa</var></dt>
+					<dd>
+						<p>If set, indicates that a conformance claim to the EPUB Accessibility 1.0 specification
+							at WCAG 2.0 Level AAA.</p>
 					</dd>
 					<dt><var>wcag_version</var></dt>
 					<dd>
@@ -437,48 +447,68 @@
 				</dl>
 
 				<h4>Variables setup</h4>
+				
 				<ol class="condition">
 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
-                <!-- EPUB Accessibility 1.0 WCAG 2.0 (A/AA/AAA) -->
-                 <li>
-                     <span><b>IF</b> the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/link[@rel="dcterms:<i>conformsTo</i>" and @href="<i>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</i>"] | /package/metadata/meta[@property="dcterms:conformsTo" and normalize-space() = "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a"]</code> :</span>
-                     <span><b>THEN LET</b> <var>epub_version</var> = '1.0', and</span>
-                 	<span><b>LET</b> <var>wcag_version</var> = '2.0', and</span>
-                 	<span><b>LET</b> <var>wcag_level</var> = 'A'.</span>
-                 </li>
-
-                  <li>
-                       <span><b>IF</b> the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/link[@rel="dcterms:<i>conformsTo</i>" and @href="<i>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa</i>"] | /package/metadata/meta[@property="dcterms:conformsTo" and normalize-space() = "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"]</code>:</span>
-                  	<span><b>THEN LET</b> <var>epub_version</var> = '1.0', and</span>
-                  	<span><b>LET</b> <var>wcag_version</var> = '2.0', and</span>
-                  	<span><b>LET</b> <var>wcag_level</var> = 'AA'.</span>
-                  </li>
-
-                  <li>
-                      <span><b>IF</b> the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/link[@rel="dcterms:<i>conformsTo</i>" and @href="<i>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa</i>"] | /package/metadata/meta[@property="dcterms:conformsTo" and normalize-space() = "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa"]</code>:</span>
-                  	<span><b>THEN LET</b> <var>epub_version</var> = '1.0', and</span>
-                  	<span><b>LET</b> <var>wcag_version</var> = '2.0', and</span>
-                  	<span><b>LET</b> <var>wcag_level</var> = 'AAA'.</span>
-                  </li>
-
-                   <!-- EPUB Accessibility 1.1 WCAG 2.X (A/AA/AAA) -->
-					<li><b>LET</b> <var>conformance</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/meta[@property="dcterms:<i>conformsTo</i>" and matches(normalize-space(), 'EPUB Accessibility 1\.1 - WCAG 2\.[0-2] Level [A]+')]</code>.</li>
-
-				   <li>
-                  	<span><b>IF</b> <var>conformance</var> is <b>NOT</b> empty:</span>
-				   	<span><b>THEN LET</b> <var>epub_version</var> = '1.1', and</span>
-				   	<span><b>LET</b> <var>wcag_version</var> = replace(<var>conformance</var>, 'EPUB Accessibility 1\.1 - WCAG (2\.[0-2]) Level [A]+', '$1'), and</span>
-				   	<span><b>LET</b> <var>wcag_level</var> = replace(<var>conformance</var>, 'EPUB Accessibility 1\.1 - WCAG 2\.[0-2] Level ', '').</span>
-                    </li>
-
-                    <li><b>LET</b> <var>certifier</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/meta[@property="a11y:<i>certifiedBy</i>"]</code>.</li>
-
-                    <li><b>LET</b> <var>certifier_credentials</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/meta[@property="a11y:<i>certifierCredential</i>"]</code>.</li>
-
-                    <li><b>LET</b> <var>certification_date</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/meta[@property="dcterms:date" and @refines=//meta[@property="a11y:certifiedBy"]/@id]</code>.</li>
-
-                    <li><b>LET</b> <var>certifier_report</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/meta[@property="a11y:<i>certifierReport</i>"]</code>.</li>
+					<!-- EPUB Accessibility 1.1 WCAG 2.X (A/AA/AAA) -->
+					<li><b>LET</b> <var>conformance</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/meta[@property="dcterms:conformsTo" and matches(normalize-space(), 'EPUB Accessibility 1\.1 - WCAG 2\.[0-2] Level [A]+')]</code>.</li>
+					
+					<!-- EPUB Accessibility 1.0 WCAG 2.0 (A/AA/AAA) -->
+					<li><b>LET</b> <var>epub10_wcag20a</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/*[(@rel="dcterms:conformsTo" and @href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a") or (@property="dcterms:conformsTo" and normalize-space() = "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a")]</code>.</li>
+					
+					<li><b>LET</b> <var>epub10_wcag20aa</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/*[(@rel="dcterms:conformsTo" and @href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa") or (@property="dcterms:conformsTo" and normalize-space() = "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa")]</code>.</li>
+					
+					<li><b>LET</b> <var>epub10_wcag20aaa</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/*[(@rel="dcterms:conformsTo" and @href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa") or (@property="dcterms:conformsTo" and normalize-space() = "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa")]</code>.</li>
+					
+					<li>
+						<span><b>IF</b> <var>conformance</var> is <b>NOT</b> empty:</span>
+						<span><b>THEN LET</b> <var>epub_version</var> = '1.1', and</span>
+						<span><b>LET</b> <var>wcag_version</var> = replace(<var>conformance</var>, 'EPUB Accessibility 1\.1 - WCAG (2\.[0-2]) Level [A]+', '$1'), and</span>
+						<span><b>LET</b> <var>wcag_level</var> = replace(<var>conformance</var>, 'EPUB Accessibility 1\.1 - WCAG 2\.[0-2] Level ', '').</span>
+					</li>
+					
+					<!-- EPUB Accessibility 1.0 WCAG 2.0 (A/AA/AAA) -->
+					<li>
+						<span><b>ELSE IF</b> <var>epub10_wcag20aaa</var>:</span>
+						<span><b>THEN LET</b> <var>epub_version</var> = '1.0', and</span>
+						<span><b>LET</b> <var>wcag_version</var> = '2.0', and</span>
+						<span><b>LET</b> <var>wcag_level</var> = 'AAA'.</span>
+					</li>
+					
+					<li>
+						<span><b>ELSE IF</b> <var>epub10_wcag20aa</var>:</span>
+						<span><b>THEN LET</b> <var>epub_version</var> = '1.0', and</span>
+						<span><b>LET</b> <var>wcag_version</var> = '2.0', and</span>
+						<span><b>LET</b> <var>wcag_level</var> = 'AA'.</span>
+					</li>
+					
+					<li>
+						<span><b>ELSE IF</b> <var>epub10_wcag20a</var>:</span>
+						<span><b>THEN LET</b> <var>epub_version</var> = '1.0', and</span>
+						<span><b>LET</b> <var>wcag_version</var> = '2.0', and</span>
+						<span><b>LET</b> <var>wcag_level</var> = 'A'.</span>
+					</li>
+					
+					<li><b>LET</b> <var>certifier</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/meta[@property="a11y:certifiedBy" and (not(@refines) or substring(@refines,2)=//*[(@rel="dcterms:conformsTo" and contains(@href, "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "EPUB Accessibility 1.1"))]/@id)]</code>.
+					
+						<div class="note">
+							<p>The <code>refines</code> attribute is used to link evaluation metadata back to the right evaluator and the 
+								evaluator back to their conformance claim. This adds complexity to the xpaths because these refinement
+								chains need to be resolved by matching fragment identifiers to IDs.</p>
+							<p>The xpath for this variable, and the following ones, can be simplified if the ID of the element containing
+								the conformance string is stored when the conformance claim is first found. This ID can then be dynamically
+								added to match against the <code>refines</code> attribute value rather than using text comparisons to relocate
+								the claim each time. The text comparisons are necessary without such an optimization because it is possible an 
+								EPUB publication has more than one conformance claim.</p>
+						</div>
+					</li>
+					
+					<li><b>LET</b> <var>certifier_credentials</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/meta[@property="a11y:certifierCredential" and (not(@refines) or substring(@refines,2)=//meta[@property="a11y:certifiedBy" and substring(@refines,2)=//*[(@rel="dcterms:conformsTo" and contains(@href, "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "EPUB Accessibility 1.1"))]/@id]/@id)]</code>.</li>
+					
+					<li><b>LET</b> <var>certification_date</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/meta[@property="dcterms:date" and substring(@refines,2)=//*[(@rel="dcterms:conformsTo" and contains(@href, "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "EPUB Accessibility 1.1"))]/@id]</code>.</li>
+					
+					<li><b>LET</b> <var>certifier_report</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/link[@rel="a11y:certifierReport" and (not(@refines) or substring(@refines,2)=//meta[@property="a11y:certifiedBy" and substring(@refines,2)=//*[(@rel="dcterms:conformsTo" and contains(@href, "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "EPUB Accessibility 1.1"))]/@id]/@id)]/@href</code>.</li>
 				</ol>
 
 				<h4 id="conformance-instructions">Instructions</h4>
@@ -1195,7 +1225,28 @@
 						</li>
 					</ol>
 			</section>
-
+		</section>
+		<section id="change-log" class="informative">
+			<h2>Change log</h2>
+			
+			<div class="note">
+				<p>This section identifies substantive changes between versions. For a list of all changes, refer to 
+					the <a
+						href="https://github.com/w3c/publ-a11y/issues?q=is%3Aissue%20state%3Aclosed%20label%3Aa11y-display-techniques-epub">issue tracker</a>.</p>
+			</div>
+			
+			<details open="">
+				<summary>Changes since the <a 
+						href="https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/techniques/epub-metadata/epub-metadata-draft-note-20250220.html">2025-02-20
+						Draft Community Group Report</a></summary>
+				<ul>
+					<li>28-Feb-2025: Added support for the <code>refines</code> attribute linking of conformance
+						metadata fields. See <a href="https://github.com/w3c/publ-a11y/issues/374">issue 374</a>.</li>
+					<li>28-Feb-2025: Fixed the ordering of the conformance claim checks so that the newest claim
+						is captured first and checking is stopped once the first claim is found.</li>
+					<li>28-Feb-2025: Updated the EPUB 1.0 conformance claim checks so only a single xpath is needed.</li>
+				</ul>
+			</details>
 		</section>
 		<div data-include="../../common/acknowledgements.html" data-include-replace="true"></div>
 	</body>

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -1122,6 +1122,24 @@
 				</ol>
 			</section>
 		</section>
+		<section id="change-log" class="informative">
+			<h2>Change log</h2>
+			
+			<div class="note">
+				<p>This section identifies substantive changes between versions. For a list of all changes, refer to 
+					the <a
+						href="https://github.com/w3c/publ-a11y/issues?q=is%3Aissue%20state%3Aclosed%20label%3Aa11y-display-techniques-onix">issue tracker</a>.</p>
+			</div>
+			
+			<details open="">
+				<summary>Changes since the <a 
+						href="https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/techniques/onix-metadata/onix-metadata-draft-note-20250220.html">2025-02-20
+						Draft Community Group Report</a></summary>
+				<ul>
+					<li>No substantive changes have been made.</li>
+				</ul>
+			</details>
+		</section>
 		<div data-include="../../common/acknowledgements.html" data-include-replace="true"></div>
 	</body>
 </html>


### PR DESCRIPTION
One of the two compact versions of the string was missing a space in the guidelines and that's the one that got picked up for the vocabulary.