### PR TITLE
Fix typos

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -294,7 +294,7 @@
 
 			<p>In some cases, a digital publication may include both
 				internal and external metadata (e.g., an EPUB
-				could have accessibility metadata in it package document
+				could have accessibility metadata in its package document
 				and also be provided to a vendor with an
 				ONIX record). In these cases, vendors and reading system
 				developers determine for themselves which
@@ -555,7 +555,7 @@
 					saying they are unsure). The neutral statement "No information is available" is
 					displayed for this case.</p>
 
-				<p>In some cases, the distributer may not be allowed to show statements the publisher did not make.
+				<p>In some cases, the distributor may not be allowed to show statements the publisher did not make.
 					Hiding such sections is acceptable in these cases.</p>
 			</section>
 		</section>
@@ -1595,7 +1595,7 @@
 								<li data-localization-id="rich-content-closed-captions"
 									data-localization-mode="compact">Videos have closed captions</li>
 								<li data-localization-id="rich-content-transcript"
-									data-localization-mode="compact">Transcript(s) provided)</li>
+									data-localization-mode="compact">Transcript(s) provided</li>
 							</ul>
 						</dd>
 
@@ -1608,7 +1608,7 @@
 								<li data-localization-id="rich-content-closed-captions"
 									data-localization-mode="descriptive">Videos included in publications have closed captions</li>
 								<li data-localization-id="rich-content-transcript"
-									data-localization-mode="compact">Transcript(s) provided)</li>
+									data-localization-mode="compact">Transcript(s) provided</li>
 							</ul>
 						</dd>
 					</dl>
@@ -1886,7 +1886,6 @@
 						be expanded. There are several short videos in
 						American Sign Language that explains key
 						concepts.</p>
-<p>No information is available</p>
 				</aside>
 			</section>
 


### PR DESCRIPTION
This PR addresses a few typos in the index draft:

- Changed `in it package` to `in its package`
- Changed `distributer` to `distributor`, to be consistent in the document. "Distributer" is an obsolete term.
- Removed an extra parenthesis in `Transcript(s) provided)`
- Removed "No information available" from the [accessibility summary example](https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/#sum-examples). It was showing both the state "no information" and an actual content, which was not consistent with the other examples.