### PR TITLE
Add tests for unknown and mixed hazard statements

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1683,6 +1683,15 @@
 							data-localization-mode="descriptive">The publication contains no hazards</p>
 					</dd>
 
+					<dt>If hazards are not known:</dt>
+					<dd>
+						<p data-localization-id="hazards-unknown"
+							data-localization-mode="compact">The presence of hazards is unknown</p>
+						<p data-localization-id="hazards-unknown"
+							data-localization-mode="descriptive">The presents
+							of hazards is unknown</p>
+					</dd>
+					
 					<dt>If there is a flashing hazard:</dt>
 					<dd>
 						<p data-localization-id="hazards-flashing"
@@ -1691,10 +1700,33 @@
 						<p data-localization-id="hazards-flashing"
 								data-localization-mode="descriptive">The
 								publication contains flashing content
-								which can cause photosensitive
+								that can cause photosensitive
 								seizures</p>
 					</dd>
 
+					<dt>If there is no flashing hazard:</dt>
+					<dd>
+						<p data-localization-id="hazards-flashing-none"
+							data-localization-mode="compact">No flashing
+							hazard</p>
+						<p data-localization-id="hazards-flashing-none"
+							data-localization-mode="descriptive">The
+							publication does not contain flashing content
+							that can cause photosensitive
+							seizures</p>
+					</dd>
+					
+					<dt>If a flashing hazard is not known:</dt>
+					<dd>
+						<p data-localization-id="hazards-flashing-unknown"
+							data-localization-mode="compact">Flashing
+							hazard not known</p>
+						<p data-localization-id="hazards-flashing-unknown"
+							data-localization-mode="descriptive">The
+							presence of flashing content that can cause
+							photosensitive seizures could not be determined</p>
+					</dd>
+					
 					<dt>If there is a motion simulation hazard:</dt>
 					<dd>
 						<p data-localization-id="hazards-motion"
@@ -1705,26 +1737,61 @@
 								publication contains motion simulations
 								that can cause motion sickness</p>
 					</dd>
-
+					
+					<dt>If there is no motion simulation hazard:</dt>
+					<dd>
+						<p data-localization-id="hazards-flashing-none"
+							data-localization-mode="compact">No motion simulation
+							hazards</p>
+						<p data-localization-id="hazards-motion-none"
+							data-localization-mode="descriptive">The
+							publication does not contain motion simulations
+							that can cause motion sickness</p>
+					</dd>
+					
+					<dt>If a motion simulation hazard is not known:</dt>
+					<dd>
+						<p data-localization-id="hazards-motion-unknown"
+							data-localization-mode="compact">Motion simulation
+							hazard not known</p>
+						<p data-localization-id="hazards-motion-unknown"
+							data-localization-mode="descriptive">The
+							presence of motion simulations that can cause
+							motion sickness could not be determined</p>
+					</dd>
+					
 					<dt>If there is a sound hazard:</dt>
 					<dd>
 						<p data-localization-id="hazards-sound"
 							data-localization-mode="compact">Sounds</p>
 						<p data-localization-id="hazards-sound"
 								data-localization-mode="descriptive">The
-								publication contains sounds which
-								can be uncomfortable</p>
+								publication contains sounds that
+								can cause sensitivity issues</p>
 					</dd>
-
-					<dt>If hazards are not known:</dt>
+					
+					<dt>If there is no sound hazard:</dt>
 					<dd>
-						<p data-localization-id="hazards-unknown"
-							data-localization-mode="compact">The presence of hazards is unknown</p>
-						<p data-localization-id="hazards-unknown"
-								data-localization-mode="descriptive">The presents
-								of hazards is unknown</p>
+						<p data-localization-id="hazards-sound-none"
+							data-localization-mode="compact">No sound
+							hazards</p>
+						<p data-localization-id="hazards-sound-none"
+							data-localization-mode="descriptive">The
+							publication does not contain sounds
+							that can cause sensitivity issues</p>
 					</dd>
-
+					
+					<dt>If a sound hazard is not known:</dt>
+					<dd>
+						<p data-localization-id="hazards-sound-unknown"
+							data-localization-mode="compact">Sound
+							hazards not known</p>
+						<p data-localization-id="hazards-sound-unknown"
+							data-localization-mode="descriptive">The
+							presence of sounds that can cause
+							sensitivity issues could not be determined</p>
+					</dd>
+					
 					<dt>If no metadata is provided:</dt>
 					<dd>
 						<p data-localization-id="hazards-no-metadata"

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -2492,7 +2492,10 @@
 					href="https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/guidelines/guidelines-draft-note-20250220.html">2025-02-20
 					Draft Community Group Report</a></summary>
 			<ul>
-				<li>2025-02-28: Fixed missing space at the end of the <code>conformance-certifier</code> string.</li>
+				<li>03-Mar-2025: Added outputs for situations where there is a mix of hazard, no hazard, and 
+					unknown hazard statements. See <a href="https://github.com/w3c/publ-a11y/issues/578">issue 
+						587</a>.</li>
+				<li>28-Feb-2025: Fixed missing space at the end of the <code>conformance-certifier</code> string.</li>
 			</ul>
 		</details>
 	</section>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -1293,6 +1293,9 @@
 						href="https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/techniques/epub-metadata/epub-metadata-draft-note-20250220.html">2025-02-20
 						Draft Community Group Report</a></summary>
 				<ul>
+					<li>03-Mar-2025: Added individual tests for unknown hazards and included outputs for situations
+						where there is a mix of hazard, no hazard, and unknown hazard statements. See <a 
+							href="https://github.com/w3c/publ-a11y/issues/578">issue 587</a>.</li>
 					<li>28-Feb-2025: Added support for the <code>refines</code> attribute linking of conformance
 						metadata fields. See <a href="https://github.com/w3c/publ-a11y/issues/374">issue 374</a>.</li>
 					<li>28-Feb-2025: Fixed the ordering of the conformance claim checks so that the newest claim

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -960,16 +960,24 @@
 								<span><b>THEN</b> display <code id="hazards-flashing">"Flashing content"</code>.</span>
 							</li>
 							<li>
-								<span><b>IF</b> <var>unknown_flashing_hazard</var>:</span>
-								<span><b>THEN</b> display <code id="hazards-flashing-unknown">"Flashing hazards not known"</code>.</span>
-							</li>
-							<li>
 								<span><b>IF</b> <var>motion_simulation_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-motion">"Motion simulation"</code>.</span>
 							</li>
 							<li>
+								<span><b>IF</b> <var>sound_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-sound">"Sounds"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>unknown_flashing_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-flashing-unknown">"Flashing hazards not known"</code>.</span>
+							</li>
+							<li>
 								<span><b>IF</b> <var>unknown_motion_simulation_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-motion-unknown">"Motion simulation hazards not known"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>unknown_sound_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-sound-unknown">"Sound hazards not known"</code>.</span>
 							</li>
 							<li>
 								<span><b>IF</b> <var>no_flashing_hazard</var>:</span>
@@ -982,14 +990,6 @@
 							<li>
 								<span><b>IF</b> <var>no_sound_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-sound-none">"No sound hazards"</code>.</span>
-							</li>
-							<li>
-								<span><b>IF</b> <var>sound_hazard</var>:</span>
-								<span><b>THEN</b> display <code id="hazards-sound">"Sounds"</code>.</span>
-							</li>
-							<li>
-								<span><b>IF</b> <var>unknown_sound_hazard</var>:</span>
-								<span><b>THEN</b> display <code id="hazards-sound-unknown">"Sound hazards not known"</code>.</span>
 							</li>
 						</ul>
 					</li>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -39,6 +39,16 @@
 	  	var {
 			color: brown;
 		}
+		li > ol.condition {
+			list-style-type: alpha;
+		}
+		
+		li > ol.condition > li >  ol.condition {
+			list-style-type: roman;
+		}
+		ol.display {
+			list-style-type: disc;
+		}
 	  	ol.condition > li {
 	  		margin-top: 1rem;
 	  		margin-left: 0;
@@ -219,15 +229,15 @@
                         </dd>
                     </dl>
 
-                    <h5>Variables setup</h5>
-                    <ol class="condition">
-                        <li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
-
-                        <li><b>LET</b> <var>all_textual_content_can_be_modified</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>displayTransformability</i>"]</code>.</li>
-
+					<h5>Variables setup</h5>
+					<ul class="variable">
+						<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
+						
+						<li><b>LET</b> <var>all_textual_content_can_be_modified</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>displayTransformability</i>"]</code>.</li>
                         <li><b>LET</b> <var>is_fixed_layout</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="rendition:<i>layout</i>" and normalize-space()="<i>pre-paginated</i>"]</code>.</li>
 
-                    </ol>
+					</ul>
+
                     <h5>Instructions</h5>
                     <ol class="condition">
                         <li>
@@ -357,9 +367,9 @@
                             <p>This indicates that text-synchronised prerecorded audio narration (natural or synthesized voice) is included for substantially all textual matter, including all alternative descriptions, e.g. via a SMIL media overlay.</p>
                         </dd>
                     </dl>
-                    <h5>Variables setup</h5>
-                    <ol class="condition">
-                        <li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
+					<h5>Variables setup</h5>
+					<ul class="variable">
+						<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
                         <li><b>LET</b> <var>all_content_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessModeSufficient</i>" and normalize-space()="<i>auditory</i>"]</code>.</li>
 
@@ -367,7 +377,7 @@
 
                         <li><b>LET</b> <var>synchronised_pre_recorded_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>synchronizedAudioText</i>"]</code>.</li>
 
-                    </ol>
+                    </ul>
                     <h5>Instructions</h5>
                     <ol class="condition">
                         <li>
@@ -447,7 +457,7 @@
 
 				<h4>Variables setup</h4>
 				
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
 					<!-- EPUB Accessibility 1.1 WCAG 2.X (A/AA/AAA) -->
@@ -508,7 +518,7 @@
 					<li><b>LET</b> <var>certification_date</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/meta[@property="dcterms:date" and substring(@refines,2)=//*[(@rel="dcterms:conformsTo" and contains(@href, "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "EPUB Accessibility 1.1"))]/@id]</code>.</li>
 					
 					<li><b>LET</b> <var>certifier_report</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/link[@rel="a11y:certifierReport" and (not(@refines) or substring(@refines,2)=//meta[@property="a11y:certifiedBy" and substring(@refines,2)=//*[(@rel="dcterms:conformsTo" and contains(@href, "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "http://www.idpf.org/epub/a11y/")) or (@property="dcterms:conformsTo" and contains(normalize-space(), "EPUB Accessibility 1.1"))]/@id]/@id)]/@href</code>.</li>
-				</ol>
+				</ul>
 
 				<h4 id="conformance-instructions">Instructions</h4>
 				<ol class="condition">
@@ -517,7 +527,7 @@
 					</li>
 					<li>
 						<span><b>ELSE</b>:</span>
-						<ul class="condition">
+						<ol class="condition">
 							<li>
 								<span><b>IF</b> <var>wcag_level</var> == 'AAA':</span>
 								<span><b>THEN</b> display <code id="conformance-aaa">"This publication exceeds accepted accessibility standards"</code>.</span>
@@ -537,15 +547,15 @@
 							<li>
 								<span><b>IF</b> <var>certifier</var> is <b>NOT</b> empty:</span>
 								<span><b>THEN</b></span>
-								<ul class="condition">
+								<ol class="display">
 									<li>display <code id="conformance-certifier">"The publication was certified by "</code></li>
 									<li>display <var>certifier</var>.</li>
-								</ul>
+								</ol>
 							</li>
 							<li>
 								<span><b>IF</b> <var>certifier_credentials</var> is <b>NOT</b> empty:</span>
 								<span><b>THEN</b></span>
-								<ul class="condition">
+								<ol class="condition">
 									<li>display <code id="conformance-certifier-credentials">"The certifier's credential is "</code></li>
 									<li>
                                         <span><b>IF</b> <var>certifier_credentials</var> is a URL.</span>
@@ -555,7 +565,7 @@
                                         <span><b>ELSE</b> display <var>certifier_credentials</var> as text.</span>
                                     </li>
 
-								</ul>
+								</ol>
 							</li>
 							<li>
 								<div class="note">
@@ -566,7 +576,7 @@
 								</div>
 								
 								<span>Display <code id="conformance-details-claim">"This publication claims to meet"</code>.</span>
-								<ul>
+								<ol class="condition">
 									<li>
 										<span><b>IF</b> <var>epub_version</var> == '<code>1.0</code>':</span>
 										<span><b>THEN</b> display <code id="conformance-details-epub-accessibility-1-0">" EPUB Accessibility 1.0"</code>.</span>
@@ -599,24 +609,20 @@
 										<span><b>ELSE IF</b> <var>wcag_level</var> == '<code>A</code>':</span>
 										<span><b>THEN</b> display <code id="conformance-details-level-a">" Level A"</code>.</span>
 									</li>
-								</ul>
+								</ol>
 							</li>
 							<li>
 								<span><b>IF</b> <var>certification_date</var> <b>THEN</b>:</span>
-                                <ul class="condition">
-
+								<ol class="display">
                                 	<li>display <code id="conformance-details-certification-info">"The publication was certified on "</code></li>
 									<li>display <var>certification_date</var>.</li>
-								</ul>
+								</ol>
 							</li>
 							<li>
 								<span><b>IF</b> <var>certifier_report</var>:</span>
-								<span><b>THEN</b></span>
-								<ul class="condition">
-									<li>display <code id="conformance-details-certifier-report">"For more information refer to the certifier's report"</code> as a named link with <var>certifier_report</var> as the URL used.</li>
-								</ul>
+								<span><b>THEN</b> display <code id="conformance-details-certifier-report">"For more information refer to the certifier's report"</code> as a named link with <var>certifier_report</var> as the URL used.</span>
 							</li>
-						</ul>
+						</ol>
 					</li>
 				</ol>
 			</section>
@@ -652,7 +658,7 @@
 					</dd>
 				</dl>
 				<h4>Variables setup</h4>
-				<ol class="condition">
+				<ul class="variable">
 
  					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
@@ -664,7 +670,7 @@
 
                     <li><b>LET</b> <var>table_of_contents_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tableOfContents</i>"]</code>.</li>
 
-  				</ol>
+  				</ul>
 				<h4 id="navigation-instructions">Instructions</h4>
 				<ol class="condition">
 					<li>
@@ -765,7 +771,7 @@
 						</dd>
 				</dl>
 				<h4>Variables setup</h4>
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
                    <li><b>LET</b> <var>chemical_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>latex-chemistry</i>"]</code>.</li>
@@ -782,14 +788,14 @@
 
 					<li><b>LET</b> <var>full_alternative_textual_descriptions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>longDescriptions</i>"]</code>.</li>
 
- 	                <li><b>LET</b> <var>math_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>latex</i>"]</code>.</li>
+					<li><b>LET</b> <var>math_formula_as_latex</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>latex</i>"]</code>.</li>
 
-	                <li><b>LET</b> <var>math_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>MathML</i>"]</code>.</li>
+					<li><b>LET</b> <var>math_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>MathML</i>"]</code>.</li>
 
-                    <li><b>LET</b> <var>open_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>openCaptions</i>"]</code>.</li>
-                    
-                    <li><b>LET</b> <var>transcript</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>transcript</i>"]</code>.</li>
-				</ol>
+					<li><b>LET</b> <var>open_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>openCaptions</i>"]</code>.</li>
+
+					<li><b>LET</b> <var>transcript</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>transcript</i>"]</code>.</li>
+				</ul>
 				<h4 id="rich-content-instructions">Instructions</h4>
 				<ol class="condition">
                     <li>
@@ -913,7 +919,7 @@
 				</dl>
 
 				<h4>Variables setup</h4>
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
                     <li><b>LET</b> <var>flashing_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>flashing</i>"]</code>.</li>
@@ -937,7 +943,7 @@
 					<li><b>LET</b> <var>unknown_motion_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>unknownMotionSimulationHazard</i>"]</code>.</li>
 					
 					<li><b>LET</b> <var>unknown_sound_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>unknownSoundHazard</i>"]</code>.</li>
-				</ol>
+				</ul>
 				
 				<h4 id="hazards-instructions">Instructions</h4>
 				<ol class="condition">
@@ -954,7 +960,7 @@
 							<b>OR</b> <var>no_flashing_hazard</var> <b>OR</b> <var>no_motion_hazard</var> <b>OR</b> <var>no_sound_hazard</var>
 							<b>OR</b> <var>unknown_flashing_hazard</var> <b>OR</b> <var>unknown_motion_hazard</var> <b>OR</b> <var>unknown_sound_hazard</var>:</span>
 						<span><b>THEN</b></span>
-						<ul class="condition">
+						<ol class="condition">
 							<li>
 								<span><b>IF</b> <var>flashing_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-flashing">"Flashing content"</code>.</span>
@@ -991,7 +997,7 @@
 								<span><b>IF</b> <var>no_sound_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-sound-none">"No sound hazards"</code>.</span>
 							</li>
-						</ul>
+						</ol>
 					</li>
 					<li>
 						<b>ELSE</b> either omit this display field if metadata is missing or display <code id="hazards-no-metadata">"No information is available"</code>.
@@ -1030,15 +1036,15 @@
 					</dd>
 				</dl>
 				<h4>Variables setup</h4>
-				<ol class="condition">
-                    <li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
+				<ul class="variable">
+					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 
                     <li><b>LET</b> <var>accessibility_summary</var> be the value of the node extracted from <var>package_document</var>, using the xpath <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilitySummary</i>"]</code>.</li>
 
-										<li><b>LET</b> <var>lang_attribute_accessibility_summary</var> be the value of the node extracted from <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessibilitySummary</i>"]/(@lang|/package/@lang)[last()]/normalize-space(.)</code>.</li>
+					<li><b>LET</b> <var>lang_attribute_accessibility_summary</var> be the value of the node extracted from <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="<i>schema:accessibilitySummary</i>"]/(@lang|/package/@lang)[last()]/normalize-space(.)</code>.</li>
 
-										<li><b>LET</b> <var>language_of_text</var> be the value of the node extracted from <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/dc:language[1]</code>.</li>
- 				</ol>
+					<li><b>LET</b> <var>language_of_text</var> be the value of the node extracted from <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/dc:language[1]</code>.</li>
+				</ul>
 				<h4 id="accessibility-summary-instructions">Instructions</h4>
 				<ol class="condition">
                    <li>
@@ -1085,13 +1091,13 @@
 					</dd>
                 </dl>
 				<h4>Variables setup</h4>
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
 					<li><b>LET</b> <var>eaa_exception_disproportionate_burden</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="a11y:<i>exemption</i>" and normalize-space()="<i>eaa-disproportionate-burden</i>"]</code>.</li>
 					<li><b>LET</b> <var>eaa_exception_fundamental_modification</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="a11y:<i>exemption</i>" and normalize-space()="<i>eaa-fundamental-alteration</i>"]</code>.</li>
 					<li><b>LET</b> <var>eaa_exemption_micro_enterprises</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="a11y:<i>exemption</i>" and normalize-space()="<i>eaa-microenterprise</i>"]</code>.</li>
 
-				</ol>
+				</ul>
 				<h4 id="legal-considerations-instructions">Instructions</h4>
 				<ol class="condition">
 					<li>
@@ -1193,7 +1199,7 @@
  					</dl>
 
 					<h4>Variables setup</h4>
-					<ol class="condition">
+					<ul class="variable">
                         <li><b>LET</b> <var>package_document</var> be the result of calling <a href="#pre-processing">preprocessing</a> given <var>package_document_as_text</var>.</li>
                         
 						<li><b>LET</b> <var>aria</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>aria</i>"]</code>.</li>
@@ -1221,7 +1227,7 @@
                         <li><b>LET</b> <var>tactile_object</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tactileObject</i>"]</code>.</li>
                         
  						<li><b>LET</b> <var>text_to_speech_hinting</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>ttsMarkup</i>"]</code>.</li>
-    				</ol>
+    				</ul>
                         
 					<h4 id="additional-accessibility-information-instructions">Instructions</h4>
 					<ol class="condition">

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -189,7 +189,6 @@
 				</ol>
 			</section>
         </section>
-
 		<section id="techniques">
 			<h2>Techniques</h2>
 
@@ -210,12 +209,12 @@
                     <dl>
                         <dt><var>all_textual_content_can_be_modified</var></dt>
                         <dd>
-                            <p>If true it indicates that the <i>accessibilityFeature="displayTransformability"</i> (All textual content can be modified) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                            <p>If true, it indicates that <i>accessibilityFeature="displayTransformability"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
                             <p><i>All textual content can be modified</i> means that the digital publication does not restrict the ability of users to modify and reflow the display of any textual content to the full extent allowed by the reading system (i.e. to change the text size or typeface, line height and word spacing, colors).</p>
                         </dd>
                         <dt><var>is_fixed_layout</var></dt>
                         <dd>
-                            <p>If true it indicates that the <i>layout="pre-paginated"</i> (Fixed format) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                            <p>If true, it indicates that <i>layout="pre-paginated"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
                             <p><i>Fixed format</i> means that digital publication is in fixed format (e.g. EPUB Fixed Layout).</p>
                         </dd>
                     </dl>
@@ -251,32 +250,32 @@
                     <dl>
                         <dt><var>all_necessary_content_textual</var></dt>
                         <dd>
-                            <p>If true it indicates that there is only a single access mode of textual or <i>accessModeSufficient="textual"</i> (all main content is provided in textual form) is present in the package document.</p>
+                            <p>If true, it indicates that there is only a single access mode of textual or <i>accessModeSufficient="textual"</i> (all main content is provided in textual form) is present in the package document.</p>
                         </dd>
                     	<dt><var>audio_only_content</var></dt>
                     	<dd>
-                    		<p>If true it indicates that there is only a single access mode of auditory (an audiobook).</p>
+                    		<p>If true, it indicates that there is only a single access mode of auditory (an audiobook).</p>
                     	</dd>
                     	<dt><var>some_sufficient_text</var></dt>
                         <dd>
-                            <p>If true it indicates that sufficient access mode metadata indicates that the content is at least partially
+                            <p>If true, it indicates that sufficient access mode metadata indicates that the content is at least partially
                             	readable in textual form (i.e., "textual" is one of a set of sufficient access modes).</p>
                         </dd>
                         <dt><var>textual_alternatives</var></dt>
                         <dd>
-                            <p>If true it indicates that at least one of the following is present in the package document:</p>
+                            <p>If true, it indicates that at least one of the following is present in the package document:</p>
                             <ul>
-                                <li><i>accessibilityFeature="alternativeText"</i> (Short alternative textual descriptions);</li>
-                                <li><i>accessibilityFeature="longDescription"</i> (Full alternative textual descriptions);</li>
-                                <li><i>accessibilityFeature="describedMath"</i> (Visual of math fully described));</li>
-                            	<li><i>accessibilityFeature="transcript"</i> (Transcripts for audio and visual content);</li>
-                            	<li>otherwise if false it means that this metadata is not present.</li>
+                                <li><i>accessibilityFeature="alternativeText"</i>;</li>
+                                <li><i>accessibilityFeature="longDescription"</i>;</li>
+                                <li><i>accessibilityFeature="describedMath"</i>;</li>
+                            	<li><i>accessibilityFeature="transcript"</i>;</li>
                             </ul>
-                            <p>This means that there are textual alternatives for the non-textual content.</p>
+                        	<p>This means that there are textual alternatives for the non-textual content.</p>
+                        	<p>Otherwise, it means that this metadata is not present.</p>
                         </dd>
                     	<dt><var>visual_only_content</var></dt>
                     	<dd>
-                    		<p>If true it indicates that there is only a single access mode of visual and there are no sufficient access modes that include textual (e.g., comics and manga with no alternative text).</p>
+                    		<p>If true, it indicates that there is only a single access mode of visual and there are no sufficient access modes that include textual (e.g., comics and manga with no alternative text).</p>
                     	</dd>
                     </dl>
                     <h5>Variables setup</h5>
@@ -341,19 +340,19 @@
                     <dl>
                         <dt><var>all_content_audio</var></dt>
                         <dd>
-                            <p>If true it indicates that the <i>accessModeSufficient="auditory"</i> (all main content is provided in audio form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                            <p>If true, it indicates that <i>accessModeSufficient="auditory"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
                         </dd>
                         
                         <dt><var>audio_content</var></dt>
                         <dd>
-                            <p>If true it indicates that the <i>accessMode="auditory"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
+                            <p>If true, it indicates that <i>accessMode="auditory"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 
                             <p>This indicates that prerecorded audio content is included as part of the work.</p>
                         </dd>
 
                         <dt><var>synchronised_pre_recorded_audio</var></dt>
                         <dd>
-                            <p>If true it indicates that the <i>accessibilityFeature="synchronizedAudioText"</i> is present in the package document, otherwise, if false, it means that the metadata is not present.</p>
+                            <p>If true, it indicates that <i>accessibilityFeature="synchronizedAudioText"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 
                             <p>This indicates that text-synchronised prerecorded audio narration (natural or synthesized voice) is included for substantially all textual matter, including all alternative descriptions, e.g. via a SMIL media overlay.</p>
                         </dd>
@@ -402,22 +401,22 @@
 				<dl>
 					<dt><var>certifier</var></dt>
 					<dd>
-						<p>Returns the description of <i>a11y:certifiedBy</i> (Compliance certification by (name)) if present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <i>a11y:certifiedBy</i> if present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the name of the organization responsible for compliance testing and certification of the product is present.</p>
 					</dd>
 					<dt><var>certifier_credentials</var></dt>
 					<dd>
-						<p>Returns the description of <i>a11y:certifierCredential</i> (Compliance certification by (URL) or text) if present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <i>a11y:certifierCredential</i> if present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the the URL of a web page belonging to an organization responsible for compliance testing and certification of the product is present – typically a ‘home page’ or a page describing the certification scheme itself.</p>
 					</dd>
 					<dt><var>certification_date</var></dt>
 					<dd>
-						<p>Returns the description of <i>dcterms:date</i> if that date property is associated with the <i>a11y:certifiedBy</i> (Latest accessibility assessment date) if present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <i>dcterms:date</i> if that date property is associated with the <i>a11y:certifiedBy</i> (Latest accessibility assessment date) if present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the date of the latest assessment or re-assessment of the accessibility of the product is present.</p>
 					</dd>
 					<dt><var>certifier_report</var></dt>
 					<dd>
-						<p>Returns the description of <i>a11y:certifierReport</i> (Compliance web page for detailed accessibility information) if present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <i>a11y:certifierReport</i> if present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that is present the URL of a compliance web page for detailed accessibility information. The web page should be maintained by an independent compliance scheme or testing organization. Note the web page may include information about specific national requirements or voluntary conformance reports.</p>
 					</dd>
 					<dt><var>epub_version</var></dt>
@@ -622,33 +621,32 @@
 				</ol>
 			</section>
 
-
-	      <section id="navigation">
-			<h3>Navigation</h3>
-    	  	<p>This technique relates to the <a href="../../guidelines/#navigation">Navigation accessibility display field</a>.</p>
+			<section id="navigation">
+				<h3>Navigation</h3>
+				<p>This technique relates to the <a href="../../guidelines/#navigation">Navigation accessibility display field</a>.</p>
                 <p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 
 				<h4>Understanding the variables</h4>
 				<dl>
 					<dt><var>index_navigation</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="index"</i> (Index navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityFeature="index"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 
                         <p>This means that there is an index that provides direct (eg hyperlinked) access to uses of the index terms in the document body.</p>
 					</dd>
  					<dt><var>next_previous_structural_navigation</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="structuralNavigation"</i> (Next / Previous structural navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityFeature="structuralNavigation"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that all levels of heading and other structural elements of the content are correctly marked up and (if applicable) numbered, to enable fast next heading / previous heading, next chapter / previous chapter navigation without returning to the table of contents.</p>
 					</dd>
                    <dt><var>page_navigation</var></dt>
                     <dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="pageNavigation"</i> (Page Navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityFeature="pageNavigation"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
                         <p>This means that the e-publication includes a means of navigating to static page break locations.</p>
                     </dd>
 					<dt><var>table_of_contents_navigation</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="tableOfContents"</i> (Table of contents navigation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityFeature="tableOfContents"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 
 						<p>This means that the resource includes a table of contents that provides links to the major sections of the content.</p>
 					</dd>
@@ -709,60 +707,60 @@
 				<dl>
                     <dt><var>chemical_formula_as_latex</var></dt>
 					<dd>
-						<p>If true it indicates that the <i>accessibilityFeature="latex-chemistry"</i> (Accessible chemistry content as Latex) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <i>accessibilityFeature="latex-chemistry"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the chemical formulae are presented using Latex and works with compatible assistive technology.</p>
 					</dd>
 					<dt><var>chemical_formula_as_mathml</var></dt>
 					<dd>
-						<p>If true it indicates that the <i>accessibilityFeature="MathML-chemistry"</i> (Accessible chemistry content as MathML) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <i>accessibilityFeature="MathML-chemistry"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the chemical formulae are presented using MathML and works with compatible assistive technology.</p>
 					</dd>
                     <dt><var>closed_captions</var></dt>
                         <dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="closedCaptions"</i> (Closed captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityFeature="closedCaptions"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
                         <p>This means that the audio content of a video can be seen via closed captions that can be turned on or off  by the viewer and which will be a separate file from the video itself.</p>
                     </dd>
 
 					<dt><var>contains_charts_diagrams</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessMode="chartOnVisual"</i> (charts encoded in visual form) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessMode="chartOnVisual"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the product has some information conveyed via some form of illustration, such as a graph, a chart, a diagram, a figure, etc).</p>
 					</dd>
 					<dt><var>contains_chemical_formula</var></dt>
 					<dd>
-						<p>If true it indicates that the <i>accessMode="chemOnVisual"</i> (Chemical content) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <i>accessMode="chemOnVisual"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the publication contains chemical notations, formulae.</p>
 					</dd>
 
 					<dt><var>contains_math_formula</var></dt>
 					<dd>
-						<p>If true it indicates that the <i>accessibilityFeature="describedMath"</i> (Mathematical content) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <i>accessibilityFeature="describedMath"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the publication contains mathematical notation, equations, formulae.</p>
 					</dd>
 					<dt><var>full_alternative_textual_descriptions</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityFeature="longDescriptions"</i> (Full alternative textual description) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityFeature="longDescriptions"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that a full alternative textual description has been supplied for all of the graphs, charts, diagrams, or figures necessary to understand the content.</p>
 					</dd>
                     
 					<dt><var>math_formula_as_latex</var></dt>
 					<dd>
-						<p>If true it indicates that the <i>accessibilityFeature="latex"</i> (Accessible math content as LaTeX) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <i>accessibilityFeature="latex"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the  math  is  presented using LaTeX and works with compatible assistive technology.</p>
 					</dd>
 					<dt><var>math_formula_as_mathml</var></dt>
 					<dd>
-						<p>If true it indicates that the <i>accessibilityFeature="MathML"</i> (Accessible math content as MathML) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <i>accessibilityFeature="MathML"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that all mathematical content is presented using MathML and works with compatible assistive technology.</p>
 					</dd>
                     <dt><var>open_captions</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="openCaptions"</i> (Open captions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="openCaptions"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that the audio content of a video can be seen via open captions, which means they cannot be turned off and are always visible when the video plays.</p>
 						</dd>
                     <dt><var>transcript</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="transcript"</i> (transcript) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="transcript"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that a transcript of the audio content of the product is supplied with it.</p>
 						</dd>
 				</dl>
@@ -845,48 +843,73 @@
 				<p>This technique relates to the <a href="../../guidelines/#hazards">Hazards accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 
-        <h4>Understanding the variables</h4>
+		        <h4>Understanding the variables</h4>
+				
 				<dl>
 					<dt><var>flashing_hazard</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="flashing"</i> (WARNING - Flashing hazards) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityHazard="flashing"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication in the accessibility metadata within the EPUB confirming that the product has a flashing hazard which must be displayed.</p>
 					</dd>
+					
 					<dt><var>motion_simulation_hazard</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="motionSimulation"</i> (WARNING - Motion simulation hazard) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityHazard="motionSimulation"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication in the accessibility metadata within the EPUB confirming that the product has a motion simulation hazard which must be displayed.</p>
 					</dd>
-					<dt><var>no_flashing_hazards</var></dt>
+					
+					<dt><var>no_flashing_hazard</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="noFlashingHazard"</i> (No flashing hazard warning necessary) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityHazard="noFlashingHazard"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no flashing hazards associated with this product.</p>
 					</dd>
+					
 					<dt><var>no_hazards_or_warnings_confirmed</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="none"</i> (no accessibility hazards) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityHazard="none"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no associated hazard warnings with this product.</p>
 					</dd>
-					<dt><var>no_motion_hazards</var></dt>
+					
+					<dt><var>no_motion_hazard</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="noMotionSimulationHazard"</i> (No motion simulation hazard warning necessary) is present in the package document, otherwise if false it means that the metadata is not present.</p> 		<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no motion simulation hazards associated with this product.</p>
+                        <p>If true, it indicates that <i>accessibilityHazard="noMotionSimulationHazard"</i> is present in the package document; otherwise, it means that the metadata is not present.</p> 		<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no motion simulation hazards associated with this product.</p>
 					</dd>
-					<dt><var>no_sound_hazards</var></dt>
+					
+					<dt><var>no_sound_hazard</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="noSoundHazard"</i> (No sound hazard warning necessary) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityHazard="noSoundHazard"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means there is a positive indication in the accessibility metadata within the EPUB confirming there are no sound hazards associated with this product.</p>
 					</dd>
+					
 					<dt><var>sound_hazard</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="Sound"</i> (WARNING - Sound hazard) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityHazard="Sound"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
  						<p>This means that there is a positive indication in the accessibility metadata within the EPUB confirming that the product has a sound hazard which must be displayed.</p>
 					</dd>
+					
+					<dt><var>unknown_flashing_hazard</var></dt>
+					<dd>
+						<p>If true, it indicates that <i>accessibilityHazard="unknownFlashingHazard"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
+						<p>This means the presence of flashing hazards could not be determined.</p>
+					</dd>
+					
 					<dt><var>unknown_if_contains_hazards</var></dt>
 					<dd>
-                        <p>If true it indicates that the <i>accessibilityHazard="unknown"</i> (unknown hazards) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                        <p>If true, it indicates that <i>accessibilityHazard="unknown"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the product has not been assessed for hazards and there is no information about potential hazards.</p>
 					</dd>
-
+					
+					<dt><var>unknown_motion_hazard</var></dt>
+					<dd>
+						<p>If true, it indicates that <i>accessibilityHazard="unknownMotionSimulationHazard"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
+						<p>This means the presence of motion simulation hazards could not be determined.</p>
+					</dd>
+					
+					<dt><var>unknown_sound_hazard</var></dt>
+					<dd>
+						<p>If true, it indicates that <i>accessibilityHazard="unknownSoundHazard"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
+						<p>This means the presence of sound hazards could not be determined.</p>
+					</dd>
 				</dl>
 
 				<h4>Variables setup</h4>
@@ -906,44 +929,75 @@
                     <li><b>LET</b> <var>no_sound_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>noSoundHazard</i>"]</code>.</li>
 
                     <li><b>LET</b> <var>sound_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>sound</i>"]</code>.</li>
-  
-                    <li><b>LET</b> <var>unknown_if_contains_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>unknown</i>"]</code>.</li>
 
+					<li><b>LET</b> <var>unknown_flashing_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>unknownFlashingHazard</i>"]</code>.</li>
+					
+					<li><b>LET</b> <var>unknown_if_contains_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>unknown</i>"]</code>.</li>
+					
+					<li><b>LET</b> <var>unknown_motion_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>unknownMotionSimulationHazard</i>"]</code>.</li>
+					
+					<li><b>LET</b> <var>unknown_sound_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityHazard</i>" and normalize-space()="<i>unknownSoundHazard</i>"]</code>.</li>
 				</ol>
+				
 				<h4 id="hazards-instructions">Instructions</h4>
 				<ol class="condition">
 					<li>
-						<span><b>IF</b> <var>no_hazards_or_warnings_confirmed</var> <b>OR</b> (<var>no_flashing_hazards</var> <b>AND</b> <var>no_motion_hazards</var> <b>AND</b> <var>no_sound_hazards</var>):</span>
+						<span><b>IF</b> <var>no_hazards_or_warnings_confirmed</var> <b>OR</b> (<var>no_flashing_hazard</var> <b>AND</b> <var>no_motion_hazard</var> <b>AND</b> <var>no_sound_hazard</var>):</span>
 						<span><b>THEN</b> display <code id="hazards-none">"No hazards"</code>.</span>
 					</li>
 					<li>
-						<span><b>ELSE IF</b> <var>flashing_hazard</var> <b>OR</b> <var>motion_simulation_hazard</var> <b>OR</b> <var>sound_hazard</var>:</span>
-						<b>THEN</b> <ul class="condition">
+						<span><b>ELSE IF</b> <var>unknown_if_contains_hazards</var> <b>OR</b> (<var>unknown_flashing_hazard</var> <b>AND</b> <var>unknown_motion_hazard</var> <b>AND</b> <var>unknown_sound_hazard</var>):</span>
+						<span><b>THEN</b> display <code id="hazards-unknown">"The presence of hazards is unknown"</code>.</span>
+					</li>
+					<li>
+						<span><b>ELSE IF</b> <var>flashing_hazard</var> <b>OR</b> <var>motion_simulation_hazard</var> <b>OR</b> <var>sound_hazard</var>
+							<b>OR</b> <var>no_flashing_hazard</var> <b>OR</b> <var>no_motion_hazard</var> <b>OR</b> <var>no_sound_hazard</var>
+							<b>OR</b> <var>unknown_flashing_hazard</var> <b>OR</b> <var>unknown_motion_hazard</var> <b>OR</b> <var>unknown_sound_hazard</var>:</span>
+						<span><b>THEN</b></span>
+						<ul class="condition">
 							<li>
 								<span><b>IF</b> <var>flashing_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-flashing">"Flashing content"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>unknown_flashing_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-flashing-unknown">"Flashing hazards not known"</code>.</span>
 							</li>
 							<li>
 								<span><b>IF</b> <var>motion_simulation_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-motion">"Motion simulation"</code>.</span>
 							</li>
 							<li>
+								<span><b>IF</b> <var>unknown_motion_simulation_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-motion-unknown">"Motion simulation hazards not known"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>no_flashing_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-flashing-none">"No flashing hazards"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>no_motion_simulation_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-motion-none">"No motion simulation hazards"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>no_sound_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-sound-none">"No sound hazards"</code>.</span>
+							</li>
+							<li>
 								<span><b>IF</b> <var>sound_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-sound">"Sounds"</code>.</span>
 							</li>
+							<li>
+								<span><b>IF</b> <var>unknown_sound_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-sound-unknown">"Sound hazards not known"</code>.</span>
+							</li>
 						</ul>
 					</li>
-                    <li>
-						<span><b>ELSE IF</b> <var>unknown_if_contains_hazards</var>:</span>
-						<span><b>THEN</b> display <code id="hazards-unknown">"The presence of hazards is unknown"</code>.</span>
-                    </li>
 					<li>
 						<b>ELSE</b> either omit this display field if metadata is missing or display <code id="hazards-no-metadata">"No information is available"</code>.
-
                     </li>
 				</ol>
 			</section>
-
 
 			<section id="accessibility-summary">
 				<h3>Accessibility summary</h3>
@@ -971,7 +1025,7 @@
 					</dd>
 					<dt><var>language_of_text</var></dt>
 					<dd>
-						<p>Returns the value of nearest "language" (Language of content) if present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the value of nearest "language" (Language of content) if present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This indicates the main language of the content and therefore the most probable language of accessibility summary.</p>
 					</dd>
 				</dl>
@@ -1016,17 +1070,17 @@
 
 					<dt><var>eaa_exception_disproportionate_burden</var></dt>
 					<dd>
-						<p>If true it indicates that the <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa_disproportionate_burden</a>"</i> (EAA exception 2 – Disproportionate burden) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa_disproportionate_burden</a>"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the digital product falls under European Accessibility Act exception for Disproportionate burden (as defined by current regulations). The product may not have to comply with requirements of the EAA if doing so would financially overburden the publisher.</p>
 					</dd>
 					<dt><var>eaa_exception_fundamental_modification</var></dt>
 					<dd>
-						<p>If true it indicates that the <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa_fundamental_modification</a>"</i> (EAA exception 3 – Fundamental modification) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa_fundamental_modification</a>"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the digital product falls under European Accessibility Act exception for Fundamental modification (as defined by current regulations). The product may not have to comply with requirements of the EAA if doing so requires a fundamental modification of the nature of the product or service.</p>
 					</dd>
 					<dt><var>eaa_exemption_micro_enterprises</var></dt>
 					<dd>
-						<p>If true it indicates that the <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa-microenterprise</a>"</i> (EEA exception 1 – Micro-enterprises) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <i><a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-property">a11y:exemption</a>="<a href="https://www.w3.org/TR/epub-a11y-exemption/#exemption-values">eaa-microenterprise</a>"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the digital product falls under European Accessibility Act exemption for Micro-enterprises (as defined by current regulations). The product may not have to comply with requirements of the EAA if the publisher is a micro-enterprise.</p>
 					</dd>
                 </dl>
@@ -1050,7 +1104,6 @@
 				</ol>
 			</section>
 
-
 			<section id="additional-accessibility-information">
 				<h3>Additional accessibility information</h3>
 				<p>This technique relates to the <a href="../../guidelines/#additional-accessibility-information">Additional accessibility information accessibility display field</a>.</p>
@@ -1061,79 +1114,79 @@
 					<dl>
 						<dt><var>aria</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="aria"</i>  (ARIA roles - semantic markup) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="aria"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that the use of ARIA, including <a href="https://w3c.github.io/dpub-aria/">DPUB ARIA</a> is used to improve the semantic markup of the publication.</p>
 						</dd>
                         
 						<dt><var>audio_descriptions</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="audioDescriptions"</i> (Audio Descriptions) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="audioDescriptions"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that there is an audio descriptions track available for video content.</p>
 						</dd>
                         
 						<dt><var>braille</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="braille"</i> (Braille) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="braille"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that there is braille available within the publication.</p>
 						</dd>
 
                         <dt><var>full_ruby_annotations</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="fullRubyAnnotations"</i> (Full Ruby Annotations) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="fullRubyAnnotations"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that ruby annotations are attached to every CJK ideographic character in the content. Ruby annotations are used as pronunciation guides for the logographic characters for languages like Chinese or Japanese. They make difficult CJK ideographic characters more accessible.</p>
 						</dd>
 						<dt><var>high_contrast_between_foreground_and_background_audio</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="highContrastAudio"</i> (Use of high contrast between foreground and background audio) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="highContrastAudio"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that foreground audio content (eg voice) is presented with no or low background noise (eg ambient sounds, music), at least 20dB below the level of the foreground, or background noise can be switched off (eg via an alternative audio track). Brief and occasional sound effects may be as loud as foreground voice so long as they are isolated from the foreground.</p>
 						</dd>
                         
                         <dt><var>high_contrast_between_text_and_background</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="highContrastDisplay"</i> (Use of high contrast between text and background color) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="highContrastDisplay"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that body text is presented with a contrast ratio of at least 4.5:1 (or 3:1 for large/heading text).</p>
 						</dd>
                         
 						<dt><var>large_print</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="largePrint"</i> (Large Print) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="largePrint"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that the e-publication has been formatted to meet large print guidelines.</p>
 						</dd>
                         
                         <dt><var>page_break_markers</var></dt>
                         <dd>
-                            <p>If true it indicates that the <i>accessibilityFeature="pageBreakMarkers"</i> (Print-equivalent page numbering) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+                            <p>If true, it indicates that <i>accessibilityFeature="pageBreakMarkers"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
                             <p>This means that the publication contains references to the page numbering.</p>
                         </dd>
 
 						<dt><var>ruby_annotations</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="rubyAnnotations"</i> (Ruby Annotations) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="rubyAnnotations"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that ruby annotations are attached to some but not all CJK ideographic characters in the content.</p>
 						</dd>
                         
 						<dt><var>sign_language</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="signLanguage"</i> (Sign language interpretation) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="signLanguage"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that a full signing of audio content of the product is supplied with the video file.</p>
 						</dd>
 
 
 						<dt><var>tactile_graphic</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="tactileGraphic"</i> (tactile 2D graphic) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="tactileGraphic"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that there is tactile graphic(s) contained within this publication.</p>
 						</dd>
                         
 						<dt><var>tactile_object</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="tactileObject"</i> (tactile 3D object) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="tactileObject"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that there is tactile 3D object(s) contained within this publication.</p>
 						</dd>
 
  						<dt><var>text_to_speech_hinting</var></dt>
 						<dd>
-							<p>If true it indicates that the <i>accessibilityFeature="ttsMarkup"</i>  (Text-to-speech markup provided) is present in the package document, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <i>accessibilityFeature="ttsMarkup"</i> is present in the package document; otherwise, it means that the metadata is not present.</p>
 							<p>This means that text-to-speech has been optimized through provision of PLS lexicons, SSML or CSS Speech synthesis hints or other speech synthesis markup languages or hinting.</p>
 						</dd>
                         

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -227,12 +227,12 @@
 					<dl>
 						<dt><var>all_textual_content_can_be_modified</var></dt>
 						<dd>
-							<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/36">code 36 of codelist 196</a> (All textual content can be modified) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/36">code 36 of codelist 196</a> (All textual content can be modified) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 							<p><i>All textual content can be modified</i> means that the digital publication does not restrict the ability of users to modify and reflow the display of any textual content to the full extent allowed by the reading system (i.e. to change the text size or typeface, line height and word spacing, colors).</p>
 						</dd>
 						<dt><var>is_fixed_layout</var></dt>
 						<dd>
-							<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/175/E201">code E201 of codelist 175</a> (Fixed format) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/175/E201">code E201 of codelist 175</a> (Fixed format) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 							<p><i>Fixed format</i> means that digital publication is in fixed format (e.g. EPUB Fixed Layout).</p>
 						</dd>
 					</dl>
@@ -263,28 +263,28 @@
 					<dl>
 						<dt><var>all_necessary_content_textual</var></dt>
 						<dd>
-							<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/52">code 52 of codelist 196</a> (All non-decorative content supports reading without sight) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/52">code 52 of codelist 196</a> (All non-decorative content supports reading without sight) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 							<p><i>All non-decorative content supports reading without sight</i> means that all contents of the digital publication necessary to use and understanding, including text, images (via their alternative descriptions), audio and video material (via their transcripts, descriptions, captions or subtitles) are fully accessible via suitable reading devices, for example text-to-speech screen readers or tactile reading devices (‘Braille displays’), and nothing in the digital publication prevents or blocks the use of alternative reading modes. The entire publication can be navigated and ‘read’ using only text rendered via sound or touch, and does not require visual perception.</p>
 						</dd>
                     	<dt><var>audio_only_content</var></dt>
 						<dd>
-							<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/81/01">code 01 of codelist 81</a> (Audiobook) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/81/01">code 01 of codelist 81</a> (Audiobook) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 							<p>This means that the primary content is an Audio recording of a reading of a book or other text.</p>
 						</dd>
 						<dt><var>real_text</var></dt>
 						<dd>
-							<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/81/10">code 10 of codelist 81</a> (Text) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/81/10">code 10 of codelist 81</a> (Text) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 							<p><i>Text</i> means that digital publication contains "real" text (user-selectable) as its main content (or as secondary content).</p>
 						</dd>
                     	<dt><var>textual_alternatives</var></dt>
 						<dd>
-							<p>If true it indicates that at least one of the following is present in the ONIX record:</p>
+							<p>If true, it indicates that at least one of the following is present in the ONIX record:</p>
 							<ul>
 								<li><a href="https://ns.editeur.org/onix/en/196/14">code 14 of codelist 196</a> (Short alternative textual descriptions);</li>
 								<li><a href="https://ns.editeur.org/onix/en/196/15">code 15 of codelist 196</a> (Full alternative textual descriptions);</li>
 								<li><a href="https://ns.editeur.org/onix/en/196/16">code 16 of codelist 196</a> (Visualized data also available as non-graphical data);</li>
 								<li><a href="https://ns.editeur.org/onix/en/175/V212">code V212 of codelist 175</a> (Transcript);</li>
-								<li>otherwise if false it means that this metadata is not present.</li>
+								<li>otherwise, it means that this metadata is not present.</li>
 							</ul>
                             <p>This means that there are textual alternatives for the non-textual content.</p>
 						</dd>
@@ -326,32 +326,32 @@
 					<dl>
 						<dt><var>all_content_audio</var></dt>
 						<dd>
-							<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/39">code 39 of codelist 196</a> (Supplementary material to an audiobook is accessible) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/39">code 39 of codelist 196</a> (Supplementary material to an audiobook is accessible) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 							<p>This means that all supplementary visual or textual material necessary for understanding of an audiobook, is available as pre-recorded audio, or has full alternative text that can be read via text-to- speech. Only for use in ONIX 3.0 or later.</p>
 						</dd>
 						<dt><var>all_content_pre_recorded</var></dt>
 						<dd>
-							<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/51">code 51 of codelist 196</a> (All non-decorative content supports reading via pre-recorded audio) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/51">code 51 of codelist 196</a> (All non-decorative content supports reading via pre-recorded audio) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 							<p>This means that all contents of the digital publication necessary to use and understanding, including any text, images (via alternative descriptions), video (via audio description) is fully accessible via suitable audio reproduction. The entire publication can be navigated and ‘read’ using only pre-recorded sound, and does not require visual or tactile perception.</p>
 						</dd>
 						<dt><var>audiobook</var></dt>
 						<dd>
-							<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/81/01">code 01 of codelist 81</a> (Audiobook) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+							<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/81/01">code 01 of codelist 81</a> (Audiobook) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 							<p>This means that the primary content is an Audio recording of a reading of a book or other text.</p>
 						</dd>
 						<dt><var>non_textual_content_audio</var></dt>
 						<dd>
-							<p>If true it indicates that one of the following codes is present in the ONIX record: </p>
+							<p>If true, it indicates that one of the following codes is present in the ONIX record: </p>
 							<ul>
 								<li><a href="https://ns.editeur.org/onix/en/81/21">code 21 of codelist 81</a> (Partial performance – spoken word);</li>
 								<li><a href="https://ns.editeur.org/onix/en/81/22">code 22 of codelist 81</a> (Additional audio content not part of main content);</li>
 							</ul>
-							<p>Otherwise, if false, it means that none of the above metadata is present.</p>
+							<p>Otherwise, it means that none of the above metadata is present.</p>
 							<p>This indicates that pre-recorded audio content is included as part of the work. It can be Audio recording of a reading, performance or dramatization of part of the work	or additional pre-recorded audio of any supplementary material such as full or partial reading, lecture, performance, dramatization, interview, background documentary or other audio content not included in the primary or un-enhanced version</p>
 						</dd>
 						<dt><var>non_textual_content_audio_in_video</var></dt>
 						<dd>
-							<p>If true it indicates that one of the following codes is present in the ONIX record: </p>
+							<p>If true, it indicates that one of the following codes is present in the ONIX record: </p>
 								<ul>
 									<li><a href="https://ns.editeur.org/onix/en/81/06">code 06 of codelist 81</a> (Video);</li>
 									<li><a href="https://ns.editeur.org/onix/en/81/25">code 25 of codelist 81</a> (Narrative animation);</li>
@@ -361,17 +361,17 @@
 									<li><a href="https://ns.editeur.org/onix/en/81/29">code 29 of codelist 81</a> (Partial performance – video);</li>
 									<li><a href="https://ns.editeur.org/onix/en/81/30">code 30 of codelist 81</a> (Additional video content not part of main work);</li>
 								</ul>
-								<p>Otherwise, if false, it means that none of the above metadata is present.</p>
+								<p>Otherwise, it means that none of the above metadata is present.</p>
 								<p>This indicates that pre-recorded video including audio content is included as part of the work. It can be video recording of a reading, performance of part of the work or additional pre-recorded video of any supplementary material such as full or partial reading, lecture, performance, dramatization, interview, background documentary or other video containing audio content.</p>
 						</dd>
 						<dt><var>synchronised_pre_recorded_audio</var></dt>
 						<dd>
-							<p>If true it indicates that one of the following codes is present in the ONIX record: </p>
+							<p>If true, it indicates that one of the following codes is present in the ONIX record: </p>
 								<ul>
 									<li><a href="https://ns.editeur.org/onix/en/196/20">code 20 of codelist 196</a> (Synchronised pre-recorded audio)</li>
 									<li><a href="https://ns.editeur.org/onix/en/175/A305">code A305 of codelist 175</a> (Synchronised audio)</li>
 								</ul>
-							<p>Otherwise, if false, it means that none of the above metadata is present.</p>
+							<p>Otherwise, it means that none of the above metadata is present.</p>
 							<p>This indicates that text-synchronised pre-recorded audio narration (natural or synthesized voice) is included for substantially all textual matter, including all alternative descriptions, e.g. via a SMIL media overlay.</p>
 						</dd>
 					</dl>
@@ -414,67 +414,67 @@
 				<dl>
 					<dt><var>certifier</var></dt>
 					<dd>
-						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/90">code 90 of codelist 196</a> (Compliance certification by (name)) if present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/90">code 90 of codelist 196</a> (Compliance certification by (name)) if present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the name of the organization responsible for compliance testing and certification of the product is present.</p>
 					</dd>
 					<dt><var>certification_date</var></dt>
 					<dd>
-						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/91">code 91 of codelist 196</a> (Latest accessibility assessment date) if present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/91">code 91 of codelist 196</a> (Latest accessibility assessment date) if present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the date of the latest assessment or re-assessment of the accessibility of the product is present.</p>
 					</dd>
 					<dt><var>certifier_credentials</var></dt>
 					<dd>
-						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/93">code 93 of codelist 196</a> (Compliance certification by (URL)) if present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/93">code 93 of codelist 196</a> (Compliance certification by (URL)) if present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the the URL of a web page belonging to an organization responsible for compliance testing and certification of the product is present – typically a ‘home page’ or a page describing the certification scheme itself.</p>
 					</dd>
 					<dt><var>certifier_report</var></dt>
 					<dd>
-						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/94">code 94 of codelist 196</a> (Compliance web page for detailed accessibility information) if present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/94">code 94 of codelist 196</a> (Compliance web page for detailed accessibility information) if present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that is present the URL of a compliance web page for detailed accessibility information. The web page should be maintained by an independent compliance scheme or testing organization. Note the web page may include information about specific national requirements or voluntary conformance reports.</p>
 					</dd>
 					<dt><var>epub_accessibility_10</var></dt>
 					<dd>
-						<p>If true it indicates that either the <a href="https://ns.editeur.org/onix/en/196/02">code 02 of codelist 196</a> (EPUB Accessibility Specification 1.0 A) or the <a href="https://ns.editeur.org/onix/en/196/03">code 03 of codelist 196</a> (EPUB Accessibility Specification 1.0 AA) are present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that either the <a href="https://ns.editeur.org/onix/en/196/02">code 02 of codelist 196</a> (EPUB Accessibility Specification 1.0 A) or the <a href="https://ns.editeur.org/onix/en/196/03">code 03 of codelist 196</a> (EPUB Accessibility Specification 1.0 AA) are present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication conforms with either the requirements of EPUB Accessibility Spec 1.0, at level A or level AA.</p>
 					</dd>
 					<dt><var>epub_accessibility_11</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/04">code 04 of codelist 196</a> (EPUB Accessibility Specification 1.1) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/04">code 04 of codelist 196</a> (EPUB Accessibility Specification 1.1) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication conforms with the requirements of EPUB Accessibility Spec 1.1.</p>
 					</dd>
 					<dt><var>level_a</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/84">code 84 of codelist 196</a> (WCAG level A) or the <a href="https://ns.editeur.org/onix/en/196/02">code 02 of codelist 196</a> (EPUB Accessibility Specification 1.0 A) are present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/84">code 84 of codelist 196</a> (WCAG level A) or the <a href="https://ns.editeur.org/onix/en/196/02">code 02 of codelist 196</a> (EPUB Accessibility Specification 1.0 A) are present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication conforms with the requirements of WCAG level A or with the requirements of EPUB Accessibility Spec 1.0 level A.</p>
 					</dd>
 					<dt><var>level_aa</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/85">code 85 of codelist 196</a> (WCAG level AA) or the <a href="https://ns.editeur.org/onix/en/196/03">code 03 of codelist 196</a> (EPUB Accessibility Specification 1.0 AA) are present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/85">code 85 of codelist 196</a> (WCAG level AA) or the <a href="https://ns.editeur.org/onix/en/196/03">code 03 of codelist 196</a> (EPUB Accessibility Specification 1.0 AA) are present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication conforms with the requirements of WCAG level AA or with the requirements of EPUB Accessibility Spec 1.0 level AA.</p>
 					</dd>
 					<dt><var>level_aaa</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/86">code 86 of codelist 196</a> (WCAG level AAA) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/86">code 86 of codelist 196</a> (WCAG level AAA) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication conforms with the requirements of WCAG level AAA.</p>
 					</dd>
 					<dt><var>lia_compliant</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/01">code 01 of codelist 196</a> (LIA Compliance Scheme) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/01">code 01 of codelist 196</a> (LIA Compliance Scheme) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication conforms with the requirements of Fondazione LIA.</p>
 					</dd>
 					<dt><var>wcag_20</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/80">code 80 of codelist 196</a> (WCAG v2.0) or the <a href="https://ns.editeur.org/onix/en/196/02">code 02 of codelist 196</a> (EPUB Accessibility Specification 1.0 A) or the <a href="https://ns.editeur.org/onix/en/196/03">code 03 of codelist 196</a> (EPUB Accessibility Specification 1.0 AA) are present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/80">code 80 of codelist 196</a> (WCAG v2.0) or the <a href="https://ns.editeur.org/onix/en/196/02">code 02 of codelist 196</a> (EPUB Accessibility Specification 1.0 A) or the <a href="https://ns.editeur.org/onix/en/196/03">code 03 of codelist 196</a> (EPUB Accessibility Specification 1.0 AA) are present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication conforms with the requirements of WCAG version 2.0 or with the requirements of EPUB Accessibility Spec 1.0 (at level A or level AA). This is because being compliant with EPUB Accessibility 1.0 specification means at least being compliant with WCAG 2.0 specification.</p>
 					</dd>
 					<dt><var>wcag_21</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/81">code 81 of codelist 196</a> (WCAG v2.1) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/81">code 81 of codelist 196</a> (WCAG v2.1) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication conforms with the requirements of WCAG version 2.1.</p>
 					</dd>
 					<dt><var>wcag_22</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/82">code 82 of codelist 196</a> (WCAG v2.2) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/82">code 82 of codelist 196</a> (WCAG v2.2) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication conforms with the requirements of WCAG version 2.2.</p>
 					</dd>
 				</dl>
@@ -606,22 +606,22 @@
 				<dl>
 					<dt><var>index_navigation</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/12">code 12 of codelist 196</a> (Index navigation) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/12">code 12 of codelist 196</a> (Index navigation) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is an index that provides direct (eg hyperlinked) access to uses of the index terms in the document body.</p>
 					</dd>
 					<dt><var>next_previous_structural_navigation</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/29">code 29 of codelist 196</a> (Next / Previous structural navigation) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/29">code 29 of codelist 196</a> (Next / Previous structural navigation) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that all levels of heading and other structural elements of the content are correctly marked up and (if applicable) numbered, to enable fast next heading / previous heading, next chapter / previous chapter navigation without returning to the table of contents.</p>
 					</dd>
 					<dt><var>page_navigation</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/19">code 19 of codelist 196</a> (Print-equivalent page numbering) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/19">code 19 of codelist 196</a> (Print-equivalent page numbering) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that in the publication contains references to the page numbering of an equivalent printed product.</p>
 					</dd>
 					<dt><var>table_of_contents_navigation</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/11">code 11 of codelist 196</a> (Table of contents navigation) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/11">code 11 of codelist 196</a> (Table of contents navigation) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a Table of Contents in the publication that allows direct (eg hyperlinked) access to all levels of text organization above individual paragraphs (eg to all sections and subsections) and to all tables, figures, illustrations etc.</p>
 					</dd>
 				</dl>
@@ -670,52 +670,52 @@
 				<dl>
 					<dt><var>charts_diagrams_as_non_graphical_data</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/16">code 16 of codelist 196</a> (Visualized data also available as non-graphical data) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/16">code 16 of codelist 196</a> (Visualized data also available as non-graphical data) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that all data presented in a visual format (graph, chart, etc) has an alternative non-graphical presentation of the same data.</p>
 					</dd>
 					<dt><var>chemical_formula_as_mathml</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/34">code 34 of codelist 196</a> (Accessible chemistry content as MathML) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/34">code 34 of codelist 196</a> (Accessible chemistry content as MathML) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the chemical formulae are presented using MathML and works with compatible assistive technology.</p>
 					</dd>
 					<dt><var>closed_captions</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/175/V210">code V210 of codelist 175</a> (Closed captions) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/175/V210">code V210 of codelist 175</a> (Closed captions) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication contains videos with closed captions or subtitles.</p>
 					</dd>
 					<dt><var>contains_math_formula</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/81/48">code 48 of codelist 81</a> (Mathematical content) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/81/48">code 48 of codelist 81</a> (Mathematical content) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the publication contains mathematical notation, equations, formulae.</p>
 					</dd>
 					<dt><var>full_alternative_textual_descriptions</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/15">code 15 of codelist 196</a> (Full alternative textual description) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/15">code 15 of codelist 196</a> (Full alternative textual description) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that a full alternative textual description has been supplied for all of the graphs, charts, diagrams, or figures necessary to understand the content.</p>
 					</dd>
 					<dt><var>math_formula_as_latex</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/35">code 35 of codelist 196</a> (Accessible math content as LaTeX) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/35">code 35 of codelist 196</a> (Accessible math content as LaTeX) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the chemical formulae are presented using LaTeX and works with compatible assistive technology.</p>
 					</dd>
 					<dt><var>math_formula_as_mathml</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/17">code 17 of codelist 196</a> (Accessible math content as MathML) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/17">code 17 of codelist 196</a> (Accessible math content as MathML) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that all mathematical content is presented using MathML and works with compatible assistive technology.</p>
 					</dd>
 					<dt><var>open_captions</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/175/V211">code V211 of codelist 175</a> (Open captions) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/175/V211">code V211 of codelist 175</a> (Open captions) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication contains videos with ‘burnt-in’ or hard captions or subtitles.</p>
 					</dd>
 					<dt><var>short_textual_alternative_images</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/14">code 14 of codelist 196</a> (Short alternative textual descriptions) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/14">code 14 of codelist 196</a> (Short alternative textual descriptions) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that all or substantially all non-text content has short alternative (textual) descriptions, usually provided via alt attributes.</p>
 					</dd>
 					<dt><var>transcript</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/175/V212">code V212 of codelist 175</a> (Transcript) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/175/V212">code V212 of codelist 175</a> (Transcript) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the publication contains full transcript of audio and audiovisual content.</p>
 					</dd>
 				</dl>
@@ -782,43 +782,58 @@
 				<dl>
 					<dt><var>flashing_hazard</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/143/13">code 13 of codelist 143</a> (WARNING - Flashing hazard) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/143/13">code 13 of codelist 143</a> (WARNING - Flashing hazard) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the product has a flashing hazard which must be displayed.</p>
 					</dd>
 					<dt><var>motion_simulation_hazard</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/143/17">code 17 of codelist 143</a> (WARNING - Motion simulation hazard) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/143/17">code 17 of codelist 143</a> (WARNING - Motion simulation hazard) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the product has a motion simulation hazard which must be displayed.</p>
 					</dd>
-					<dt><var>no_flashing_hazards</var></dt>
+					<dt><var>no_flashing_hazard</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/143/14">code 14 of codelist 143</a> (No flashing hazard warning necessary) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/143/14">code 14 of codelist 143</a> (No flashing hazard warning necessary) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means there is a positive indication in the ONIX record confirming there are no flashing hazards associated with this product.</p>
 					</dd>
 					<dt><var>no_hazards_or_warnings_confirmed</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/143/00">code 00 of codelist 143</a> (No known hazards or warnings) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/143/00">code 00 of codelist 143</a> (No known hazards or warnings) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means there is a positive indication in the ONIX record confirming there are no associated hazard warnings with this product.</p>
 					</dd>
-					<dt><var>no_motion_hazards</var></dt>
+					<dt><var>no_motion_hazard</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/143/18">code 18 of codelist 143</a> (No motion simulation hazard warning necessary) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/143/18">code 18 of codelist 143</a> (No motion simulation hazard warning necessary) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means there is a positive indication in the ONIX record confirming there are no motion simulation hazards associated with this product.</p>
 					</dd>
-					<dt><var>no_sound_hazards</var></dt>
+					<dt><var>no_sound_hazard</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/143/16">code 16 of codelist 143</a> (No sound hazard warning necessary) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/143/16">code 16 of codelist 143</a> (No sound hazard warning necessary) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means there is a positive indication in the ONIX record confirming there are no sound hazards associated with this product.</p>
 					</dd>
 					<dt><var>sound_hazard</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/143/15">code 15 of codelist 143</a> (WARNING - Sound hazard) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/143/15">code 15 of codelist 143</a> (WARNING - Sound hazard) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that there is a positive indication that the product has a sound hazard which must be displayed.</p>
+					</dd>
+					<dt><var>unknown_flashing_hazard</var></dt>
+					<dd>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/143/24">code 24 of codelist 143</a> (Flashing risk unknown) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
+						<p>This means the presence of flashing hazards could not be determined.</p>
 					</dd>
 					<dt><var>unknown_if_contains_hazards</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/08">code 08 of codelist 196</a> (Unknown accessibility) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/08">code 08 of codelist 196</a> (Unknown accessibility) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the product has not been assessed for hazards and there is no information about potential hazards.</p>
+					</dd>
+					<dt><var>unknown_motion_hazard</var></dt>
+					<dd>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/143/26">code 26 of codelist 143</a> (Motion simulation risk unknown) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
+						<p>This means the presence of motion simulation hazards could not be determined.</p>
+					</dd>
+					<dt><var>unknown_sound_hazard</var></dt>
+					<dd>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/143/25">code 25 of codelist 143</a> (Sound risk unknown) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
+						<p>This means the presence of sound hazards could not be determined.</p>
 					</dd>
 				</dl>
 				<h4>Variables setup</h4>
@@ -826,21 +841,30 @@
 					<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
 					<li><b>LET</b> <var>flashing_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "13"]</code>.</li>
 					<li><b>LET</b> <var>motion_simulation_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "17"]</code>.</li>
-					<li><b>LET</b> <var>no_flashing_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "14"]</code>.</li>
+					<li><b>LET</b> <var>no_flashing_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "14"]</code>.</li>
 					<li><b>LET</b> <var>no_hazards_or_warnings_confirmed</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "00"]</code>.</li>
-					<li><b>LET</b> <var>no_motion_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "18"]</code>.</li>
-					<li><b>LET</b> <var>no_sound_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "16"]</code>.</li>
+					<li><b>LET</b> <var>no_motion_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "18"]</code>.</li>
+					<li><b>LET</b> <var>no_sound_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "16"]</code>.</li>
 					<li><b>LET</b> <var>sound_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "15"]</code>.</li>
+					<li><b>LET</b> <var>unknown_flashing_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "24"]</code>.</li>
 					<li><b>LET</b> <var>unknown_if_contains_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "08"]</code>.</li>
+					<li><b>LET</b> <var>unknown_motion_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "26"]</code>.</li>
+					<li><b>LET</b> <var>unknown_sound_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "25"]</code>.</li>
 				</ol>
 				<h4 id="hazards-instructions">Instructions</h4>
 				<ol class="condition">
 					<li>
-						<span><b>IF</b> <var>no_hazards_or_warnings_confirmed</var> <b>OR</b> (<var>no_flashing_hazards</var> <b>AND</b> <var>no_motion_hazards</var> <b>AND</b> <var>no_sound_hazards</var>):</span>
+						<span><b>IF</b> <var>no_hazards_or_warnings_confirmed</var> <b>OR</b>  (<var>no_flashing_hazard</var> <b>AND</b> <var>no_motion_hazard</var> <b>AND</b> <var>no_sound_hazard</var>):</span>
 						<span><b>THEN</b> display <code id="hazards-none">"No hazards"</code>.</span>
 					</li>
 					<li>
-						<span><b>ELSE IF</b> <var>flashing_hazard</var> <b>OR</b> <var>motion_simulation_hazard</var> <b>OR</b> <var>sound_hazard</var>:</span>
+						<span><b>ELSE IF</b> <var>unknown_if_contains_hazards</var> <b>OR</b> (<var>unknown_flashing_hazard</var> <b>AND</b> <var>unknown_motion_hazard</var> <b>AND</b> <var>unknown_sound_hazard</var>):</span>
+						<span><b>THEN</b> display <code id="hazards-unknown">"The presence of hazards is unknown"</code>.</span>
+					</li>
+					<li>
+						<span><b>ELSE IF</b> <var>flashing_hazard</var> <b>OR</b> <var>motion_simulation_hazard</var> <b>OR</b> <var>sound_hazard</var>
+							<b>OR</b> <var>no_flashing_hazard</var> <b>OR</b> <var>no_motion_hazard</var> <b>OR</b> <var>no_sound_hazard</var>
+							<b>OR</b> <var>unknown_flashing_hazard</var> <b>OR</b> <var>unknown_motion_hazard</var> <b>OR</b> <var>unknown_sound_hazard</var>:</span>
 						<span><b>THEN</b></span>
 						<ol class="condition">
 							<li>
@@ -848,18 +872,38 @@
 								<span><b>THEN</b> display <code id="hazards-flashing">"Flashing content"</code>.</span>
 							</li>
 							<li>
+								<span><b>IF</b> <var>unknown_flashing_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-flashing-unknown">"Flashing hazards not known"</code>.</span>
+							</li>
+							<li>
 								<span><b>IF</b> <var>motion_simulation_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-motion">"Motion simulation"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>unknown_motion_simulation_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-motion-unknown">"Motion simulation hazards not known"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>no_flashing_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-flashing-none">"No flashing hazards"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>no_motion_simulation_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-motion-none">"No motion simulation hazards"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>no_sound_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-sound-none">"No sound hazards"</code>.</span>
 							</li>
 							<li>
 								<span><b>IF</b> <var>sound_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-sound">"Sounds"</code>.</span>
 							</li>
+							<li>
+								<span><b>IF</b> <var>unknown_sound_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-sound-unknown">"Sound hazards not known"</code>.</span>
+							</li>
 						</ol>
-					</li>
-					<li>
-						<span><b>ELSE IF</b> <var>unknown_if_contains_hazards</var>:</span>
-						<span><b>THEN</b> display <code id="hazards-unknown">"The presence of hazards is unknown"</code>.</span>
 					</li>
 					<li>
 						<b>ELSE</b> display <code id="hazards-no-metadata">"No information is available"</code>.
@@ -882,17 +926,17 @@
 				<dl>
 					<dt><var>accessibility_addendum</var></dt>
 					<dd>
-						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/92">code 92 of codelist 196</a> (Accessibility addendum) if present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/92">code 92 of codelist 196</a> (Accessibility addendum) if present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means there is a human-written text containing a short addendum to the accessibility detail of the product. It contains precise information that the publisher could not express with the other's codes.</p>
 					</dd>
 					<dt><var>accessibility_summary</var></dt>
 					<dd>
-						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/00">code 00 of codelist 196</a>  (Accessibility summary) if present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/00">code 00 of codelist 196</a>  (Accessibility summary) if present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means there is a human-written text containing a short explanatory summary of the accessibility of the product or the URL of a web page comprising such a summary. Summarizes the already existent information and may add information that the publisher could not express with the other codes.</p>
 					</dd>
 					<dt><var>known_limited_accessibility</var></dt>
 					<dd>
-						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/09">code 09 of codelist 196</a> (Inaccessible, or known limited accessibility) if present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the description of <a href="https://ns.editeur.org/onix/en/196/09">code 09 of codelist 196</a> (Inaccessible, or known limited accessibility) if present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means there is a human-written text containing details of and reasons for limitations on accessibility of an ebook.</p>
 					</dd>
 					<dt><var>lang_attribute_accessibility_addendum</var></dt>
@@ -912,7 +956,7 @@
 					</dd>
 					<dt><var>language_of_text</var></dt>
 					<dd>
-						<p>Returns the value of nearest  <a href="https://ns.editeur.org/onix/en/22/01">code 01 of codelist 22</a> (Language of text)  if present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>Returns the value of nearest  <a href="https://ns.editeur.org/onix/en/22/01">code 01 of codelist 22</a> (Language of text)  if present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This indicates the main language of the content and therefore the most probable language of accessibility summary and addendum.</p>
 					</dd>
 				</dl>
@@ -977,17 +1021,17 @@
 				<dl>
 					<dt><var>eaa_exception_disproportionate_burden</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/76">code 76 of codelist 196</a> (EAA exception 2 – Disproportionate burden) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/76">code 76 of codelist 196</a> (EAA exception 2 – Disproportionate burden) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the digital product falls under European Accessibility Act exception for Disproportionate burden (as defined by current regulations). The product may not have to comply with requirements of the EAA if doing so would financially overburden the publisher.</p>
 					</dd>
 					<dt><var>eaa_exception_fundamental_modification</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/77">code 77 of codelist 196</a> (EAA exception 3 – Fundamental modification) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/77">code 77 of codelist 196</a> (EAA exception 3 – Fundamental modification) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the digital product falls under European Accessibility Act exception for Fundamental modification (as defined by current regulations). The product may not have to comply with requirements of the EAA if doing so requires a fundamental modification of the nature of the product or service.</p>
 					</dd>
 					<dt><var>eaa_exemption_micro_enterprises</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/75">code 75 of codelist 196</a> (EEA exception 1 – Micro-enterprises) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/75">code 75 of codelist 196</a> (EEA exception 1 – Micro-enterprises) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the digital product falls under European Accessibility Act exemption for Micro-enterprises (as defined by current regulations). The product may not have to comply with requirements of the EAA if the publisher is a micro-enterprise.</p>
 					</dd>
 				</dl>
@@ -1020,48 +1064,48 @@
 				<dl>
 					<dt><var>color_not_sole_means_of_conveying_information</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/25">code 25 of codelist 196</a> (Use of color is not sole means of conveying information) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/25">code 25 of codelist 196</a> (Use of color is not sole means of conveying information) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that for readers with color vision deficiency, use of color (eg in diagrams, graphs and charts, in prompts or on buttons inviting a response) is not the sole means of graphical distinction or of conveying information.</p>
 					</dd>
 					<dt><var>dyslexia_readability</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/24">code 24 of codelist 196</a> (Dyslexia readability) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/24">code 24 of codelist 196</a> (Dyslexia readability) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the product has been specifically adapted or has features specifically to improve readability for dyslexic readers, for example specialized font, character and/or line spacing, justification and paragraph spacing, coloring and other options provided specifically to improve readability for dyslexic readers.</p>
 					</dd>
 					<dt><var>high_contrast_between_foreground_and_background_audio</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/27">code 27 of codelist 196</a> (Use of high contrast between foreground and background audio) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/27">code 27 of codelist 196</a> (Use of high contrast between foreground and background audio) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that foreground audio content (eg voice) is presented with no or low background noise (eg ambient sounds, music), at least 20dB below the level of the foreground, or background noise can be switched off (eg via an alternative audio track). Brief and occasional sound effects may be as loud as foreground voice so long as they are isolated from the foreground.</p>
 					</dd>
 					<dt><var>high_contrast_between_text_and_background</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/26">code 26 of codelist 196</a> (Use of high contrast between text and background color) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/26">code 26 of codelist 196</a> (Use of high contrast between text and background color) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that body text is presented with a contrast ratio of at least 4.5:1 (or 3:1 for large/heading text).</p>
 					</dd>
 					<dt><var>sign_language</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/175/V213">code V213 of codelist 175</a> (Sign language interpretation) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/175/V213">code V213 of codelist 175</a> (Sign language interpretation) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that a full signing of audio content of the product supplied with the video file.</p>
 					</dd>
 					<dt><var>text_to_speech_hinting</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/21">code 21 of codelist 196</a> (Text-to-speech hinting provided) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/21">code 21 of codelist 196</a> (Text-to-speech hinting provided) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that text-to-speech has been optimized through provision of PLS lexicons, SSML or CSS Speech synthesis hints or other speech synthesis markup languages or hinting.</p>
 					</dd>
 					<dt><var>ultra_high_contrast_between_text_and_background</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/196/37">code 37 of codelist 196</a> (Use of ultra-high contrast between text foreground and background) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/196/37">code 37 of codelist 196</a> (Use of ultra-high contrast between text foreground and background) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that body text is presented with a contrast ratio of at least 7:1 (or 4.5:1 for large/heading text).</p>
 					</dd>
 					<dt><var>visible_page_numbering</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/175/E205">code E205 of codelist 175</a> (Visible page numbering) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/175/E205">code E205 of codelist 175</a> (Visible page numbering) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that the e-publication (mostly in the case of a fixed-format) contains visible page numbers.</p>
 					</dd>
 					
 					<dt><var>without_background_sounds</var></dt>
 					<dd>
-						<p>If true it indicates that the <a href="https://ns.editeur.org/onix/en/175/A312">code A312 of codelist 175</a> (Without background sounds) is present in the ONIX record, otherwise if false it means that the metadata is not present.</p>
+						<p>If true, it indicates that <a href="https://ns.editeur.org/onix/en/175/A312">code A312 of codelist 175</a> (Without background sounds) is present in the ONIX record; otherwise, it means that the metadata is not present.</p>
 						<p>This means that pre-recorded audiobook narration does not contain any background sounds, including music, sound effects, etc, though music and effects may be present if isolated from the speech (ie the sounds do not overlap).</p>
 					</dd>
 				</dl>

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -50,6 +50,16 @@
 	  	var {
 			color: brown;
 		}
+		li > ol.condition {
+			list-style-type: lower-alpha;
+		}
+		
+		li > ol.condition > li >  ol.condition {
+			list-style-type: upper-roman;
+		}
+		ol.display {
+			list-style-type: disc;
+		}
 	  	ol.condition > li {
 	  		margin-top: 1rem;
 	  		margin-left: 0;
@@ -182,11 +192,11 @@
 				</aside>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<p>To generate the internal representation, run the following steps:</p>
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>record</var> be textual representation of the ONIX record for the publication given <var>onix_record_as_text</var>.</li>
 					<li><b>LET</b> <var>onix</var> be the DOM tree that results from parsing <var>record</var> using an XML DOM parser.</li>
 					<li>return <var>onix</var>.</li>
-				</ol>
+				</ul>
 				<aside class="note">
 					<p>The XML file being processed may contain namespaces, in the techniques when we use XPATH we will assume that the default namespace of the root record is used.</p>
 				</aside>
@@ -237,11 +247,11 @@
 						</dd>
 					</dl>
 					<h4>Variables setup</h4>
-					<ol class="condition">
+					<ul class="variable">
 						<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
 						<li><b>LET</b> <var>all_textual_content_can_be_modified</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "36"]</code>.</li>
 						<li><b>LET</b> <var>is_fixed_layout</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormDetail[normalize-space() = "E201"]</code> <b>AND</b> <b>NOT</b> the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormDetail[normalize-space() = "E200"]</code>.</li>
-					</ol>
+					</ul>
 					<h4>Instructions</h4>
 					<ol class="condition">
 						<li>
@@ -290,13 +300,13 @@
 						</dd>
 					</dl>
 					<h4>Variables setup</h4>
-					<ol class="condition">
+					<ul class="variable">
 						<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
 						<li><b>LET</b> <var>all_necessary_content_textual</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "52"]</code>.</li>
 						<li><b>LET</b> <var>audio_only_content</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail[PrimaryContentType = "81" or ProductContentType = "81"] </code>.</li>
 						<li><b>LET</b> <var>real_text</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail[PrimaryContentType = "10" or ProductContentType = "10"]</code>.</li>
 						<li><b>LET</b> <var>textual_alternatives</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and (ProductFormFeatureValue = "14" or ProductFormFeatureValue = "15" or ProductFormFeatureValue = "16")]</code> <b>OR</b> calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormDetail[normalize-space() = "V212"]</code>.</li>
-					</ol>
+					</ul>
 					<h4>Instructions</h4>
 					<ol class="condition">
                         <li>
@@ -376,7 +386,7 @@
 						</dd>
 					</dl>
 					<h4>Variables setup</h4>
-					<ol class="condition">
+					<ul class="variable">
 						<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
 						<li><b>LET</b> <var>all_content_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "39"]</code>.</li>
 						<li><b>LET</b> <var>all_content_pre_recorded</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "51"]</code>.</li>
@@ -384,7 +394,7 @@
 						<li><b>LET</b> <var>non_textual_content_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail[PrimaryContentType = "21" or ProductContentType = "22" or ProductContentType = "21" or ProductContentType = "22"] </code>.</li>
 						<li><b>LET</b> <var>non_textual_content_audio_in_video</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail[PrimaryContentType = "06" or PrimaryContentType = "25" or PrimaryContentType = "26" or PrimaryContentType = "27" or PrimaryContentType = "28" or PrimaryContentType = "29" or PrimaryContentType = "30" or ProductContentType = "06" or ProductContentType = "25" or ProductContentType = "26" or ProductContentType = "27" or ProductContentType = "28" or ProductContentType = "29" or ProductContentType = "30"] </code>.</li>
 						<li><b>LET</b> <var>synchronised_pre_recorded_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "20"]</code> <b>AND</b> calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormDetail[normalize-space() = "A305"]</code>.</li>
-					</ol>
+					</ul>
 					<h4>Instructions</h4>
 					<ol class="condition">
 						<li>
@@ -480,7 +490,7 @@
 				</dl>
 
 				<h4>Variables setup</h4>
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
 					<li><b>LET</b> <var>certifier</var> be the value of the node extracted from <var>onix</var>, using the xpath <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "90"]/ProductFormFeatureDescription</code>.</li>
 					<li><b>LET</b> <var>certification_date</var> be the value of the node extracted from <var>onix</var>, using the xpath <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "91"]/ProductFormFeatureDescription</code>.</li>
@@ -495,7 +505,7 @@
 					<li><b>LET</b> <var>wcag_20</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "80"]</code> <b>OR</b> calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "02"]</code> <b>OR</b> calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "03"]</code>.</li>
 					<li><b>LET</b> <var>wcag_21</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "81"]</code>.</li>
 					<li><b>LET</b> <var>wcag_22</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "82"]</code>.</li>
-				</ol>
+				</ul>
 
 				<h4 id="conformance-instructions">Instructions</h4>
 				<ol class="condition">
@@ -524,18 +534,18 @@
 					<li>
 						<span><b>IF</b> <var>certifier</var> is <b>NOT</b> empty:</span>
 						<span><b>THEN</b></span>
-						<ul class="condition">
+						<ol class="display">
 							<li>display <code id="conformance-certifier">"The publication was certified by "</code></li>
 							<li>display <var>certifier</var>.</li>
-						</ul>
+						</ol>
 					</li>
 					<li>
 						<span><b>IF</b> <var>certifier_credentials</var> is <b>NOT</b> empty:</span>
 						<span><b>THEN</b></span>
-						<ul class="condition">
+						<ol class="display">
 							<li>display <code id="conformance-certifier-credentials">"The certifier's credential is"</code></li>
 							<li>display <var>certifier_credentials</var> as link <b>IF</b> <var>certifier_credentials</var> is an URL.</li>
-						</ul>
+						</ol>
 					</li>
 					<li>
 						<div class="note">
@@ -583,17 +593,14 @@
 					<li>
 						<span><b>IF</b> <var>certification_date</var>:</span>
 						<span><b>THEN</b></span>
-						<ul class="condition">
+						<ol class="display">
 							<li>display <code id="conformance-details-certification-info">"The publication was certified on"</code></li>
 							<li>display <var>certification_date</var>.</li>
-						</ul>
+						</ol>
 					</li>
 					<li>
 						<span><b>IF</b> <var>certifier_report</var>:</span>
-						<span><b>THEN</b></span>
-						<ul class="condition">
-							<li>display <code id="conformance-details-certifier-report">"For more information refer to the certifier's report"</code> as a named link with <var>certifier_report</var> as the URL used.</li>
-						</ul>
+						<span><b>THEN</b> display <code id="conformance-details-certifier-report">"For more information refer to the certifier's report"</code> as a named link with <var>certifier_report</var> as the URL used.</span>
 					</li>
 				</ol>
 			</section>
@@ -626,13 +633,13 @@
 					</dd>
 				</dl>
 				<h4>Variables setup</h4>
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
 					<li><b>LET</b> <var>index_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "12"]</code>.</li>
 					<li><b>LET</b> <var>next_previous_structural_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "29"]</code>.</li>
 					<li><b>LET</b> <var>page_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "19"]</code>.</li>
 					<li><b>LET</b> <var>table_of_contents_navigation</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "11"]</code>.</li>
-				</ol>
+				</ul>
 				<h4 id="navigation-instructions">Instructions</h4>
 				<ol class="condition">
 					<li>
@@ -720,7 +727,7 @@
 					</dd>
 				</dl>
 				<h4>Variables setup</h4>
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
 					<li><b>LET</b> <var>charts_diagrams_as_non_graphical_data</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "16"]</code>.</li>
 					<li><b>LET</b> <var>chemical_formula_as_mathml</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "34"]</code>.</li>
@@ -732,7 +739,7 @@
 					<li><b>LET</b> <var>open_captions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail[ProductFormDetail = "V211"]</code>.</li>
 					<li><b>LET</b> <var>short_textual_alternative_images</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "14"]</code>.</li>
 					<li><b>LET</b> <var>transcript</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail[ProductFormDetail = "V212"]</code>.</li>
-				</ol>
+				</ul>
 				<h4 id="rich-content-instructions">Instructions</h4>
 				<ol class="condition">
 					<li>
@@ -837,7 +844,7 @@
 					</dd>
 				</dl>
 				<h4>Variables setup</h4>
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
 					<li><b>LET</b> <var>flashing_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "13"]</code>.</li>
 					<li><b>LET</b> <var>motion_simulation_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "17"]</code>.</li>
@@ -850,7 +857,7 @@
 					<li><b>LET</b> <var>unknown_if_contains_hazards</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "08"]</code>.</li>
 					<li><b>LET</b> <var>unknown_motion_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "26"]</code>.</li>
 					<li><b>LET</b> <var>unknown_sound_hazard</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "12" and ProductFormFeatureValue = "25"]</code>.</li>
-				</ol>
+				</ul>
 				<h4 id="hazards-instructions">Instructions</h4>
 				<ol class="condition">
 					<li>
@@ -961,7 +968,7 @@
 					</dd>
 				</dl>
 				<h4>Variables setup</h4>
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
 					<li><b>LET</b> <var>accessibility_addendum</var> be the value of the node extracted from <var>onix</var>, using the xpath <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "92"]/ProductFormFeatureDescription</code>.</li>
 					<li><b>LET</b> <var>accessibility_summary</var> be the value of the node extracted from <var>onix</var>, using the xpath <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "00"]/ProductFormFeatureDescription</code>.</li>
@@ -970,7 +977,7 @@
 					<li><b>LET</b> <var>lang_attribute_accessibility_summary</var> be the value extracted from <var>onix</var>, using the xpath <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "00"]/ProductFormFeatureDescription/(@lang|ancestor::*/@lang)[last()]</code>.</li>
 					<li><b>LET</b> <var>lang_known_limited_accessibility</var> be the value extracted from <var>onix</var>, using the xpath <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "09"]/ProductFormFeatureDescription/(@lang|ancestor::*/@lang)[last()]</code>.</li>
 					<li><b>LET</b> <var>language_of_text</var> be the value of the node extracted from <var>onix</var>, using the xpath <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/Language[LanguageRole="01"]/LanguageCode</code>.</li>
-				</ol>
+				</ul>
 				<h4 id="accessibility-summary-instructions">Instructions</h4>
 				<ol class="condition">
 					<li>
@@ -1036,12 +1043,12 @@
 					</dd>
 				</dl>
 				<h4>Variables setup</h4>
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
 					<li><b>LET</b> <var>eaa_exception_disproportionate_burden</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "76"]</code>.</li>
 					<li><b>LET</b> <var>eaa_exception_fundamental_modification</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "77"]</code>.</li>
 					<li><b>LET</b> <var>eaa_exemption_micro_enterprises</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "75"]</code>.</li>
-				</ol>
+				</ul>
 				<h4 id="legal-considerations-instructions">Instructions</h4>
 				<ol class="condition">
 					<li>
@@ -1111,7 +1118,7 @@
 				</dl>
 
 				<h4>Variables setup</h4>
-				<ol class="condition">
+				<ul class="variable">
 					<li><b>LET</b> <var>onix</var> be the result of calling <a href="#preprocessing">preprocessing</a> given <var>onix_record_as_text</var>.</li>
 					<li><b>LET</b> <var>color_not_sole_means_of_conveying_information</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "25"]</code>.</li>
 					<li><b>LET</b> <var>dyslexia_readability</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "24"]</code>.</li>
@@ -1122,7 +1129,7 @@
 					<li><b>LET</b> <var>ultra_high_contrast_between_text_and_background</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail/ProductFormFeature[ProductFormFeatureType = "09" and ProductFormFeatureValue = "37"]</code>.</li>
 					<li><b>LET</b> <var>visible_page_numbering</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail[ProductFormDetail = "E205"]</code>.</li>
 					<li><b>LET</b> <var>without_background_sounds</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>onix</var>, <code class="xpath">/ONIXMessage/Product/DescriptiveDetail[ProductFormDetail = "A312"]</code>.</li>
-				</ol>
+				</ul>
 
 				<h4>Instructions</h4>
 				<ol class="condition">

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -872,16 +872,24 @@
 								<span><b>THEN</b> display <code id="hazards-flashing">"Flashing content"</code>.</span>
 							</li>
 							<li>
-								<span><b>IF</b> <var>unknown_flashing_hazard</var>:</span>
-								<span><b>THEN</b> display <code id="hazards-flashing-unknown">"Flashing hazards not known"</code>.</span>
-							</li>
-							<li>
 								<span><b>IF</b> <var>motion_simulation_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-motion">"Motion simulation"</code>.</span>
 							</li>
 							<li>
+								<span><b>IF</b> <var>sound_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-sound">"Sounds"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>unknown_flashing_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-flashing-unknown">"Flashing hazards not known"</code>.</span>
+							</li>
+							<li>
 								<span><b>IF</b> <var>unknown_motion_simulation_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-motion-unknown">"Motion simulation hazards not known"</code>.</span>
+							</li>
+							<li>
+								<span><b>IF</b> <var>unknown_sound_hazard</var>:</span>
+								<span><b>THEN</b> display <code id="hazards-sound-unknown">"Sound hazards not known"</code>.</span>
 							</li>
 							<li>
 								<span><b>IF</b> <var>no_flashing_hazard</var>:</span>
@@ -894,14 +902,6 @@
 							<li>
 								<span><b>IF</b> <var>no_sound_hazard</var>:</span>
 								<span><b>THEN</b> display <code id="hazards-sound-none">"No sound hazards"</code>.</span>
-							</li>
-							<li>
-								<span><b>IF</b> <var>sound_hazard</var>:</span>
-								<span><b>THEN</b> display <code id="hazards-sound">"Sounds"</code>.</span>
-							</li>
-							<li>
-								<span><b>IF</b> <var>unknown_sound_hazard</var>:</span>
-								<span><b>THEN</b> display <code id="hazards-sound-unknown">"Sound hazards not known"</code>.</span>
 							</li>
 						</ol>
 					</li>

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -1180,7 +1180,9 @@
 						href="https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/techniques/onix-metadata/onix-metadata-draft-note-20250220.html">2025-02-20
 						Draft Community Group Report</a></summary>
 				<ul>
-					<li>No substantive changes have been made.</li>
+					<li>03-Mar-2025: Added individual tests for unknown hazards and included outputs for situations
+						where there is a mix of hazard, no hazard, and unknown hazard statements. See <a 
+							href="https://github.com/w3c/publ-a11y/issues/578">issue 587</a>.</li>
 				</ul>
 			</details>
 		</section>


### PR DESCRIPTION
This pull request adds variables and checks for the individual unknown hazard statements. It also modifies the outputs in the techniques as I described in https://github.com/w3c/publ-a11y/issues/578#issuecomment-2688661659

This change means that we're now outputting six new strings - one for each of the three no hazard statements and one for each of the three unknown hazard statements.

The descriptive output for sound hazard looks like it wasn't updated when we changed the "loud sounds" compact statement to plain old "sounds". It mentioned "uncomfortable sounds", but for now I've changed it to "sensitivity issues" since we don't know exactly what the hazard is short of a publisher description in the summary. If anyone can think of better wording, though, I'm open to changing it.

I also noticed the variable descriptions weren't quite right grammatically, so I made some fixes to the wording (across all the fields). As well, there were still a number of places where the EPUB techniques were citing the ONIX code number descriptions in parentheses. I stripped these out as it's confusing to re-use ONIX definitions for the schema.org metadata.

Fixes #578 

***

[Guidelines Preview](https://raw.githack.com/w3c/publ-a11y/fix/unknown-hazards/a11y-meta-display-guide/2.0/draft/guidelines/index.html) | [Guidelines Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/unknown-hazards/a11y-meta-display-guide/2.0/draft/guidelines/index.html)
[EPUB Preview](https://raw.githack.com/w3c/publ-a11y/fix/unknown-hazards/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html) | [EPUB Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/unknown-hazards/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html)
[ONIX Preview](https://raw.githack.com/w3c/publ-a11y/fix/unknown-hazards/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html) | [ONIX Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/unknown-hazards/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html)
