### PR TITLE
consistently spell ruby with a lower case "r"

### DIFF
--- a/a11y-meta-display-guide/2.1/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.1/draft/techniques/epub-metadata/index.html
@@ -1506,7 +1506,7 @@
 						</li>
 						<li>
 							<span><b>IF</b> <var>ruby_annotations</var>:</span>
-							<span><b>THEN</b> display <code id="additional-accessibility-information-ruby-annotations">"Some Ruby annotations"</code>.</span>
+							<span><b>THEN</b> display <code id="additional-accessibility-information-ruby-annotations">"Some ruby annotations"</code>.</span>
 						</li>
 						<li>
 							<span><b>IF</b> <var>sign_language</var>:</span>


### PR DESCRIPTION
closes #735