### PR TITLE
Harmonize hazard strings and fix ID

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1707,7 +1707,7 @@
 					<dd>
 						<p data-localization-id="hazards-flashing-none"
 							data-localization-mode="compact">No flashing
-							hazard</p>
+							hazards</p>
 						<p data-localization-id="hazards-flashing-none"
 							data-localization-mode="descriptive">The
 							publication does not contain flashing content
@@ -1719,7 +1719,7 @@
 					<dd>
 						<p data-localization-id="hazards-flashing-unknown"
 							data-localization-mode="compact">Flashing
-							hazard not known</p>
+							hazards not known</p>
 						<p data-localization-id="hazards-flashing-unknown"
 							data-localization-mode="descriptive">The
 							presence of flashing content that can cause
@@ -1739,7 +1739,7 @@
 					
 					<dt>If there is no motion simulation hazard:</dt>
 					<dd>
-						<p data-localization-id="hazards-flashing-none"
+						<p data-localization-id="hazards-motion-none"
 							data-localization-mode="compact">No motion simulation
 							hazards</p>
 						<p data-localization-id="hazards-motion-none"


### PR DESCRIPTION
Pluralizes "hazards" in guidelines to be consistent with the other strings and fixes the ID for the unknown motion hazard compact string.

Fixes #684 