### PR TITLE
Restructure the metadata guide

### DIFF
--- a/epub-a11y-meta-guide/1.0/draft/index.html
+++ b/epub-a11y-meta-guide/1.0/draft/index.html
@@ -66,7 +66,6 @@
                 }
             };//]]>
       </script>
-
 		<style>
 			/*prevent examples from horizontal scrolling*/
 			pre {
@@ -75,27 +74,49 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p></p>
+			<p>The EPUB Accessibility Metadata Guide details when to set the Schema.org accessibility metadata
+				properties in the EPUB package document.</p>
+			<p>This guide only details usage for EPUB publications. The guidance in this document may not be relevant to
+				other formats.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="toc"></section>
 		<section id="introduction">
 			<h2>Introduction</h2>
+
+			<p>Schema.org [[schema-org]] is described as a <q>collaborative, community activity with a mission to
+					create, maintain, and promote schemas for structured data.</q> Of particular importance is that it
+				includes the following set of accessibility properties for describing creative works:</p>
+
+			<ul>
+				<li><a href="https://schema.org/accessMode">accessMode</a></li>
+				<li><a href="https://schema.org/accessModeSufficient">accessModeSufficient</a></li>
+				<li><a href="https://schema.org/accessibilityFeature">accessibilityFeature</a></li>
+				<li><a href="https://schema.org/accessibilityHazard">accessibilityHazard</a></li>
+				<li><a href="https://schema.org/accessibilitySummary">accessibilitySummary</a></li>
+			</ul>
+
+			<p>These properties are key to the discoverability of EPUB publications and are central to the requirements
+				of the EPUB Accessibility standard [[epub-a11y]]. They are also used to generate accessibility
+				statements about a publication, as described in the <a
+					href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/">Accessibility Metadata
+					Display Guide for Digital Publications</a>.</p>
+
+			<p>To provide maximum value for readers, the metadata needs to be consistent, which is where the <a
+					href="https://www.w3.org/2021/a11y-discov-vocab/latest/">Schema.org Accessibility Properties for
+					Discoverability Vocabulary</a> [[a11y-discov-vocab]] comes in. This vocabulary defines controlled
+				sets values to use with each property (with the exception of summaries, which are free-form text).</p>
+
+			<p>But even with a controlled vocabulary, as schema.org is intended to describe any resource on or
+				referenced from the web, the value definitions do not always fully reflect how to apply them to EPUB
+				publications. That is where this guide fits in. Its goal is add clarity on how to apply the metadata to
+				both reflowable and fixed-layout EPUB publications.</p>
 		</section>
-		<section id="metadata">
-			<h2>Accessibility metadata</h2>
+		<section id="accessMode">
+			<h2>Access modes</h2>
 
-			<p>This metadata as outlined in EPUB Accessibility 1.1 [[epub-a11y-11]], can be found in the EPUB package
-				document [[EPUB-33]].</p>
-
-			<div class="note">
-				<p>For the complete list of approved terms to use with these properties, refer to the <a
-						href="https://www.w3.org/2021/a11y-discov-vocab/latest/">Schema.org Accessibility Properties for
-						Discoverability Vocabulary</a> [[a11y-discov-vocab]].</p>
-			</div>
-
-			<section id="accessMode">
-				<h3>Access modes</h3>
+			<section id="accessmode-overview">
+				<h3>Overview</h3>
 
 				<p>An access mode is defined as a "human sense perceptual system or cognitive faculty through which a
 					user may process or perceive the content of a digital resource." [[iso24751-3]] For example, if an
@@ -122,10 +143,17 @@
 							and tactile diagrams.</p>
 					</li>
 				</ul>
+			</section>
+
+			<section id="accessmode-general">
+				<h3>General application guidelines</h3>
+
+				<p>Access modes are set in the [[schema-org]] <a href="https://schema.org/accessMode"
+							><code>accessMode</code> property</a>. Repeat the property for each access mode.</p>
 
 				<p>For a user to determine whether an EPUB publication is suitable for their needs, they need to know
-					which of these access modes are required to consume the content. List all applicable access modes in
-					the [[schema-org]] <a href="https://schema.org/accessMode"><code>accessMode</code> property</a>,
+					which access modes are required to consume the content. List all applicable access modes in the
+						[[schema-org]] <a href="https://schema.org/accessMode"><code>accessMode</code> property</a>,
 					repeating the property for each applicable mode.</p>
 
 				<aside class="example" title="Metadata entries for textual and visual access modes">
@@ -153,67 +181,66 @@
 					access mode. See the following section on <a href="#accessModeSufficient">sufficient access
 						modes</a> for how to indicate that the available adaptations allow the content to be consumed in
 					another mode.</p>
+			</section>
 
-				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessMode">The
-							<code>accessMode</code> Property</a> [[a11y-discov-vocab]] for more information about this
-					property and its values.</p>
+			<section id="accessmode-values">
+				<h3>Setting values</h3>
 
-				<section id="accessmode-visual">
-					<h4>Access mode: visual</h4>
+				<section id="accessmode-primary">
+					<h4>Primary access modes</h4>
 
-					<p>Indicates that the resource contains information encoded in visual form.</p>
+					<section id="accessmode-auditory">
+						<h5>Auditory</h5>
 
-					<div class="note">
-						<p>This value is not set if the only visual imagery is presentational or not directly relevant
-							to understanding the content.</p>
+						<p>Indicates that the resource contains information encoded in auditory form.</p>
 
-						<p>If the only images within the EPUB are: cover, author, corporate logos, or decorative images
-							the <code>accessMode</code> of 'visual' would not be included in the metadata.</p>
-					</div>
-
-					<aside id="example-access-mode-visual" class="example" title="AccessMode: Visual">
-						<p>The following two examples shows a visual only image being presented. This would not be
-							accessible and would fail <a href="https://www.w3.org/TR/WCAG22/#non-text-content">WCAG
-								1.1.1 (Non Text Content)</a> since there is no alt text description provided.</p>
-						<pre>
-                            <code>
-                            &lt;p&gt;
-                                &lt;img src="images/hawk.jpg"&gt;
-                            &lt;/p&gt;
-                            
-                            or
-                            
-                            &lt;div style="background-image: url('images/hawk.jpg')"&gt;&lt;/div&gt;
-                            </code>
-                        </pre>
-						<p>The metadata to included in the package document would be:</p>
-						<pre>
-                            <code>
-                            &lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
-                            </code>
-                        </pre>
 						<div class="note">
-							<p>In the <a href="#example-access-mode-visual">Example: AccessMode: Visual</a> no alt text
-								description of the image was provided, demonstrating the single metadata
-									<code>accessMode</code> of "visual". If however, the example included an alt text
-								description for the image both the <code>accessMode</code> of 'visual' and 'textual'
-								would be included in the metadata.</p>
+							<p>This value is not set when the auditory content conveys no information. For example, an
+								instructional video might include background music while all the necessary information
+								to complete the task is conveyed visually and/or through text captions.</p>
 						</div>
-					</aside>
-				</section>
+						<aside class="example" title="AccessMode: Auditory">
+							<pre>
+                            <code>
+                            &lt;figure&gt;
+                               &lt;audio controls&gt;
+                                   &lt;source src="audiofile.mp3" type="audio/mpeg"&gt;
+                                   Your browser does not support the audio element.
+                               &lt;/audio&gt;
+                               &lt;figcaption&gt;Interview with Dr. Smith about climate change research&lt;/figcaption&gt;
+                            &lt;/figure&gt;                            
+                            </code>
+                        </pre>
+							<p>The metadata to included in the package document would be:</p>
+							<pre>
+                            <code>
+                            &lt;meta property="schema:accessMode"&gt;auditory&lt;/meta&gt;
+                            </code>
+                            In addition, since there is a textual figcaption description present the additional metadata would be also included:
+                            <code>
+                            &lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
+                            </code>
+                        </pre>
+							<div class="note">
+								<p>Ideally there would also be a textual transcript included, and depending on its
+									existance this would affect the accessModeSufficient metadata inclusion of
+									'textual'.</p>
+							</div>
+						</aside>
+					</section>
 
-				<section id="accessmode-textual">
-					<h4>Access mode: textual</h4>
+					<section id="accessmode-textual">
+						<h5>Textual</h5>
 
-					<p>Indicates that the resource contains information encoded in textual form.</p>
-					<div class="note">
-						<p>This value is not set if the only textual content is for navigational purposes. For example,
-							an audiobook might include a table of contents, but it is not necessary to read the table of
-							contents to read the work. Likewise, books with synchronized text-audio playback may only
-							include headings to allow structured navigation.</p>
-					</div>
-					<aside class="example" title="AccessMode: Textual">
-						<pre>
+						<p>Indicates that the resource contains information encoded in textual form.</p>
+						<div class="note">
+							<p>This value is not set if the only textual content is for navigational purposes. For
+								example, an audiobook might include a table of contents, but it is not necessary to read
+								the table of contents to read the work. Likewise, books with synchronized text-audio
+								playback may only include headings to allow structured navigation.</p>
+						</div>
+						<aside class="example" title="AccessMode: Textual">
+							<pre>
                             <code>
                              &lt;p&gt;
                                 The red-tailed hawk is one of North America's most widespread raptors.
@@ -222,9 +249,9 @@
                                 These majestic birds can often be seen soaring high above open fields, scanning for prey with their keen eyesight.
                             &lt;/p&gt;                            </code>
                         </pre>
-						<p>Since there is textual content within the EPUB, the metadata to included in the package
-							document would be:</p>
-						<pre>
+							<p>Since there is textual content within the EPUB, the metadata to included in the package
+								document would be:</p>
+							<pre>
                             <code>
                             &lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
                             </code>
@@ -237,63 +264,74 @@
                             &lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
                             </code>
                         </pre>
-					</aside>
-				</section>
+						</aside>
+					</section>
 
-				<section id="accessmode-auditory">
-					<h4>Access mode: auditory</h4>
+					<section id="accessmode-visual">
+						<h5>Visual</h5>
 
-					<p>Indicates that the resource contains information encoded in auditory form.</p>
+						<p>Indicates that the resource contains information encoded in visual form.</p>
 
-					<div class="note">
-						<p>This value is not set when the auditory content conveys no information. For example, an
-							instructional video might include background music while all the necessary information to
-							complete the task is conveyed visually and/or through text captions.</p>
-					</div>
-					<aside class="example" title="AccessMode: Auditory">
-						<pre>
-                            <code>
-                            &lt;figure&gt;
-                               &lt;audio controls&gt;
-                                   &lt;source src="audiofile.mp3" type="audio/mpeg"&gt;
-                                   Your browser does not support the audio element.
-                               &lt;/audio&gt;
-                               &lt;figcaption&gt;Interview with Dr. Smith about climate change research&lt;/figcaption&gt;
-                            &lt;/figure&gt;                            
-                            </code>
-                        </pre>
-						<p>The metadata to included in the package document would be:</p>
-						<pre>
-                            <code>
-                            &lt;meta property="schema:accessMode"&gt;auditory&lt;/meta&gt;
-                            </code>
-                            In addition, since there is a textual figcaption description present the additional metadata would be also included:
-                            <code>
-                            &lt;meta property="schema:accessMode"&gt;textual&lt;/meta&gt;
-                            </code>
-                        </pre>
 						<div class="note">
-							<p>Ideally there would also be a textual transcript included, and depending on its existance
-								this would affect the accessModeSufficient metadata inclusion of 'textual'.</p>
+							<p>This value is not set if the only visual imagery is presentational or not directly
+								relevant to understanding the content.</p>
+
+							<p>If the only images within the EPUB are: cover, author, corporate logos, or decorative
+								images the <code>accessMode</code> of 'visual' would not be included in the
+								metadata.</p>
 						</div>
-					</aside>
+
+						<aside id="example-access-mode-visual" class="example" title="AccessMode: Visual">
+							<p>The following two examples shows a visual only image being presented. This would not be
+								accessible and would fail <a href="https://www.w3.org/TR/WCAG22/#non-text-content">WCAG
+									1.1.1 (Non Text Content)</a> since there is no alt text description provided.</p>
+							<pre>
+                            <code>
+                            &lt;p&gt;
+                                &lt;img src="images/hawk.jpg"&gt;
+                            &lt;/p&gt;
+                            
+                            or
+                            
+                            &lt;div style="background-image: url('images/hawk.jpg')"&gt;&lt;/div&gt;
+                            </code>
+                        </pre>
+							<p>The metadata to included in the package document would be:</p>
+							<pre>
+                            <code>
+                            &lt;meta property="schema:accessMode"&gt;visual&lt;/meta&gt;
+                            </code>
+                        </pre>
+							<div class="note">
+								<p>In the <a href="#example-access-mode-visual">Example: AccessMode: Visual</a> no alt
+									text description of the image was provided, demonstrating the single metadata
+										<code>accessMode</code> of "visual". If however, the example included an alt
+									text description for the image both the <code>accessMode</code> of 'visual' and
+									'textual' would be included in the metadata.</p>
+							</div>
+						</aside>
+					</section>
 				</section>
 
-				<section id="accessmode-text-on-visual">
-					<h4>Access mode: Text On Visual</h4>
+				<section id="accessmode-visual-indicators">
+					<h4>Visual content indicators</h4>
 
-					<p>Indicates that the resource contains text encoded in visual form.</p>
+					<section id="accessmode-text-on-visual">
+						<h5>Text On visual</h5>
 
-					<aside id="example-access-mode-text-on-visual" class="example" title="AccessMode: Text On Visual">
-						<pre>
+						<p>Indicates that the resource contains text encoded in visual form.</p>
+
+						<aside id="example-access-mode-text-on-visual" class="example"
+							title="AccessMode: Text On Visual">
+							<pre>
                             <code>
                             &lt;p&gt;
                                 &lt;img src="images/newspaper-clipping.jpg" alt="Newspaper Clipping: Climate Crisis: Local Scientist Speaks Out. By Jane Wilson. Our measurements indicate a 2.3°C increase over the past decade alone."&gt;
                             &lt;/p&gt;
                             </code>
                         </pre>
-						<p>The metadata to included in the package document would be:</p>
-						<pre>
+							<p>The metadata to included in the package document would be:</p>
+							<pre>
                             <code>
                             &lt;meta property="schema:accessMode"&gt;textOnVisual&lt;/meta&gt;
                             </code>
@@ -304,85 +342,93 @@
                             &lt;meta property="schema:accessibilityFeature"&gt;alternativeText&lt;/meta&gt;
                             </code>
                         </pre>
-					</aside>
+						</aside>
+					</section>
 				</section>
-			
+
 				<section id="accessMode-sync">
-					<h3>Setting access modes for synchronized text-audio</h3>
-					
+					<h4>Synchronized text and audio</h4>
+
 					<p>Setting the correct access modes and sufficient access modes for EPUB 3 publications that contain
-						synchronized text-audio playback requires evaluating whether playback is essential to reading the
-						publication or an additional feature.</p>
-					
+						synchronized text-audio playback requires evaluating whether playback is essential to reading
+						the publication or an additional feature.</p>
+
 					<p>EPUB 3's <a href="https://www.w3.org/TR/epub/#sec-media-overlays">media overlays</a> [[epub-3]]
-						allows EPUB creators to synchronize the full text of a publication with full audio narration. These
-						types of publications are commonly referred to as "read aloud" books, as the user chooses whether or
-						not to turn on the narration (unlike traditional audiobooks where only the audio is available).</p>
-					
+						allows EPUB creators to synchronize the full text of a publication with full audio narration.
+						These types of publications are commonly referred to as "read aloud" books, as the user chooses
+						whether or not to turn on the narration (unlike traditional audiobooks where only the audio is
+						available).</p>
+
 					<p>In this case, because the audio playback is an extra feature, EPUB creators would
-						<strong>not</strong> list "<code>auditory</code>" as an <a href="#accessMode">access mode</a>.
-						Rather, they would indicate the presence of text and audio synchronization as an <a
-							href="#accessMode-sync">accessibility feature</a>:</p>
-					
+							<strong>not</strong> list "<code>auditory</code>" as an <a href="#accessMode">access
+							mode</a>. Rather, they would indicate the presence of text and audio synchronization as an
+							<a href="#accessMode-sync">accessibility feature</a>:</p>
+
 					<pre>&lt;meta
     property="schema:accessibilityFeature">
    synchronizedAudioText
 &lt;/meta></pre>
-					
-					<p>Although the audio is not essential to reading the publication, having full audio playback capability
-						means that there is an auditory <a href="#accessModeSufficient">sufficient access mode</a> &#8212;
-						the user can listen to the complete publication. Consequently, the EPUB creator would declare a
-						<code>schema:accessModeSufficient</code> property with the value <code>auditory</code>:</p>
-					
+
+					<p>Although the audio is not essential to reading the publication, having full audio playback
+						capability means that there is an auditory <a href="#accessModeSufficient">sufficient access
+							mode</a> &#8212; the user can listen to the complete publication. Consequently, the EPUB
+						creator would declare a <code>schema:accessModeSufficient</code> property with the value
+							<code>auditory</code>:</p>
+
 					<pre>&lt;meta
     property="schema:accessModeSufficient">
    auditory
 &lt;/meta></pre>
-					
+
 					<div class="note">
-						<p>When media overlays are present, EPUB creators should not add "<code>auditory</code>" to all the
-							possible sufficient access modes just because it is possible to turn on text-audio playback.</p>
-						
-						<p>For example, a publication with media overlays that has text and images (with text alternatives)
-							would only declare the following sufficient access modes: "<code>textual</code>",
-							"<code>auditory</code>", and "<code>textual,visual</code>".</p>
-						
+						<p>When media overlays are present, EPUB creators should not add "<code>auditory</code>" to all
+							the possible sufficient access modes just because it is possible to turn on text-audio
+							playback.</p>
+
+						<p>For example, a publication with media overlays that has text and images (with text
+							alternatives) would only declare the following sufficient access modes:
+								"<code>textual</code>", "<code>auditory</code>", and "<code>textual,visual</code>".</p>
+
 						<p>It would <strong>not</strong> declare "<code>textual,auditory</code>" or
-							"<code>textual,visual,auditory</code>".</p>
+								"<code>textual,visual,auditory</code>".</p>
 					</div>
-					
-					<p>Another use for media overlays &#8212; more typical among accessible republishers such as libraries
-						that serve blind and low vision readers &#8212; is to provide full audio synchronized to the major
-						headings of a publication. These types of publications are more like traditional audiobooks, as all
-						the information in the work is typically available in auditory form. The minimal text does not allow
-						meaningful visual reading or text-to-speech playback; it is only to provide structured navigation
-						capabilities.</p>
-					
+
+					<p>Another use for media overlays &#8212; more typical among accessible republishers such as
+						libraries that serve blind and low vision readers &#8212; is to provide full audio synchronized
+						to the major headings of a publication. These types of publications are more like traditional
+						audiobooks, as all the information in the work is typically available in auditory form. The
+						minimal text does not allow meaningful visual reading or text-to-speech playback; it is only to
+						provide structured navigation capabilities.</p>
+
 					<p>In this case, being able to hear the audio is essential to being able to read the publication, so
 						EPUB creators will list an auditory access mode:</p>
-					
+
 					<pre>&lt;meta
     property="schema:accessMode">
    auditory
 &lt;/meta></pre>
-					
-					<p>In a reverse of the first case discussed, EPUB creators will <strong>not</strong> identify text-audio
-						synchronization as a feature of the publication since the amount of text provided is trivial.</p>
-					
+
+					<p>In a reverse of the first case discussed, EPUB creators will <strong>not</strong> identify
+						text-audio synchronization as a feature of the publication since the amount of text provided is
+						trivial.</p>
+
 					<p>Likewise, since the text in the publication only provides heading navigation, EPUB creators will
-						<strong>not</strong> list a textual access mode. The user does not need to, and is not expected
-						to, visually read this text.</p>
-					
+							<strong>not</strong> list a textual access mode. The user does not need to, and is not
+						expected to, visually read this text.</p>
+
 					<div class="note">
-						<p>Some publications that provide the body in auditory form may include the backmatter in text form,
-							allowing users to use text-to-speech playback to render it. In this case, there would be a
-							textual component.</p>
+						<p>Some publications that provide the body in auditory form may include the backmatter in text
+							form, allowing users to use text-to-speech playback to render it. In this case, there would
+							be a textual component.</p>
 					</div>
 				</section>
 			</section>
+		</section>
+		<section id="accessModeSufficient">
+			<h2>Sufficient access modes</h2>
 
-			<section id="accessModeSufficient">
-				<h3>Sufficient access modes</h3>
+			<section id="ams-overview">
+				<h3>Overview</h3>
 
 				<p>The access modes sufficient to consume an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication"
 						>EPUB publication</a> express a broader picture of the potential usability than do the <a
@@ -391,6 +437,10 @@
 					modes, and sets of modes, that allow a user to read a publication. Sufficient access modes account
 					for the affordances and adaptations that the EPUB creators have provided, allowing users to
 					determine whether they can the read content regardless of its default nature.</p>
+			</section>
+
+			<section id="ams-general">
+				<h3>General application guidelines</h3>
 
 				<p>Sufficient access modes are identified in the [[schema-org]] <a
 						href="https://schema.org/accessModeSufficient"><code>accessModeSufficient</code> property</a>.
@@ -512,24 +562,33 @@
 						of EPUB might allow for richer metadata, but the basic expression shown in this section is
 						sufficient for discovery purposes.</p>
 				</div>
+			</section>
 
-				<section>
-					<h4>Single Values</h4>
+			<section id="ams-values">
+				<h3>Setting values</h3>
 
-					<p>Having a single <code>accessMode</code> implies that the entire content of the EPUB can be
-						consumed with only that mode of accessing the content within the book.</p>
+				<section id="ams-single-values">
+					<h4>Single reading modes</h4>
+
+					<p>Having a single <code>accessModeSufficient</code> implies that the entire content of the EPUB can
+						be consumed with only that mode of accessing the content within the book.</p>
 
 					<section id="metadata-access-mode-sufficient-visual">
-						<h5>AccessModeSufficient: Visual</h5>
+						<h5>Visual-only readability</h5>
+
 						<p>Indicates that only visual perception is necessary to consume the information.</p>
+
 						<p>An example of this would be a children's picture book.</p>
+
 						<aside id="example-access-mode-sufficient-visual" class="example"
 							title="AccessModeSufficient: Visual">
 							<pre>
                                  Content files includes:
                                     Only images, (i.e. no text, audio, or tactile content)
                             </pre>
+
 							<p>The metadata to included in the package document would be:</p>
+
 							<pre>
                                 <code>
                                 &lt;meta property="schema:accessModeSufficient"&gt;visual&lt;/meta&gt;
@@ -543,13 +602,17 @@
 					</section>
 
 					<section id="metadata-access-mode-sufficient-textual">
-						<h5>AccessModeSufficient: Textual</h5>
+						<h5>Textual-only readability</h5>
+
 						<p>Indicates that the ability to read textual content is necessary to consume the
 							information.</p>
+
 						<p>Note that reading textual content does not require visual perception, as textual content can
 							be rendered as audio using a text-to-speech capable device or embossed as braille for
 							tactile reading.</p>
+
 						<p>An example of this would be a romance novel.</p>
+
 						<aside class="example" title="AccessModeSufficient: Tactile">
 							<pre>
                                  Content files includes:
@@ -569,7 +632,7 @@
 					</section>
 
 					<section id="metadata-access-mode-sufficient-auditory">
-						<h5>AccessModeSufficient: Auditory</h5>
+						<h5>Auditory-only readability</h5>
 
 						<p>Indicates that auditory perception is necessary to consume the information.</p>
 
@@ -580,7 +643,9 @@
                                 Content files includes:
                                      Only audio, (i.e no text, images, or tactile content)
                             </pre>
+
 							<p>The metadata to included in the package document would be:</p>
+
 							<pre>
                                 <code>
                                 &lt;meta property="schema:accessModeSufficient"&gt;auditory&lt;/meta&gt;
@@ -594,16 +659,20 @@
 					</section>
 				</section>
 
-				<section>
-					<h4>Combined Values</h4>
+				<section id="ams-combined-values">
+					<h4>Combined reading modes</h4>
+
 					<p>Combining various <code>accessModeSufficient</code>s implies that a combination of access modes
 						are required to completely consume and understand the content within the EPUB.</p>
 
 					<section id="metadata-access-mode-sufficient-visual-textual">
-						<h5>AccessModeSufficient: Visual &amp; Textual</h5>
+						<h5>Visual &amp; textual readability</h5>
+
 						<p>Indicates that both visual perception and the ability to read textual content is necessary to
 							consume the information.</p>
+
 						<p>An example of this would be a cookbook.</p>
+
 						<aside id="example-access-mode-sufficient-visual-textual" class="example"
 							title="AccessModeSufficient: Visual &amp; Textual">
 							<pre>
@@ -633,10 +702,13 @@
 					</section>
 
 					<section id="metadata-access-mode-sufficient-visual-auditory">
-						<h5>AccessModeSufficient: Visual &amp; Auditory</h5>
+						<h5>Visual &amp; auditory readability</h5>
+
 						<p>Indicates that both visual perception and the ability to hear the content is necessary to
 							consume the information.</p>
+
 						<p>An example of this would be a narrated picture book.</p>
+
 						<aside id="example-access-mode-sufficient-visual-auditory" class="example"
 							title="AccessModeSufficient: Visual &amp; Auditory">
 							<pre>
@@ -671,9 +743,11 @@
 					</section>
 
 					<section id="metadata-access-mode-sufficient-auditory-textual">
-						<h5>AccessModeSufficient: Auditory &amp; Textual</h5>
+						<h5>Auditory &amp; textual readability</h5>
+
 						<p>Indicates that both the ability to hear the content and read textual content is necessary to
 							consume the information.</p>
+
 						<p>Examples of this would be an an audio book with synchronized text highlighting, or an
 							interactive dictionary where you could hear the pronunciation of the defined words.</p>
 						<aside class="example" title="AccessModeSufficient: Auditory &amp; Textual">
@@ -696,9 +770,12 @@
 					</section>
 				</section>
 			</section>
+		</section>
+		<section id="accessibilityFeature">
+			<h2>Accessibility features</h2>
 
-			<section id="accessibilityFeature">
-				<h3>Accessibility features</h3>
+			<section id="features-overview">
+				<h3>Overview</h3>
 
 				<p>Identifying all the accessibility features and adaptations included in an <a
 						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a> allows users to
@@ -707,6 +784,10 @@
 				<p>For example, a math textbook might have a textual access mode, but that alone does not indicate
 					whether MathML markup is available. Whether a visual work only provides alternative text or whether
 					it includes extended descriptions is also important to know when gauging its usability.</p>
+			</section>
+
+			<section id="features-general">
+				<h3>General application guidelines</h3>
 
 				<p>Accessibility features are identified in the [[schema-org]] <a
 						href="https://schema.org/accessibilityFeature"><code>accessibilityFeature</code> property</a>.
@@ -740,9 +821,14 @@
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature">The
 							<code>accessibilityFeature</code> Property</a> [[a11y-discov-vocab]] for more information
 					about this property and its values.</p>
+			</section>
 
-				<section id="accessibility-feature-values">
-					<h4>Values</h4>
+			<section id="features-values">
+				<h3>Setting values</h3>
+
+				<section id="features-org">
+					<h4>Organization of values</h4>
+
 					<p>The <code>accessibilityFeature</code> property provides a list of all the applicable
 						accessibility characteristics of the content. It allows a user agent to discover these
 						characteristics without having to parse or interpret the structure of the content.</p>
@@ -772,23 +858,24 @@
 					<p><a href="#tactile-terms">Tactile terms</a> identify content that is formatted for tactile use,
 						such as graphics and objects.</p>
 
-					<p><a href="#international-terms">Internationalization terms</a> identify those accessibility
-						characteristics of the content which are required for internationalization.</p>
+					<p><a href="#i18n-terms">Internationalization terms</a> identify those accessibility characteristics
+						of the content which are required for internationalization.</p>
+				</section>
 
-					<section id="structure-navigation-terms">
-						<h5>Structure and navigation terms</h5>
+				<section id="structure-navigation-terms">
+					<h4>Structure and navigation terms</h4>
 
-						<section id="metadata-a11y-features-aria">
-							<h6>ARIA</h6>
+					<section id="metadata-a11y-features-aria">
+						<h5>ARIA</h5>
 
-							<p>Indicates the resource includes ARIA roles to organize and improve the structure and
-								navigation.</p>
+						<p>Indicates the resource includes ARIA roles to organize and improve the structure and
+							navigation.</p>
 
-							<p>The use of this value corresponds to the inclusion of [[DPUB-ARIA]] semantics, Document
-								Structure, Landmark, and Window roles [[WAI-ARIA]].</p>
+						<p>The use of this value corresponds to the inclusion of [[DPUB-ARIA]] semantics, Document
+							Structure, Landmark, and Window roles [[WAI-ARIA]].</p>
 
-							<aside class="example" title="AccessibilityFeature: ARIA">
-								<pre>
+						<aside class="example" title="AccessibilityFeature: ARIA">
+							<pre>
                                 <code>
                                 &lt;!-- role="doc-chapter", role="doc-pagebreak", and aria-label="5" are all ARIA roles --&gt;
                                 &lt;section epub:type="chapter" <b>role="doc-chapter"</b>&gt;
@@ -798,22 +885,23 @@
                                 &lt;/section&gt;
                                 </code>
                             </pre>
-								<p>The metadata to included in the package document would be:</p>
-								<pre>
+							<p>The metadata to included in the package document would be:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;ARIA&lt;/meta&gt;
                                 &lt;meta property="schema:accessibilityFeature"&gt;PageBreakMarker&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
-						</section>
+						</aside>
+					</section>
 
-						<section id="metadata-a11y-features-index">
-							<h5>Index</h5>
-							<p>The resource includes an index to the content.</p>
+					<section id="metadata-a11y-features-index">
+						<h5>Index</h5>
 
-							<aside class="example" title="AccessibilityFeature: Index">
-								<pre>
+						<p>The resource includes an index to the content.</p>
+
+						<aside class="example" title="AccessibilityFeature: Index">
+							<pre>
                                 <code>
                                 &lt;!-- Defined Index in the Nav Doc --&gt;
                                 &lt;nav role="doc-index" aria-labelledby="index"&gt;
@@ -832,44 +920,46 @@
                                 &lt;/nav&gt;
                                 </code>
                             </pre>
-								<p>The metadata to included in the package document would be:</p>
-								<pre>
+							<p>The metadata to included in the package document would be:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;index&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
+						</aside>
 
-						</section>
+					</section>
 
-						<section id="metadata-a11y-features-pageBreakMarkers">
-							<h5>Page Break Markers</h5>
+					<section id="metadata-a11y-features-pageBreakMarkers">
+						<h5>Page Break Markers</h5>
 
-							<p>The resource includes static page markers, such as those identified by the
-									<code>doc-pagebreak</code>
-								<code>role</code> [[DPUB-ARIA]].</p>
+						<p>The resource includes static page markers, such as those identified by the
+								<code>doc-pagebreak</code>
+							<code>role</code> [[DPUB-ARIA]].</p>
 
-							<aside class="example" title="AccessibilityFeature: Page Break Marker">
-								<pre>
+						<aside class="example" title="AccessibilityFeature: Page Break Marker">
+							<pre>
                                 <code>
                                 &lt;!-- role="doc-pagebreak"--&gt;
                                 &lt;span id="page_5" epub:type="pagebreak" role="doc-pagebreak" <b>aria-label="5"</b>/&gt;
                                 </code>
                             </pre>
-								<p>The metadata to included in the package document would look like:</p>
-								<pre>
+							<p>The metadata to included in the package document would look like:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;PageBreakMarker&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
-						</section>
-						<section id="metadata-a11y-features-pageNavigation">
-							<h5>Page Navigation</h5>
-							<p>The resource includes a Page List to the content.</p>
+						</aside>
+					</section>
 
-							<aside class="example" title="AccessibilityFeature: Page Navigation">
-								<pre>
+					<section id="metadata-a11y-features-pageNavigation">
+						<h5>Page Navigation</h5>
+
+						<p>The resource includes a Page List to the content.</p>
+
+						<aside class="example" title="AccessibilityFeature: Page Navigation">
+							<pre>
                                 <code>
                                 &lt;!-- Defined pagelist in the Nav Doc --&gt;
                                 &lt;nav epub:type="page-list" role="doc-index" aria-labelledby="pglist"&gt;
@@ -888,89 +978,101 @@
                                 &lt;/nav&gt;
                                 </code>
                             </pre>
-								<p>The metadata to included in the package document would be:</p>
-								<pre>
+							<p>The metadata to included in the package document would be:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;pageNavigation&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
+						</aside>
 
-						</section>
-						<section id="metadata-a11y-features-readingOrder">
-							<h5>Reading Order</h5>
-							<p>The reading order of the content is clearly defined in the markup (e.g., figures,
-								sidebars and other secondary content has been marked up to allow it to be skipped
-								automatically and/or manually escaped from.</p>
-							<p>Add this metadata of <code>readingOrder</code> only when the accessible reading order
-								matches the visual layout reading order.</p>
-							<p>An example when this would not be the case is a two page spread where the intent is to
-								visually read across the page boundry, since AT would read down the first page and then
-								continue reading down the 2nd page.</p>
-							<p>The metadata to include in the package document when the visual reading order matches the
-								accessible reading order would be:</p>
-							<pre>
+					</section>
+
+					<section id="metadata-a11y-features-readingOrder">
+						<h5>Reading Order</h5>
+
+						<p>The reading order of the content is clearly defined in the markup (e.g., figures, sidebars
+							and other secondary content has been marked up to allow it to be skipped automatically
+							and/or manually escaped from.</p>
+
+						<p>Add this metadata of <code>readingOrder</code> only when the accessible reading order matches
+							the visual layout reading order.</p>
+
+						<p>An example when this would not be the case is a two page spread where the intent is to
+							visually read across the page boundry, since AT would read down the first page and then
+							continue reading down the 2nd page.</p>
+
+						<p>The metadata to include in the package document when the visual reading order matches the
+							accessible reading order would be:</p>
+
+						<pre>
                             <code>
                             &lt;meta property="schema:accessibilityFeature"&gt;readingOrder&lt;/meta&gt;
                             </code>
                         </pre>
 
-						</section>
-						<section id="metadata-a11y-features-structuralNavigation">
-							<h5>Structural Navigation</h5>
-							<p>The metadata <code>structuralNavigation</code> is used to indicate that an EPUB document
-								has been structured to support accessible navigation through its content. This is
-								crucial for users of assistive technologies.</p>
+					</section>
 
-							<p>The use of headings, lists, tables, asides, etc. in the resource fully and accurately
-								reflects the document hierarchy, allowing navigation by assistive technologies.</p>
+					<section id="metadata-a11y-features-structuralNavigation">
+						<h5>Structural Navigation</h5>
 
-							<p>You should use this metadata when your document meets the following criteria:</p>
+						<p>The metadata <code>structuralNavigation</code> is used to indicate that an EPUB document has
+							been structured to support accessible navigation through its content. This is crucial for
+							users of assistive technologies.</p>
 
-							<ul>
-								<li><b>Semantic Structure</b>: The document uses semantic HTML5 elements that accurately
-									represent the content's logical structure.</li>
-								<li><b>Heading Hierarchy</b>: Headings (h1-h6) are used in a meaningful, hierarchical
-									manner that reflects the document's outline.</li>
-								<li><b>Navigational Elements</b>: The document includes: <ul>
-										<li>Properly nested headings</li>
-										<li>Ordered and unordered lists where appropriate</li>
-										<li>Tables with appropriate headers and captions</li>
-										<li>Semantic elements like section, article, aside, etc.</li>
-										<li>Meaningful landmark roles</li>
-									</ul>
-								</li>
-							</ul>
+						<p>The use of headings, lists, tables, asides, etc. in the resource fully and accurately
+							reflects the document hierarchy, allowing navigation by assistive technologies.</p>
 
-							<p>Benefits of Structural Navigation:</p>
+						<p>You should use this metadata when your document meets the following criteria:</p>
 
-							<ul>
-								<li>Enables screen readers to provide better navigation</li>
-								<li>Allows users to jump between sections easily</li>
-								<li>Provides a clear, logical understanding of the document's structure</li>
-								<li>Improves overall accessibility and usability</li>
-							</ul>
-							<p>The metadata to include in the package document when proper structural elements are used
-								to facility accessible navigation would be:</p>
-							<pre>
+						<ul>
+							<li><b>Semantic Structure</b>: The document uses semantic HTML5 elements that accurately
+								represent the content's logical structure.</li>
+							<li><b>Heading Hierarchy</b>: Headings (h1-h6) are used in a meaningful, hierarchical manner
+								that reflects the document's outline.</li>
+							<li><b>Navigational Elements</b>: The document includes: <ul>
+									<li>Properly nested headings</li>
+									<li>Ordered and unordered lists where appropriate</li>
+									<li>Tables with appropriate headers and captions</li>
+									<li>Semantic elements like section, article, aside, etc.</li>
+									<li>Meaningful landmark roles</li>
+								</ul>
+							</li>
+						</ul>
+
+						<p>Benefits of Structural Navigation:</p>
+
+						<ul>
+							<li>Enables screen readers to provide better navigation</li>
+							<li>Allows users to jump between sections easily</li>
+							<li>Provides a clear, logical understanding of the document's structure</li>
+							<li>Improves overall accessibility and usability</li>
+						</ul>
+						<p>The metadata to include in the package document when proper structural elements are used to
+							facility accessible navigation would be:</p>
+						<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;structuralNavigation&lt;/meta&gt;
                                 </code>
                             </pre>
 
-						</section>
-						<section id="metadata-a11y-features-tableOfContents">
-							<h5>Table Of Contents</h5>
-							<p>The resource includes a table of contents that provides links to the major sections of
-								the content.</p>
-							<div class="note">
-								<p>The Table of Contents referred to here is the one in the 'Nav Doc', which is
-									processed by the Reading System to access the content. The publisher could also add
-									an additional Table of Contents in the front matter of the book in the 'spine' but
-									this is not required for use of this metadata.</p>
-							</div>
-							<aside class="example" title="AccessibilityFeature: Table Of Contents">
-								<pre>
+					</section>
+
+					<section id="metadata-a11y-features-tableOfContents">
+						<h5>Table Of Contents</h5>
+
+						<p>The resource includes a table of contents that provides links to the major sections of the
+							content.</p>
+
+						<div class="note">
+							<p>The Table of Contents referred to here is the one in the 'Nav Doc', which is processed by
+								the Reading System to access the content. The publisher could also add an additional
+								Table of Contents in the front matter of the book in the 'spine' but this is not
+								required for use of this metadata.</p>
+						</div>
+
+						<aside class="example" title="AccessibilityFeature: Table Of Contents">
+							<pre>
                                 <code>
                                 &lt;!-- Defined TOC in the Nav Doc --&gt;
                                 &lt;nav epub:type="toc" role="doc-toc" aria-labelledby="nav-toc"&gt;
@@ -987,45 +1089,48 @@
                                 &lt;/nav&gt;
                                 </code>
                             </pre>
-								<p>The metadata to include in the package document would be:</p>
-								<pre>
+							<p>The metadata to include in the package document would be:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;tableOfContents&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
-						</section>
+						</aside>
 					</section>
+				</section>
 
-					<section id="adaptation-terms">
-						<h5>Adaptation Terms</h5>
+				<section id="adaptation-terms">
+					<h4>Adaptation Terms</h4>
 
-						<section id="metadata-a11y-features-alternativeText">
-							<h5>Alternative Text</h5>
+					<section id="metadata-a11y-features-alternativeText">
+						<h5>Alternative Text</h5>
 
-							<p>Alternative text is provided for visual content. In fixed layout books this would
-								typically be in the form of textual descriptions of the images contained within the
-								publication.</p>
-							<aside class="example" title="AccessibilityFeature: Alternative Text">
-								<pre>
+						<p>Alternative text is provided for visual content. In fixed layout books this would typically
+							be in the form of textual descriptions of the images contained within the publication.</p>
+
+						<aside class="example" title="AccessibilityFeature: Alternative Text">
+							<pre>
                                  <code>
                                     &lt;img src="images/hawk.jpg" alt="A majestic hawk perches on a tree branch, its sharp golden eyes scanning the landscape, feathered wings folded, powerful talons gripping the bark against a soft blue sky background."&gt; 
                                  </code>
                             </pre>
-								<p>The metadata to include in the package document would be:</p>
-								<pre>
+							<p>The metadata to include in the package document would be:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;alternativeText&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
-						</section>
-						<section id="metadata-a11y-features-audioDescription">
-							<h5>Audio Description</h5>
-							<p>Audio descriptions are available (e.g., via an HTML <code>track</code> element with its
-									<code>kind</code> attribute set to "descriptions").</p>
-							<aside class="example" title="AccessibilityFeature: Audio Description>">
-								<pre>
+						</aside>
+					</section>
+
+					<section id="metadata-a11y-features-audioDescription">
+						<h5>Audio Description</h5>
+
+						<p>Audio descriptions are available (e.g., via an HTML <code>track</code> element with its
+								<code>kind</code> attribute set to "descriptions").</p>
+
+						<aside class="example" title="AccessibilityFeature: Audio Description>">
+							<pre>
                                 <code>
                                 &lt;video controls&gt;
                                     &lt;source src="chapter4-video.mp4" type="video/mp4"&gt;
@@ -1039,10 +1144,10 @@
                                 &lt;/video&gt;
                                 </code>
                             </pre>
-								<p>The VTT file would contain timed text descriptions of visual elements not conveyed by
-									dialogue.</p>
-								<p>A sample audio description VTT file might look like:</p>
-								<pre>
+							<p>The VTT file would contain timed text descriptions of visual elements not conveyed by
+								dialogue.</p>
+							<p>A sample audio description VTT file might look like:</p>
+							<pre>
                             chapter4-video-audio-description.vtt
                             
                             WEBVTT
@@ -1053,25 +1158,28 @@
                             The driver, wearing a black leather jacket, turns sharply around a bend.
                             </pre>
 
-								<p>The metadata to include in the package document would be:</p>
-								<pre>
+							<p>The metadata to include in the package document would be:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;audioDescription&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
+						</aside>
 
-						</section>
-						<section id="metadata-a11y-features-closedCaptions">
-							<h5>Closed Captions</h5>
-							<p>Indicates that synchronized closed captions are available for audio and video
-								content.</p>
-							<p>Closed captions are defined separately from the video, allowing users to control whether
-								they are rendered or not, unlike <a href="#metadata-a11y-features-openCaptions">open
-									captions</a> which would be rendered directly onto the video during the video
-								editing process, becoming a permanent part of the visual content. </p>
-							<aside class="example" title="AccessibilityFeature: Closed Captions">
-								<pre>
+					</section>
+
+					<section id="metadata-a11y-features-closedCaptions">
+						<h5>Closed Captions</h5>
+
+						<p>Indicates that synchronized closed captions are available for audio and video content.</p>
+
+						<p>Closed captions are defined separately from the video, allowing users to control whether they
+							are rendered or not, unlike <a href="#metadata-a11y-features-openCaptions">open captions</a>
+							which would be rendered directly onto the video during the video editing process, becoming a
+							permanent part of the visual content. </p>
+
+						<aside class="example" title="AccessibilityFeature: Closed Captions">
+							<pre>
                                 <code>
                                 &lt;video controls width="480" height="360"&gt;
                                   &lt;source src="ch1-interview.mp4" type="video/mp4"&gt;
@@ -1091,8 +1199,8 @@
                                 &lt;/video&gt;                                
                                 </code>
                             </pre>
-								<p>A sample WebVTT might look like:</p>
-								<pre>
+							<p>A sample WebVTT might look like:</p>
+							<pre>
                             ch1-interview-captions-en.vtt
                             
                             WEBVTT
@@ -1104,44 +1212,50 @@
                             Today we're discussing accessibility in web design.
                             </pre>
 
-								<p>The metadata to include in the package document would be:</p>
-								<pre>
+							<p>The metadata to include in the package document would be:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;closedCaptions&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
+						</aside>
 
 
-						</section>
-						<section id="metadata-a11y-features-describedMath">
-							<h5>Described Math</h5>
-							<p>Textual descriptions of math equations are included in the alt attribute for image-based
-								equations, or by other means.</p>
-							<aside class="example" title="AccessibilityFeature: Described Math">
-								<pre>
+					</section>
+
+					<section id="metadata-a11y-features-describedMath">
+						<h5>Described Math</h5>
+
+						<p>Textual descriptions of math equations are included in the alt attribute for image-based
+							equations, or by other means.</p>
+
+						<aside class="example" title="AccessibilityFeature: Described Math">
+							<pre>
                                 <code>
                                     &lt;img src="images/quadraticFormula.jpg" alt="A X-squared + B X + C = zero"&gt; 
                                 </code>
                              </pre>
-								<aside class="note"> This however is not recommended since a more accessible way to
-									include math would be to use real <a href="#metadata-a11y-features-MathML"
-										>MathML</a> markup instead of an image of the math equation. </aside>
+							<aside class="note"> This however is not recommended since a more accessible way to include
+								math would be to use real <a href="#metadata-a11y-features-MathML">MathML</a> markup
+								instead of an image of the math equation. </aside>
 
-								<p>The metadata to include in the package document would be:</p>
-								<pre>
+							<p>The metadata to include in the package document would be:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;describedMath&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
-						</section>
-						<section id="metadata-a11y-features-longDescription">
-							<h5>Long Description</h5>
-							<p>Descriptions are provided for image-based visual content and/or complex structures such
-								as tables, mathematics, diagrams, and charts.</p>
-							<aside class="example" title="AccessibilityFeature: Long Description">
-								<pre>
+						</aside>
+					</section>
+
+					<section id="metadata-a11y-features-longDescription">
+						<h5>Long Description</h5>
+
+						<p>Descriptions are provided for image-based visual content and/or complex structures such as
+							tables, mathematics, diagrams, and charts.</p>
+
+						<aside class="example" title="AccessibilityFeature: Long Description">
+							<pre>
                                 <code>
                                 &lt;figure&gt;
                                   &lt;img src="complex-chart.jpg" 
@@ -1161,24 +1275,28 @@
                                 &lt;/figure&gt;
                                 </code>
                             </pre>
-								<aside class="note"> An even better long description would be to inclue the real HTML
-									table which makes up the chart. </aside>
+							<aside class="note"> An even better long description would be to inclue the real HTML table
+								which makes up the chart. </aside>
 
-								<p>The metadata to include in the package document would be:</p>
-								<pre>
+							<p>The metadata to include in the package document would be:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;longDescription&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
-						</section>
-						<section id="metadata-a11y-features-openCaptions">
-							<h5>Open Captions</h5>
-							<p>Indicates that synchronized open captions are available for audio and video content.</p>
-							<p>Open captions are part of the video stream and cannot be turned off by the user, unlike
-									<a href="#metadata-a11y-features-closedCaptions">closed captions.</a></p>
-							<aside class="example" title="AccessibilityFeature: Open Captions">
-								<pre>
+						</aside>
+					</section>
+
+					<section id="metadata-a11y-features-openCaptions">
+						<h5>Open Captions</h5>
+
+						<p>Indicates that synchronized open captions are available for audio and video content.</p>
+
+						<p>Open captions are part of the video stream and cannot be turned off by the user, unlike <a
+								href="#metadata-a11y-features-closedCaptions">closed captions.</a></p>
+
+						<aside class="example" title="AccessibilityFeature: Open Captions">
+							<pre>
                                 <code>
                                 &lt;video controls width="480" height="360"&gt;
                                     &lt;source src="ch1-interview-with-embedded-captions.mp4" type="video/mp4"&gt;
@@ -1188,21 +1306,22 @@
                                 </code>
                             </pre>
 
-								<p>The metadata to include in the package document would be:</p>
-								<pre>
+							<p>The metadata to include in the package document would be:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;openCaptions&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
-						</section>
-						<section id="metadata-a11y-features-signLanguage">
-							<h5>Sign Language</h5>
+						</aside>
+					</section>
 
-							<p>Sign language interpretation is available for audio and video content.</p>
+					<section id="metadata-a11y-features-signLanguage">
+						<h5>Sign Language</h5>
 
-							<aside class="example" title="AccessibilityFeature: Sign Language">
-								<pre>
+						<p>Sign language interpretation is available for audio and video content.</p>
+
+						<aside class="example" title="AccessibilityFeature: Sign Language">
+							<pre>
                                 <code>
                                 &lt;?xml version="1.0" encoding="UTF-8"?&gt;
                                 &lt;html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en"&gt;
@@ -1244,159 +1363,171 @@
                                 &lt;/html&gt;                         
                                 </code>
                             </pre>
-								<p>The metadata to include in the package document would be:</p>
-								<pre>
+							<p>The metadata to include in the package document would be:</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;signLanguage&lt;/meta&gt;
                                 </code>
                             </pre>
-								<p>Also since there are captions you would include closedCaptions</p>
-								<pre>
+							<p>Also since there are captions you would include closedCaptions</p>
+							<pre>
                                 <code>
                                 &lt;meta property="schema:accessibilityFeature"&gt;closedCaptions&lt;/meta&gt;
                                 </code>
                             </pre>
-							</aside>
+						</aside>
 
-						</section>
-						<section id="metadata-a11y-features-transcript">
-							<h5>Transcript</h5>
-
-						</section>
 					</section>
 
-					<section id="rendering-control-terms">
-						<h5>Rendering Control Terms</h5>
+					<section id="metadata-a11y-features-transcript">
+						<h5>Transcript</h5>
 
-						<section id="metadata-a11y-features-synchronizedAudioText">
-							<h5>Synchronized Audio Text</h5>
-
-						</section>
-						<section id="metadata-a11y-features-timingControl">
-							<h5>Timing Control</h5>
-
-						</section>
-					</section>
-
-					<section id="specialized-markup-terms">
-						<h5>Specialized Markup Terms</h5>
-
-						<section id="metadata-a11y-features-ChemML">
-							<h5>Chemistry Represented using ChemML</h5>
-
-						</section>
-
-						<section id="metadata-a11y-features-latex-chemistry">
-							<h5>Chemistry Represented using LaTeX</h5>
-
-						</section>
-
-						<section id="metadata-a11y-features-MathML-chemistry">
-							<h5>Chemistry Represented using MathML</h5>
-
-						</section>
-
-						<section id="metadata-a11y-features-latex">
-							<h5>Math Represented using LaTeX</h5>
-
-						</section>
-						<section id="metadata-a11y-features-MathML">
-							<h5>Math Represented using MathML</h5>
-
-						</section>
-						<section id="metadata-a11y-features-ttsMarkup">
-							<h5>Text-To-Speech Markup</h5>
-
-						</section>
-					</section>
-
-					<section id="clarity-terms">
-						<h5>Clarity Terms</h5>
-
-						<section id="metadata-a11y-features-highContrastAudio">
-							<h5>High Contrast Audio</h5>
-
-						</section>
-
-						<section id="metadata-a11y-features-highContrastDisplay">
-							<h5>High Contrast Display</h5>
-
-						</section>
-						<section id="metadata-a11y-features-largePrint">
-							<h5>Large Print</h5>
-
-						</section>
-					</section>
-
-					<section id="tactile-terms">
-						<h5>Tactile Terms</h5>
-
-						<section id="metadata-a11y-features-braille">
-							<h5>Braille</h5>
-
-						</section>
-
-						<section id="metadata-a11y-features-tactileGraphic">
-							<h5>Tactile Graphic</h5>
-
-						</section>
-						<section id="metadata-a11y-features-tactileObject">
-							<h5>Tactile Object</h5>
-
-						</section>
-					</section>
-
-					<section id="international-terms">
-						<h5>International Terms</h5>
-
-						<section id="metadata-a11y-features-fullRubyAnnotations">
-							<h5>Full Ruby Annotations</h5>
-
-						</section>
-						<section id="metadata-a11y-features-horizontalWriting">
-							<h5>horizontalWriting</h5>
-
-						</section>
-						<section id="metadata-a11y-features-rubyAnnotations">
-							<h5>Ruby Annotations</h5>
-
-						</section>
-						<section id="metadata-a11y-features-verticalWriting">
-							<h5>Vertical Writing</h5>
-
-						</section>
-						<section id="metadata-a11y-features-withAdditionalWordSegmentation">
-							<h5>With Additional Word Segmentation</h5>
-
-						</section>
-						<section id="metadata-a11y-features-withoutAdditionalWordSegmentation">
-							<h5>Without Additional Word Segmentation</h5>
-
-						</section>
-					</section>
-
-					<section id="accessibility-feature-none">
-						<h5>None</h5>
-
-						<p>Indicates that the resource does not contain any accessibility features.</p>
-
-						<p>The none value must not be set with any other feature value.</p>
-					</section>
-
-					<section id="accessibility-feature-unknown">
-						<h5>Unknown</h5>
-
-						<p>Indicates that the author has not yet checked if the resource contains accessibility
-							features. This value is only intended as a placeholder until an accessibility review can be
-							completed.</p>
-
-						<p>The unknown value must not be set with any other feature value.</p>
 					</section>
 				</section>
-			</section>
 
-			<section id="accessibilityHazard">
-				<h3>Accessibility hazards</h3>
+				<section id="rendering-control-terms">
+					<h4>Rendering Control Terms</h4>
+
+					<section id="metadata-a11y-features-synchronizedAudioText">
+						<h5>Synchronized Audio Text</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-timingControl">
+						<h5>Timing Control</h5>
+
+					</section>
+				</section>
+
+				<section id="specialized-markup-terms">
+					<h4>Specialized Markup Terms</h4>
+
+					<section id="metadata-a11y-features-ChemML">
+						<h5>Chemistry Represented using ChemML</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-latex-chemistry">
+						<h5>Chemistry Represented using LaTeX</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-MathML-chemistry">
+						<h5>Chemistry Represented using MathML</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-latex">
+						<h5>Math Represented using LaTeX</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-MathML">
+						<h5>Math Represented using MathML</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-ttsMarkup">
+						<h5>Text-To-Speech Markup</h5>
+
+					</section>
+				</section>
+
+				<section id="clarity-terms">
+					<h4>Clarity Terms</h4>
+
+					<section id="metadata-a11y-features-highContrastAudio">
+						<h5>High Contrast Audio</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-highContrastDisplay">
+						<h5>High Contrast Display</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-largePrint">
+						<h5>Large Print</h5>
+
+					</section>
+				</section>
+
+				<section id="tactile-terms">
+					<h4>Tactile Terms</h4>
+
+					<section id="metadata-a11y-features-braille">
+						<h5>Braille</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-tactileGraphic">
+						<h5>Tactile Graphic</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-tactileObject">
+						<h5>Tactile Object</h5>
+
+					</section>
+				</section>
+
+				<section id="i18n-terms">
+					<h4>Internationalization Terms</h4>
+
+					<section id="metadata-a11y-features-fullRubyAnnotations">
+						<h5>Full Ruby Annotations</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-horizontalWriting">
+						<h5>horizontalWriting</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-rubyAnnotations">
+						<h5>Ruby Annotations</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-verticalWriting">
+						<h5>Vertical Writing</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-withAdditionalWordSegmentation">
+						<h5>With Additional Word Segmentation</h5>
+
+					</section>
+
+					<section id="metadata-a11y-features-withoutAdditionalWordSegmentation">
+						<h5>Without Additional Word Segmentation</h5>
+
+					</section>
+				</section>
+
+				<section id="accessibility-feature-none">
+					<h4>None</h4>
+
+					<p>Indicates that the resource does not contain any accessibility features.</p>
+
+					<p>The none value must not be set with any other feature value.</p>
+				</section>
+
+				<section id="accessibility-feature-unknown">
+					<h4>Unknown</h4>
+
+					<p>Indicates that the author has not yet checked if the resource contains accessibility features.
+						This value is only intended as a placeholder until an accessibility review can be completed.</p>
+
+					<p>The unknown value must not be set with any other feature value.</p>
+				</section>
+			</section>
+		</section>
+		<section id="accessibilityHazard">
+			<h2>Accessibility hazards</h2>
+
+			<section id="hazards-overview">
+				<h3>Overview</h3>
 
 				<p>There are three widely recognized hazards that can affect readers of digital content:</p>
 
@@ -1427,6 +1558,10 @@
 						specify a sound hazard until additional guidance is developed. This technique will be updated
 						whenever there is more clarity on this issue.</p>
 				</div>
+			</section>
+
+			<section id="hazards-general">
+				<h3>General application guidelines</h3>
 
 				<p>Hazards are identified in the [[schema-org]] <a href="https://schema.org/accessibilityHazard"
 							><code>accessibilityHazard</code> property</a>. Repeat this property for each hazard.</p>
@@ -1500,12 +1635,39 @@
 					about this property and its values.</p>
 			</section>
 
-			<section id="accessibilitySummary">
-				<h3>Accessibility summary</h3>
+			<section id="hazards-values">
+				<h3>Setting values</h3>
+
+				<section id="hazards">
+					<h4>Hazards</h4>
+				</section>
+
+				<section id="hazards-unknown">
+					<h4>Unknown hazards</h4>
+				</section>
+
+				<section id="hazards-none">
+					<h4>No hazards</h4>
+				</section>
+			</section>
+		</section>
+		<section id="accessibilitySummary">
+			<h2>Accessibility summary</h2>
+
+			<section id="summary-overview">
+				<h3>Overview</h3>
 
 				<p>An accessibility summary provides a brief, human-readable description of the accessibility
 					characteristics of an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
 						publication</a> that cannot be expressed through the other discovery metadata.</p>
+			</section>
+
+			<section id="summary-general">
+				<h3>General application guidelines</h3>
+
+				<p>An accessibility summary is provided using the [[schema-org]] <a
+						href="https://schema.org/accessibilitySummary"
+					><code>accessibilitySummary</code> property</a>.</p>
 
 				<p>The accessibility summary should not simply repeat the conformance information provided in the
 						<code>dcterms:conformsTo</code> property, for example, or the features listed in the
@@ -1534,10 +1696,6 @@
 					the reason(s) it fails should be noted in the summary. Similarly, if an EPUB creator is hesitant to
 					make a formal claim of conformance, the reasons why can be explained in the summary.</p>
 
-				<p>An accessibility summary is provided using the [[schema-org]] <a
-						href="https://schema.org/accessibilitySummary"
-					><code>accessibilitySummary</code> property</a>.</p>
-
 				<aside class="example"
 					title="Accessibility summary for a publication that fails the content accessibility requirements">
 					<pre>&lt;meta
@@ -1561,44 +1719,31 @@
 				<p>Do not repeat this property to provide translations of a summary. EPUB does not define a method for
 					including translations. Putting different <code>xml:lang</code> attributes on properties does not
 					indicate a translation and could lead to wrong summary being rendered to users.</p>
-
-				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilitySummary">The
-							<code>accessibilitySummary</code> property</a> [[a11y-discov-vocab]] for more
-					information.</p>
-			</section>
-
-			<section id="accessibilityAPI">
-				<h3>Accessibility APIs</h3>
-
-				<p>The use of the <code>schema:accesibilityAPI</code> property is no longer necessary for <a
-						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>. <a
-						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> are not responsible for
-					the interaction between <a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading
-						systems</a> and the underlying platform APIs.</p>
-
-				<p>Meeting the requirements of [[wcag2]] is a better measure of the accessibility of scripting, as this
-					property does not differentiate between ARIA markup used for document structure or for identifying
-					controls.</p>
-			</section>
-
-			<section id="accessibilityControl">
-				<h3>Accessible Control</h3>
-
-				<p>The use of the <code>schema:accesibilityControl</code> property is no longer necessary for <a
-						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>. This property
-					does not differentiate issues arising from the <a
-						href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading system</a> interface from
-					those in the underlying content, which has led to confusion about its use.</p>
-
-				<p>Meeting the requirements of [[wcag2]] will mitigate most known issues with the content and is
-					sufficient for authoring purposes.</p>
 			</section>
 		</section>
-		<section id="metadata-conformance">
-			<h3>Conformance metadata</h3>
+		<section id="accessibilityAPI">
+			<h2>Accessibility APIs</h2>
+
+			<p>It is not necessary to set the <code>schema:accesibilityAPI</code> property for <a
+					href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>. <a
+					href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> are not responsible for the
+				interaction between <a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading systems</a>
+				and the underlying platform APIs.</p>
+		</section>
+		<section id="accessibilityControl">
+			<h2>Accessible Control</h2>
+
+			<p>It is not necessary to set the <code>schema:accesibilityControl</code> property for <a
+					href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>. This property does
+				not differentiate issues arising from the <a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system"
+					>reading system</a> interface from those in the underlying content, which has led to confusion about
+				its use.</p>
+
+			<p>Meeting the requirements of [[wcag2]] will mitigate most known issues with the content and is sufficient
+				for authoring purposes.</p>
 		</section>
 		<section id="metadata-examples" class="informative">
-			<h3>Examples</h3>
+			<h2>Examples</h2>
 
 			<p>The following examples show the metadata that would be added to an <a
 					href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a> that has textual and


### PR DESCRIPTION
This pull request picks up from the hasty merge I did to create this document from the a11y and fxl techniques documents. 

What I've done is split each of the properties into three subsections (two for summary):

- Overview - includes the explanatory text about the property from the a11y techniques 
- General application guidelines - includes the high-level instructions on how to set the properties from the a11y techniques
- Setting values - includes the guidance for the vocabulary terms from the fxl guide

I also put in a brief abstract and introduction, but we can revisit all of this later.

***

[Preview](https://raw.githack.com/w3c/publ-a11y/cleanup/a11y-guide/epub-a11y-meta-guide/1.0/draft/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/epub-a11y-meta-guide/1.0/draft/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/cleanup/a11y-guide/epub-a11y-meta-guide/1.0/draft/index.html)