### PR TITLE
Note the limitations of the node selectors

### DIFF
--- a/a11y-meta-display-guide/2.1/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.1/draft/techniques/epub-metadata/index.html
@@ -173,6 +173,9 @@
 
 					<p>Translation of these XPath selectors may be necessary if the input record is transformed into
 						another form, such as a JSON structure.</p>
+					
+					<p>Note that the node selectors in this document only account for EPUB 3 metadata. To process 
+						EPUB 2 publications, compatible XPaths will need to be provided.</p>
 				</section>
 
 				<section id="output-statements">
@@ -243,15 +246,11 @@
 				<p>Many of the techniques rely on checking for the presence or absence of metadata in the metadata
 					section of the Package document.</p>
 
-				<aside class="note">
-					<p>All XPATHs are made for EPUB 3, while for EPUB 2 they would need to be adjusted.</p>
-				</aside>
-
 				<p>This algorithm takes:</p>
 				<ul>
 					<li>the <var>package_document</var> argument: the internal representation of the Package document
 						(output of <a href="#pre-processing">preprocessing</a>);</li>
-					<li>the <var>path</var> argument: the XPATH of the node to check the presence of.</li>
+					<li>the <var>path</var> argument: the XPath of the node to check the presence of.</li>
 				</ul>
 				<p>To check for node, run the following steps:</p>
 				<ol class="condition">

--- a/a11y-meta-display-guide/2.1/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.1/draft/techniques/onix-metadata/index.html
@@ -229,7 +229,7 @@
 					<li>return <var>onix</var>.</li>
 				</ul>
 				<aside class="note">
-					<p>The XML file being processed may contain namespaces, in the techniques when we use XPATH we will assume that the default namespace of the root record is used.</p>
+					<p>The XML file being processed may contain namespaces, in the techniques when we use XPath we will assume that the default namespace of the root record is used.</p>
 				</aside>
 			</section>
 			<section id="check-for-node">
@@ -238,7 +238,7 @@
 				<p>This algorithm takes:</p>
 				<ul>
 					<li>the <var>onix</var> argument: the internal representation of ONIX record (output of <a href="#preprocessing">preprocessing</a>);</li>
-					<li>the <var>path</var> argument: the XPATH of the node to check the presence of.</li>
+					<li>the <var>path</var> argument: the XPath of the node to check the presence of.</li>
 				</ul>
 				<p>To check for node, run the following steps:</p>
 				<ol class="condition">

--- a/a11y-meta-display-guide/2.1/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.1/draft/techniques/onix-metadata/index.html
@@ -171,6 +171,12 @@
 					
 					<p>Translation of these XPath selectors may be necessary if the input record is transformed into
 						another form, such as a JSON structure.</p>
+					
+					<p>Note that the node selectors in this document only account for ONIX records that use <a 
+							href="https://www.editeur.org/74/faqs/#q10">reference names</a>. To process records that 
+						use short tags, the records will either need to be <a 
+							href="https://www.editeur.org/93/release-3.0-downloads/#Tools">transformed to use reference
+							names</a> or compatible XPaths will need to be provided.</p>
 				</section>
 				
 				<section id="output-statements">
@@ -206,7 +212,6 @@
 				</section>
 			</section>
 		</section>
-	
 		<section id="common-functions">
 			<h2>Common Functions</h2>
 			<p>In this section we define the functions common to all techniques, which are called by them during execution.</p>


### PR DESCRIPTION
Makes it specific in the node selectors section that the xpaths only apply to epub 3 and onix records that use reference names.

Fixes #713  

***

[EPUB Preview](https://raw.githack.com/w3c/publ-a11y/fix/issue-713/a11y-meta-display-guide/2.1/draft/techniques/epub-metadata/index.html) | [EPUB Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.1/draft/techniques/epub-metadata/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/issue-713/a11y-meta-display-guide/2.1/draft/techniques/epub-metadata/index.html)
[ONIX Preview](https://raw.githack.com/w3c/publ-a11y/fix/issue-713/a11y-meta-display-guide/2.1/draft/techniques/onix-metadata/index.html) | [ONIX Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.1/draft/techniques/onix-metadata/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/fix/issue-713/a11y-meta-display-guide/2.1/draft/techniques/onix-metadata/index.html)
