### PR TITLE
Add placeholder doc for guidelines implementation report

### DIFF
--- a/a11y-meta-display-guide/2.0/implementations/index..html
+++ b/a11y-meta-display-guide/2.0/implementations/index..html
@@ -2,41 +2,58 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>Accessibility Metadata Display Guide for Digital Publications 2.0 &#8212; Implementation Report</title>
-		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script class="remove">
-			var respecConfig = {
-				group: "publishingcg",
-				specStatus: "base",
-				shortName: "publ-a11y-display-guide-impl",
-				noRecTrack: true,
-				edDraftURI: null,
-				latestVersion: "https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/implementations/",
-				editors:[{
-					name: "George Kerscher",
-					company: "DAISY Consortium",
-					companyURL: "http://daisy.org",
-					w3cid: 1460
-				}],
-				processVersion: 2020,
-				includePermalinks: true,
-				permalinkEdge: true,
-				permalinkHide: false,
-				github: {
-					repoURL: "https://github.com/w3c/publ-a11y",
-					branch: "main"
-				}
-			};</script>
+		<title>Accessibility Metadata Display Guide for Digital Publications 2.0 — Implementation Report</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+		<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" />
+		<style>
+			p.subtitle {
+				font-size: 180%;
+				color: var(--heading-text);
+				margin-top: 0;
+			}
+			body, nav#toc {
+				background-image: none !important;
+			}
+			nav#toc {
+				padding-top: 2rem !important;
+			}
+		</style>
 	</head>
-	<body>
-		<section id="abstract">This document provides a list of known implementations of the techniques described in the
-			Accessibility Metadata Display Guide for Digital Publications 2.0.</section>
-		<section id="sotd"></section>
+	
+	<body class="h-entry informative">
+		<div class="head">
+			<hgroup>
+				<h1 id="title" class="title">Accessibility Metadata Display Guide for Digital Publications 2.0</h1>
+				<p class="subtitle">Implementation Report</p>
+			</hgroup>
+			<hr title="Separator for header" />
+		</div>
+		
+		<nav id="toc">
+			<h2 class="introductory" id="table-of-contents">Table of Contents</h2>
+			<ol class="toc">
+				<li class="tocline"><a class="tocxref" href="#intro"><bdi class="secno">1. </bdi>Introduction</a></li>
+				<li class="tocline"><a class="tocxref" href="#implementations"><bdi class="secno">2. </bdi>Implementations</a></li>
+			</ol>
+		</nav>
+		
+		
 		<section id="intro">
-			<h2>Introduction</h2>
+			<div class="header-wrapper">
+				<h2 id="x1-introduction"><bdi class="secno">1. </bdi>Introduction</h2>
+			</div>
 		</section>
+		
+		
 		<section id="implementations">
-			<h2>Implementations</h2>
+			<div class="header-wrapper">
+				<h2 id="x2-implementations"><bdi class="secno">2. </bdi>Implementations</h2>
+			</div>
 		</section>
+		
+		
+		<p role="navigation" id="back-to-top">
+			<a href="#title"><abbr title="Back to Top">↑</abbr></a>
+		</p>
 	</body>
 </html>

--- a/a11y-meta-display-guide/2.0/implementations/index..html
+++ b/a11y-meta-display-guide/2.0/implementations/index..html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+	<head>
+		<meta charset="utf-8" />
+		<title>Accessibility Metadata Display Guide for Digital Publications 2.0 &#8212; Implementation Report</title>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script class="remove">
+			var respecConfig = {
+				group: "publishingcg",
+				specStatus: "base",
+				shortName: "publ-a11y-display-guide-impl",
+				noRecTrack: true,
+				edDraftURI: null,
+				latestVersion: "https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/implementations/",
+				editors:[{
+					name: "George Kerscher",
+					company: "DAISY Consortium",
+					companyURL: "http://daisy.org",
+					w3cid: 1460
+				}],
+				processVersion: 2020,
+				includePermalinks: true,
+				permalinkEdge: true,
+				permalinkHide: false,
+				github: {
+					repoURL: "https://github.com/w3c/publ-a11y",
+					branch: "main"
+				}
+			};</script>
+	</head>
+	<body>
+		<section id="abstract">This document provides a list of known implementations of the techniques described in the
+			Accessibility Metadata Display Guide for Digital Publications 2.0.</section>
+		<section id="sotd"></section>
+		<section id="intro">
+			<h2>Introduction</h2>
+		</section>
+		<section id="implementations">
+			<h2>Implementations</h2>
+		</section>
+	</body>
+</html>


### PR DESCRIPTION
The file to work on will be under the /a11y-meta-display-guide/2.0/implementations/ folder

The URL to it once merged will be https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/implementations/

There's not really anything to review yet as it's just a shell, so you can merge this and start working on it whenever you're ready @GeorgeKerscher 