### PR TITLE
Updated the title of the readme

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/README.md
+++ b/a11y-meta-display-guide/2.0/draft/README.md
@@ -1,5 +1,5 @@
-# User Experience Guide for Displaying Accessibility Metadata 2.0
- 
+#Accessibility Metadata Display Guide for Digital Publications 2.0
+
 * [Current Editor's Draft - Guidelines](https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/)
 * [Current Editor's Draft - Techniques](https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/):
 	* [Display Techniques for EPUB Accessibility Metadata 2.0](https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/)


### PR DESCRIPTION
Reviewed documents to remove the word "principle" everywhere. The readme.md had the old name of the guidelines and this  resolves that oversight. This fixes #653 