### PR TITLE
Fix leading whitespace in descriptive statements

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -687,8 +687,7 @@
 								data-localization-mode="compact">Appearance
 								can be modified</p>
 							<p data-localization-id="ways-of-reading-visual-adjustments-modifiable"
-								data-localization-mode="descriptive">
-								Appearance of the text and page layout can
+								data-localization-mode="descriptive">Appearance of the text and page layout can
 								be
 								modified according to the capabilities of
 								the reading system (font family and font
@@ -716,8 +715,7 @@
 							<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
 								data-localization-mode="compact">No information about appearance modifiability is available</p>
 							<p data-localization-id="ways-of-reading-visual-adjustments-unknown"
-								data-localization-mode="descriptive">
-								No information about appearance modifiability is available</p>
+								data-localization-mode="descriptive">No information about appearance modifiability is available</p>
 						</dd>
 					</dl>
 				</section>
@@ -841,8 +839,7 @@
 						missing. Alternatively it can be stated that
 						<span
 							data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
-								data-localization-mode="descriptive">
-								No information about prerecorded audio is available</span>.
+								data-localization-mode="descriptive">No information about prerecorded audio is available</span>.
 					</p>
 				</div>
 
@@ -870,8 +867,7 @@
 							<p data-localization-id="ways-of-reading-prerecorded-audio-only"
 								data-localization-mode="compact">Prerecorded audio only</p>
 							<p data-localization-id="ways-of-reading-prerecorded-audio-only"
-								data-localization-mode="descriptive">
-								Audiobook with no text alternative</p>
+								data-localization-mode="descriptive">Audiobook with no text alternative</p>
 						</dd>
 
 						<dt>If there is prerecorded audio synchronized with text:</dt>
@@ -896,8 +892,7 @@
 								data-localization-mode="compact">
 								No information about prerecorded audio is available</p>
 							<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
-								data-localization-mode="descriptive">
-								No information about prerecorded audio is available</p>
+								data-localization-mode="descriptive">No information about prerecorded audio is available</p>
 						</dd>
 					</dl>
 				</section>
@@ -1549,16 +1544,14 @@
 					<dd>
 						<p data-localization-id="rich-content-closed-captions" data-localization-mode="compact">
 							Videos have closed captions</p>
-						<p data-localization-id="rich-content-closed-captions" data-localization-mode="descriptive">
-								Videos included in publications have closed captions</p>
+						<p data-localization-id="rich-content-closed-captions" data-localization-mode="descriptive">Videos included in publications have closed captions</p>
 					</dd>
 
 					<dt>If open captions are provided for videos:</dt>
 					<dd>
 						<p data-localization-id="rich-content-open-captions" data-localization-mode="compact">
 							Videos have open captions</p>
-						<p data-localization-id="rich-content-open-captions" data-localization-mode="descriptive">
-								Videos included in publications have open captions</p>
+						<p data-localization-id="rich-content-open-captions" data-localization-mode="descriptive">Videos included in publications have open captions</p>
 					</dd>
 
 					<dt>If transcripts are provided for auditory content:</dt>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -889,8 +889,7 @@
 						<dt>If no metadata is provided:</dt>
 						<dd>
 							<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
-								data-localization-mode="compact">
-								No information about prerecorded audio is available</p>
+								data-localization-mode="compact">No information about prerecorded audio is available</p>
 							<p data-localization-id="ways-of-reading-prerecorded-audio-no-metadata"
 								data-localization-mode="descriptive">No information about prerecorded audio is available</p>
 						</dd>
@@ -1213,21 +1212,16 @@
 								<p>
 									<span
 										data-localization-id="conformance-details-claim"
-										data-localization-mode="compact">This
-										publication claims to meet</span>
+										data-localization-mode="compact">This publication claims to meet</span>
 									<span
 										data-localization-id="conformance-details-epub-accessibility-1-1"
-										data-localization-mode="compact"> EPUB
-										Accessibility
-										1.1</span>
+										data-localization-mode="compact"> EPUB Accessibility 1.1</span>
 									<span
 										data-localization-id="conformance-details-wcag-2-1"
-										data-localization-mode="compact"> WCAG
-										2.1</span>
+										data-localization-mode="compact"> WCAG 2.1</span>
 									<span
 										data-localization-id="conformance-details-level-aa"
-										data-localization-mode="compact"> Level
-										AA</span>
+										data-localization-mode="compact"> Level AA</span>
 								</p>
 								<p><span data-localization-id="conformance-details-certification-info"
 										data-localization-mode="compact">The
@@ -1542,15 +1536,13 @@
 
 					<dt>If closed captions are provided for videos:</dt>
 					<dd>
-						<p data-localization-id="rich-content-closed-captions" data-localization-mode="compact">
-							Videos have closed captions</p>
+						<p data-localization-id="rich-content-closed-captions" data-localization-mode="compact">Videos have closed captions</p>
 						<p data-localization-id="rich-content-closed-captions" data-localization-mode="descriptive">Videos included in publications have closed captions</p>
 					</dd>
 
 					<dt>If open captions are provided for videos:</dt>
 					<dd>
-						<p data-localization-id="rich-content-open-captions" data-localization-mode="compact">
-							Videos have open captions</p>
+						<p data-localization-id="rich-content-open-captions" data-localization-mode="compact">Videos have open captions</p>
 						<p data-localization-id="rich-content-open-captions" data-localization-mode="descriptive">Videos included in publications have open captions</p>
 					</dd>
 

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -1215,7 +1215,7 @@
 					</li>
 					<li>
 						<span><b>IF</b> <var>visible_page_numbering</var>:</span>
-						<span><b>THEN</b> display <code id="additional-accessibility-information-visible-page-numbering">"Visible page numbering "</code>.</span>
+						<span><b>THEN</b> display <code id="additional-accessibility-information-visible-page-numbering">"Visible page numbering"</code>.</span>
 					</li>
 					
 					<li>


### PR DESCRIPTION
Note that the leading whitespace in the conformance statements is correct because those get concatenated to each other.