### PR TITLE
Remove categories in Additional information section

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -2419,6 +2419,7 @@
 					href="https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/guidelines/guidelines-draft-note-20250220.html">2025-02-20
 					Draft Community Group Report</a></summary>
 			<ul>
+			<li>10-apr-2025: Removed the categories in the Additional information section.</li>
 			<li>06-apr-2025: Modified the localization section. Simplifies the description and provide link to the working area for localizations.</li>
 
 			<li>01-apr-2025: Made language improvements in the implementation section.Put the change log in the correct order.</li>

--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -2038,7 +2038,7 @@
 					missing.</p>
 			</div>
 
-			<p>This section lists additional metadata categories that
+			<p>This section lists additional metadata that
 				can help users better understand the
 				accessibility characteristics of digital publications.
 				These are for metadata that do not fit into
@@ -2047,63 +2047,8 @@
 
 			<p>Additional accessibility information includes a wide
 				range of information related to the
-				publication's content. Therefore, the features are
-				grouped below so that the presentation is more
-				understandable. Implementors may choose to group the additional information by these categories in their presentations.</p>
+				publication's content. </p>
 
-<p>The categories are:</p>
-			<dl>
-				<dt>Structure</dt>
-				<dd>
-					<p>For information on any structuring aids that
-						facilitate use of a resource (e.g., ARIA).</p>
-				</dd>
-				<dt>Page breaks</dt>
-				<dd>The inclusion of page break markers from a print
-					source allows users to identify where they are
-					in a digital publication relative to its print
-					equivalent. </dd>
-				<dt>Adaptation</dt>
-				<dd>
-					<p>For information on provisions in the content that
-						enable reading in alternative access modes
-
-						(e.g., ruby annotations, sign
-						language, transcripts).</p>
-
-
-
-				</dd>
-
-
-				<dt>Clarity</dt>
-				<dd>
-					<p>For information on ways that the content has been
-						enhanced for improved auditory or visual
-						clarity (e.g., pronunciation markup).</p>
-				</dd>
-
-				<dt>Tactile</dt>
-				<dd>
-					<p>For information on content that is available in
-						a tactile form (e.g., tactile content, tactile
-						graphics, tactile objects).</p>
-				</dd>
-
-				<!-- maybe we can remove Content
-				<dt>Content</dt>
-				<dd>
-					<p>For information on specific types of content
-						present in the digital publication (e.g., text
-						on visual, music on visual).</p>
-				</dd> -->
-
-				<dt>Other</dt>
-				<dd>
-					<p>For information that does not fall into one of
-						the preceding categories (e.g., timing control).</p>
-				</dd>
-			</dl>
 
 			<section id="add-info-statements">
 				<h4>Display statements</h4>


### PR DESCRIPTION
Removed the description of Additional information categories. Also added this to the change log fixes #672