### PR TITLE
Add shortnames to the display guide files

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -9,6 +9,7 @@
 	<script class="remove">
 		// <![CDATA[
 		var respecConfig = {
+			shortName: "a11y-display-guidelines",
 			group: "publishingcg",
 			specStatus: "CG-DRAFT",
 			noRecTrack: true,

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -8,6 +8,7 @@
 		<script class="remove">
 			// <![CDATA[
 			var respecConfig = {
+				shortName: "epub-techniques",
 				group: "publishingcg",
 				specStatus: "CG-DRAFT",
 				noRecTrack: true,

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -8,6 +8,7 @@
 		<script class="remove">
 			// <![CDATA[
 			var respecConfig = {
+				shortName: "onix-techniques",
 				group: "publishingcg",
 				specStatus: "CG-DRAFT",
 				noRecTrack: true,


### PR DESCRIPTION
We forgot to add these to the respec metadata and when I exported the files to publish respec instead inserted the repository name into the final report URLs.