### PR TITLE
Corrections in the EPUB technique document

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -888,17 +888,6 @@
 						<p>This means that the audio content of a video can be seen via closed captions that can be turned on or off  by the viewer and which will be a separate file from the video itself.</p>
 					</dd>
 
-					<dt><var>contains_charts_diagrams</var></dt>
-					<dd>
-						<p>If true, it indicates that <i>accessMode="chartOnVisual"</i> is present in the package document.</p>
-						<p>This means that there is a positive indication that the product has some information conveyed via some form of illustration, such as a graph, a chart, a diagram, a figure, etc).</p>
-					</dd>
-					<dt><var>contains_chemical_formula</var></dt>
-					<dd>
-						<p>If true, it indicates that <i>accessMode="chemOnVisual"</i> is present in the package document.</p>
-						<p>This means that there is a positive indication that the publication contains chemical notations, formulae.</p>
-					</dd>
-
 					<dt><var>contains_math_formula</var></dt>
 					<dd>
 						<p>If true, it indicates that <i>accessibilityFeature="describedMath"</i> is present in the package document.</p>
@@ -952,18 +941,6 @@
 						on <var>package_document</var>, <code class="xpath"
 								>/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and
 								normalize-space()="<i>closedCaptions</i>"]</code>.</li>
-
-					<li><b>LET</b>
-						<var>contains_charts_diagrams</var> be the result of calling <a href="#check-for-node">check for
-							node</a> on <var>package_document</var>, <code class="xpath"
-								>/package/metadata/meta[@property="schema:<i>accessMode</i>" and
-								normalize-space()="<i>chartOnVisual</i>"]</code>.</li>
-
-					<li><b>LET</b>
-						<var>contains_chemical_formula</var> be the result of calling <a href="#check-for-node">check
-							for node</a> on <var>package_document</var>, <code class="xpath"
-								>/package/metadata/meta[@property="schema:<i>accessMode</i>" and
-								normalize-space()="<i>chemOnVisual</i>"]</code>.</li>
 
 					<li><b>LET</b>
 						<var>contains_math_formula</var> be the result of calling <a href="#check-for-node">check for

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -1447,6 +1447,20 @@
 						<li><b>LET</b> <var>audio_descriptions</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>audioDescription</i>"]</code>.</li>
 						
 						<li><b>LET</b> <var>braille</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>braille</i>"]</code>.</li>
+
+						<li><b>LET</b> <var>full_ruby_annotations</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>fullRubyAnnotations</i>"]</code>.</li>
+
+						<li><b>LET</b> <var>high_contrast_between_foreground_and_background_audio</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>highContrastAudio</i>"]</code>.</li>
+
+						<li><b>LET</b> <var>high_contrast_between_text_and_background</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>highContrastDisplay</i>"]</code>.</li>
+
+						<li><b>LET</b> <var>large_print</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>largePrint</i>"]</code>.</li>
+
+						<li><b>LET</b> <var>page_break_markers</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>pageBreakMarkers</i>"]</code>.</li>
+
+						<li><b>LET</b> <var>ruby_annotations</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>rubyAnnotations</i>"]</code>.</li>
+
+						<li><b>LET</b> <var>sign_language</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>signLanguage</i>"]</code>.</li>
 					   
 						<li><b>LET</b> <var>tactile_graphic</var> be the result of calling <a href="#check-for-node">check for node</a> on <var>package_document</var>, <code class="xpath">/package/metadata/meta[@property="schema:<i>accessibilityFeature</i>" and normalize-space()="<i>tactileGraphic</i>"]</code>.</li>
 						


### PR DESCRIPTION
This PR addresses a couple of issues in the EPUB technique document:

- Remove unused variables: `contains_charts_diagrams` and `contains_chemical_formula`.
- Add missing variables setup for the Additional accessibility information field.