### PR TITLE
Update all relative paths to use latest link urls

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -12,9 +12,9 @@
 			group: "publishingcg",
 			specStatus: "CG-DRAFT",
 			noRecTrack: true,
-			latestVersion: "https://www.w3.org/publishing/a11y/UX-Guide-metadata/principles/",
+			latestVersion: "https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/",
 			edDraftURI: "https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/",
-			canonicalURI: "https://www.w3.org/publishing/a11y/UX-Guide-metadata/principles/",
+			canonicalURI: "https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/",
 			editors: [
 				{
 					"name": "Charles LaPierre",
@@ -377,10 +377,10 @@
 
 			<ul>
 				<li>
-					<p><a href="../techniques/epub-metadata/index.html">Display Techniques for EPUB Accessibility Metadata 2.0</a></p>
+					<p><a href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/">Display Techniques for EPUB Accessibility Metadata 2.0</a></p>
 				</li>
 				<li>
-					<p><a href="../techniques/onix-metadata/index.html">Display Techniques for ONIX Accessibility Metadata 2.0</a></p>
+					<p><a href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/">Display Techniques for ONIX Accessibility Metadata 2.0</a></p>
 				</li>
 			</ul>
 
@@ -730,11 +730,11 @@
 
 					<ul>
 						<li><a
-								href="../techniques/epub-metadata/index.html#visual-adjustments">EPUB
+								href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/#visual-adjustments">EPUB
 								Accessibility:
 								Visual Adjustments</a></li>
 						<li><a
-								href="../techniques/onix-metadata/index.html#visual-adjustments">ONIX:
+								href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/#visual-adjustments">ONIX:
 								Visual
 								Adjustments</a></li>
 					</ul>
@@ -822,11 +822,11 @@
 
 					<ul>
 						<li><a
-								href="../techniques/epub-metadata/index.html#supports-nonvisual-reading">EPUB
+								href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/#supports-nonvisual-reading">EPUB
 								Accessibility: Support for nonvisual
 								reading</a></li>
 						<li><a
-								href="../techniques/onix-metadata/index.html#supports-nonvisual-reading">ONIX:
+								href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/#supports-nonvisual-reading">ONIX:
 								Support
 								for nonvisual reading</a></li>
 					</ul>
@@ -909,10 +909,10 @@
 						defined in the following documents:</p>
 					<ul>
 						<li><a
-								href="../techniques/epub-metadata/index.html#prerecorded-audio">EPUB
+								href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/#prerecorded-audio">EPUB
 								Accessibility: Prerecorded audio</a></li>
 						<li><a
-								href="../techniques/onix-metadata/index.html#prerecorded-audio">ONIX: Prerecorded audio</a></li>
+								href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/#prerecorded-audio">ONIX: Prerecorded audio</a></li>
 					</ul>
 				</section>
 			</section>
@@ -1324,12 +1324,12 @@
 
 				<ul>
 					<li><a
-							href="../techniques/epub-metadata/index.html#conformance-group">EPUB
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/#conformance-group">EPUB
 							Accessibility:
 							Conformance</a></li>
 
 					<li><a
-							href="../techniques/onix-metadata/index.html#conformance-group">ONIX:
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/#conformance-group">ONIX:
 							Conformance</a></li>
 
 				</ul>
@@ -1467,11 +1467,11 @@
 
 				<ul>
 					<li><a
-							href="../techniques/epub-metadata/index.html#navigation">EPUB
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/#navigation">EPUB
 							Accessibility:
 							Navigation</a></li>
 					<li><a
-							href="../techniques/onix-metadata/index.html#navigation">ONIX:
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/#navigation">ONIX:
 							Navigation</a></li>
 				</ul>
 			</section>
@@ -1622,11 +1622,11 @@
 
 				<ul>
 					<li><a
-							href="../techniques/epub-metadata/index.html#rich-content">EPUB
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/#rich-content">EPUB
 							Accessibility: Rich content</a>
 					</li>
 					<li><a
-							href="../techniques/onix-metadata/index.html#rich-content">ONIX:
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/#rich-content">ONIX:
 							Rich content</a></li>
 				</ul>
 			</section>
@@ -1832,11 +1832,11 @@
 
 				<ul>
 					<li><a
-							href="../techniques/epub-metadata/index.html#hazards">EPUB
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/#hazards">EPUB
 							Accessibility:
 							Hazards</a></li>
 					<li><a
-							href="../techniques/onix-metadata/index.html#hazards">ONIX:
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/#hazards">ONIX:
 							Hazards</a></li>
 				</ul>
 			</section>
@@ -1896,11 +1896,11 @@
 
 				<ul>
 					<li><a
-							href="../techniques/epub-metadata/index.html#accessibility-summary">EPUB
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/#accessibility-summary">EPUB
 							Accessibility:
 							Accessibility Summary</a></li>
 					<li><a
-							href="../techniques/onix-metadata/index.html#accessibility-summary">ONIX:
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/#accessibility-summary">ONIX:
 							Accessibility
 							Summary</a></li>
 				</ul>
@@ -2018,11 +2018,11 @@
 					defined in the following documents:</p>
 				<ul>
 					<li><a
-							href="../techniques/epub-metadata/index.html#legal-considerations">EPUB
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/#legal-considerations">EPUB
 							Accessibility:
 							legal considerations</a></li>
 					<li><a
-							href="../techniques/onix-metadata/index.html#legal-considerations">ONIX:
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/#legal-considerations">ONIX:
 							legal
 							considerations</a></li>
 				</ul>
@@ -2134,10 +2134,10 @@
 
 				<ul>
 					<li><a
-							href="../techniques/epub-metadata/index.html#additional-accessibility-information">EPUB
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/#additional-accessibility-information">EPUB
 							Accessibility: Additional accessibility information</a></li>
 					<li><a
-							href="../techniques/onix-metadata/index.html#additional-accessibility-information">ONIX:
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/#additional-accessibility-information">ONIX:
 							Additional accessibility information</a></li>
 				</ul>
 			</section>

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -11,9 +11,9 @@
 				group: "publishingcg",
 				specStatus: "CG-DRAFT",
 				noRecTrack: true,
-				latestVersion: "https://www.w3.org/publishing/a11y/UX-Guide-metadata/techniques/epub-metadata/",
+				latestVersion: "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/",
 				edDraftURI: "https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/",
-				canonicalURI: "https://www.w3.org/publishing/a11y/UX-Guide-metadata/techniques/epub-metadata/",
+				canonicalURI: "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/",
 				editors: [
 					{
 						"name": "Charles LaPierre",
@@ -75,7 +75,7 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This document provides techniques for meeting the guidelines of the <a href="../../guidelines/"
+			<p>This document provides techniques for meeting the guidelines of the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/"
 					>Accessibility Metadata Display Guide for Digital Publications 2.0</a>. It provides practical
 				examples on how to extract information from an EPUB package document and show it to end users.</p>
 		</section>
@@ -91,7 +91,7 @@
 
 				<div class="note">
 					<p>Techniques for displaying accessibility metadata in other metadata formats can be found in the <a
-							href="../../guidelines/#techniques">Display Techniques for Displaying Accessibility
+							href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#techniques">Display Techniques for Displaying Accessibility
 							Metadata</a>.</p>
 				</div>
 			</section>
@@ -269,7 +269,7 @@
 			<section id="ways-of-reading">
 				<h3>Ways of reading</h3>
 
-				<p>This technique relates to the <a href="../../guidelines/#ways-of-reading">Ways of reading
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#ways-of-reading">Ways of reading
 						accessibility display field</a>.</p>
 
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing
@@ -278,7 +278,7 @@
 				<section id="visual-adjustments">
 					<!-- https://www.w3.org/TR/pub-manifest/#manifest-processing -->
 					<h4>Visual adjustments</h4>
-					<p>This technique relates to the <a href="../../guidelines/#visual-adjustments">Visual adjustments accessibility display field</a>.</p>
+					<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#visual-adjustments">Visual adjustments accessibility display field</a>.</p>
   
 					<h5>Understanding the variables</h5>
 					<dl>
@@ -319,7 +319,7 @@
 				
 				<section id="supports-nonvisual-reading">
 					<h4>Supports nonvisual reading</h4>
-					<p>This technique relates to the <a href="../../guidelines/#supports-nonvisual-reading">Supports
+					<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#supports-nonvisual-reading">Supports
 							nonvisual reading accessibility display field</a>.</p>
 
 					<h5>Understanding the variables</h5>
@@ -414,7 +414,7 @@
 
 				<section id="prerecorded-audio">
 					<h4>Prerecorded audio</h4>
-					<p>This technique relates to the <a href="../../guidelines/#prerecorded-audio">Prerecorded audio
+					<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#prerecorded-audio">Prerecorded audio
 							accessibility display field</a>.</p>
 
 					<h5>Understanding the variables</h5>
@@ -488,7 +488,7 @@
 
 			<section id="conformance-group">
 				<h3>Conformance</h3>
-				<p>This technique relates to the <a href="../../guidelines/#conformance-group">Conformance accessibility
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#conformance-group">Conformance accessibility
 						display field</a>.</p>
 
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing
@@ -677,17 +677,16 @@
 									<li>
 										<span><b>ELSE</b> display <var>certifier_credentials</var> as text.</span>
 									</li>
-                                    <div class="note">
-                                        <p>If the certifier metadata value is a text-based badge or a credential, then only the text is displayed. If the badge or credential is expressed as a URL, then the URL can be made a link for users to access. The display of image logos or badges is typically arranged between the certifier and the distributor. The distributor would be responsible for identifying the certifier's text or link credential and replacing it with the image or linked image.</p>
-                                    </div>
-
 								</ol>
+								<div class="note">
+									<p>If the certifier metadata value is a text-based badge or a credential, then only the text is displayed. If the badge or credential is expressed as a URL, then the URL can be made a link for users to access. The display of image logos or badges is typically arranged between the certifier and the distributor. The distributor would be responsible for identifying the certifier's text or link credential and replacing it with the image or linked image.</p>
+								</div>
 							</li>
 							<li>
 								<div class="note">
 									<p>The instructions from here on define the output for the detailed conformance
 										information. Refer to the <a
-											href="../../guidelines/#detailed-conformance-information">Detailed
+											href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#detailed-conformance-information">Detailed
 											Conformance section</a> in the guidelines for more information on how to
 										present these strings.</p>
 								</div>
@@ -761,7 +760,7 @@
 
 			<section id="navigation">
 				<h3>Navigation</h3>
-				<p>This technique relates to the <a href="../../guidelines/#navigation">Navigation accessibility display field</a>.</p>
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#navigation">Navigation accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing the Package document.</p>
 
 				<h4>Understanding the variables</h4>
@@ -865,7 +864,7 @@
 
 			<section id="rich-content">
 				<h3>Rich content</h3>
-				<p>This technique relates to the <a href="../../guidelines/#rich-content">Rich content accessibility
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#rich-content">Rich content accessibility
 						display field</a>.</p>
 
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing
@@ -1046,7 +1045,7 @@
 
 			<section id="hazards">
 				<h3>Hazards</h3>
-				<p>This technique relates to the <a href="../../guidelines/#hazards">Hazards accessibility display
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#hazards">Hazards accessibility display
 						field</a>.</p>
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing
 					the Package document.</p>
@@ -1231,7 +1230,7 @@
 
 			<section id="accessibility-summary">
 				<h3>Accessibility summary</h3>
-				<p>This technique relates to the <a href="../../guidelines/#accessibility-summary">Accessibility summary
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#accessibility-summary">Accessibility summary
 						accessibility display field</a>.</p>
 
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing
@@ -1305,7 +1304,7 @@
 					section. If you are a publisher, we want your feedback! Please visit the GitHub Issue tracking
 					linked above to leave a comment.</div>
 
-				<p>This technique relates to the <a href="../../guidelines/#legal-considerations">Legal considerations
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#legal-considerations">Legal considerations
 						accessibility display field</a>.</p>
 
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing
@@ -1351,7 +1350,7 @@
 
 			<section id="additional-accessibility-information">
 				<h3>Additional accessibility information</h3>
-				<p>This technique relates to the <a href="../../guidelines/#additional-accessibility-information"
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#additional-accessibility-information"
 						>Additional accessibility information accessibility display field</a>.</p>
 
 				<p>This algorithm takes the <var>package_document_as_text</var> argument: a UTF-8 string representing

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -11,9 +11,9 @@
 				group: "publishingcg",
 				specStatus: "CG-DRAFT",
 				noRecTrack: true,
-				latestVersion: "https://www.w3.org/publishing/a11y/UX-Guide-metadata/techniques/onix-metadata/",
+				latestVersion: "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/",
 				edDraftURI: "https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/",
-				canonicalURI: "https://www.w3.org/publishing/a11y/UX-Guide-metadata/techniques/onix-metadata/",
+				canonicalURI: "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/",
 				editors: [
 					{
 						"name": "Gregorio Pellegrino",
@@ -87,7 +87,7 @@
 	<body>
 		<section id="abstract">
 			<p>This document provides techniques for meeting the guidelines of the 
-				<a href="../../guidelines/">Accessibility Metadata Display Guide for Digital Publications 2.0</a>.
+				<a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/">Accessibility Metadata Display Guide for Digital Publications 2.0</a>.
 				It provides practical examples on how to extract information from an ONIX record and show it to 
 				end users.</p>
 		</section>
@@ -113,7 +113,7 @@
         		</p>
         		
         		<div class="note">
-        			<p>Techniques for displaying accessibility metadata in other metadata formats can be found in the <a href="../../guidelines/#techniques">Display Techniques for Displaying Accessibility Metadata</a></p>
+        			<p>Techniques for displaying accessibility metadata in other metadata formats can be found in the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#techniques">Display Techniques for Displaying Accessibility Metadata</a></p>
         		</div>
         	</section>
             
@@ -250,14 +250,14 @@
 			<section id="ways-of-reading">
                 <h3>Ways of reading</h3>
 
-                <p>This technique relates to the <a href="../../guidelines/#ways-of-reading">Ways of reading accessibility display field</a>.</p>
+                <p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#ways-of-reading">Ways of reading accessibility display field</a>.</p>
   
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 
 
 				<section id="visual-adjustments">
 					<h3>Visual adjustments</h3>
-					<p>This technique relates to the <a href="../../guidelines/#visual-adjustments">Visual adjustments accessibility display field</a>.</p>
+					<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#visual-adjustments">Visual adjustments accessibility display field</a>.</p>
 					<h4>Understanding the variables</h4>
 					<dl>
 						<dt><var>all_textual_content_can_be_modified</var></dt>
@@ -293,7 +293,7 @@
 	
 				<section id="supports-nonvisual-reading">
 					<h3>Supports nonvisual reading</h3>
-					<p>This technique relates to the <a href="../../guidelines/#supports-nonvisual-reading">Supports nonvisual reading accessibility display field</a>.</p>
+					<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#supports-nonvisual-reading">Supports nonvisual reading accessibility display field</a>.</p>
 					<h4>Understanding the variables</h4>
 					<dl>
 						<dt><var>all_necessary_content_textual</var></dt>
@@ -355,7 +355,7 @@
 				
 				<section id="prerecorded-audio">
 					<h3>Prerecorded audio</h3>
-					<p>This technique relates to the <a href="../../guidelines/#prerecorded-audio">Pre-recorded audio accessibility display field</a>.</p>
+					<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#prerecorded-audio">Pre-recorded audio accessibility display field</a>.</p>
 					<h4>Understanding the variables</h4>
 					<dl>
 						<dt><var>all_content_audio</var></dt>
@@ -439,7 +439,7 @@
 
 			<section id="conformance-group">
 				<h3>Conformance</h3>
-				<p>This technique relates to the <a href="../../guidelines/#conformance-group">Conformance accessibility display field</a>.</p>
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#conformance-group">Conformance accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
@@ -575,7 +575,7 @@
 						<div class="note">
 							<p>The instructions from here on define the output for the detailed conformance
 								information. Refer to the 
-								<a href="../../guidelines/#detailed-conformance-information">Detailed Conformance section</a>
+								<a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#detailed-conformance-information">Detailed Conformance section</a>
 								in the guidelines for more information on how to present these strings.</p>
 						</div>
 						
@@ -631,7 +631,7 @@
 
 			<section id="navigation">
 				<h3>Navigation</h3>
-				<p>This technique relates to the <a href="../../guidelines/#navigation">Navigation accessibility display field</a>.</p>
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#navigation">Navigation accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
@@ -695,7 +695,7 @@
 
 			<section id="rich-content">
 				<h3>Rich content</h3>
-				<p>This technique relates to the <a href="../../guidelines/#rich-content">Rich content accessibility display field</a>.</p>
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#rich-content">Rich content accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
@@ -811,7 +811,7 @@
 
 			<section id="hazards">
 				<h3>Hazards</h3>
-				<p>This technique relates to the <a href="../../guidelines/#hazards">Hazards accessibility display field</a>.</p>
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#hazards">Hazards accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
@@ -949,7 +949,7 @@
 
 			<section id="accessibility-summary">
 				<h3>Accessibility summary</h3>
-				<p>This technique relates to the <a href="../../guidelines/#accessibility-summary">Accessibility summary accessibility display field</a>.</p>
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#accessibility-summary">Accessibility summary accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<aside class="note">
 					Being human-written, the accessibility summary and addendum will appear in the original language of the publication. Therefore it is necessary of take care of setting up the correct language tag information.
@@ -1064,7 +1064,7 @@
 			<section id="legal-considerations">
 				<h3>Legal considerations</h3>
 				<p class="issue" data-number="350">We are actively seeking comments on this "legal consideration" section. If you are a publisher, we want your feedback! Please visit the GitHub Issue tracking linked above to leave a comment.</p>
-				<p>This technique relates to the <a href="../../guidelines/#legal-considerations">Legal considerations accessibility display field</a>.</p>
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#legal-considerations">Legal considerations accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 				<h4>Understanding the variables</h4>
 				<dl>
@@ -1105,7 +1105,7 @@
 
 			<section id="additional-accessibility-information">
 				<h3>Additional accessibility information</h3>
-				<p>This technique relates to the <a href="../../guidelines/#additional-accessibility-information">Additional accessibility information accessibility display field</a>.</p>
+				<p>This technique relates to the <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/#additional-accessibility-information">Additional accessibility information accessibility display field</a>.</p>
 				<p>This algorithm takes the <var>onix_record_as_text</var> argument: a UTF-8 string representing the ONIX record.</p>
 
 		

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -566,10 +566,10 @@
 						<ol class="display">
 							<li>display <code id="conformance-certifier-credentials">"The certifier's credential is"</code></li>
 							<li>display <var>certifier_credentials</var> as link <b>IF</b> <var>certifier_credentials</var> is an URL.</li>
-                            <div class="note">
-                                <p>If the certifier metadata value is a text-based badge or a credential, then only the text is displayed. If the badge or credential is expressed as a URL, then the URL can be made a link for users to access. The display of image logos or badges is typically arranged between the certifier and the distributor. The distributor would be responsible for identifying the certifier's text or link credential and replacing it with the image or linked image.</p>
-                            </div>
 						</ol>
+						<div class="note">
+							<p>If the certifier metadata value is a text-based badge or a credential, then only the text is displayed. If the badge or credential is expressed as a URL, then the URL can be made a link for users to access. The display of image logos or badges is typically arranged between the certifier and the distributor. The distributor would be responsible for identifying the certifier's text or link credential and replacing it with the image or linked image.</p>
+						</div>
 					</li>
 					<li>
 						<div class="note">


### PR DESCRIPTION
This is prep for the final release of the guidelines. It changes all the relative path linking between documents to use the new latest link urls. These urls are not yet active, so they won't work until we finalize the publication date and publish. We can merge this as we get closer to publishing.

(We can't keep the current relative paths as the publishing process requires a flat directory structure and I'm not sure it'd be wise to assume the documents could reference each other using relative paths after publishing even if we tried to tweak them.)