### PR TITLE
Delete mentions to gitlocalize

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -2390,9 +2390,8 @@
 				materials, we propose a collection mechanism based on a
 				detailed identification of the provenance. Because
 				persons and organizations with different levels of
-				technicality must be able to contribute, we accept both
-				raw files via Pull requests and also propose a friendly
-				localization user interface through GitLocalize.
+				technicality must be able to contribute, we accept 
+				raw files via Pull requests.
 			</p>
 
 		</section>
@@ -2408,10 +2407,7 @@
 				possible:</p>
 			<ul>
 				<li>If you don’t know what a JSON or a Pull Request is,
-					you are welcome to contact us so we can attribute a
-					translator role at the <a
-						href="https://gitlocalize.com/repo/9555">Gitlocalize
-						dedicated project page</a>.</li>
+					you are welcome to contact us.</li>
 				<li>If you feel technically ready or have a collaborator
 					that can push a pull request, the process is to
 					duplicate the canonical original file


### PR DESCRIPTION
As we have recently experienced difficulties with GitLocalize, we don't use it anymore.