### PR TITLE
Remove xhtml namespace

### DIFF
--- a/a11y-meta-display-guide/2.0/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/draft/guidelines/index.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 <head>
-	<meta charset="utf-8" />
+	<meta charset="utf-8">
 	<title>Accessibility Metadata Display Guide for Digital Publications
 		2.0</title>
 	<script src="https://www.w3.org/Tools/respec/respec-w3c"
 		class="remove" defer="defer"></script>
 	<script class="remove">
-		// <![CDATA[
 		var respecConfig = {
 			group: "publishingcg",
 			specStatus: "CG-DRAFT",
@@ -67,7 +66,6 @@
 				}
 			}
 		};
-		// ]]>
 	</script>
 	<style>
 		.responsive {
@@ -275,7 +273,7 @@
 
 			<img class="responsive" src="media/MetadataProcessing.png"
 				aria-details="ecosystem"
-				alt="Outline of the processing for EPUB, PDF, ONIX and MARC metadata. Description follows." />
+				alt="Outline of the processing for EPUB, PDF, ONIX and MARC metadata. Description follows.">
 
 			<div class="note">
 				<p>Work on integrating PDF and MARC is ongoing. The

--- a/a11y-meta-display-guide/2.0/draft/localizations/index.html
+++ b/a11y-meta-display-guide/2.0/draft/localizations/index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title>Display guide localization strings visualiser</title>
          <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script class="remove">
-		// <![CDATA[
 		var respecConfig = {
 			group: "publishingcg",
 			specStatus: "CG-DRAFT",
@@ -50,7 +49,6 @@
 			},
 
 		};
-		// ]]>
 	</script>
 		<style>
 			.responsive {

--- a/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/index.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Display Techniques for EPUB Accessibility Metadata 2.0</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script src="../../common/js/add_ids.js" class="remove"></script>
 		<script class="remove">
-			// <![CDATA[
 			var respecConfig = {
 				group: "publishingcg",
 				specStatus: "CG-DRAFT",
@@ -33,7 +32,6 @@
 				},
 				preProcess: [addStringIDs]
 			};
-			// ]]>
 	  </script>
 		<style>
 	  	var {

--- a/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/index.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Display Techniques for ONIX Accessibility Metadata 2.0</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script src="../../common/js/add_ids.js" class="remove"></script>
 		<script class="remove">
-			// <![CDATA[
 			var respecConfig = {
 				group: "publishingcg",
 				specStatus: "CG-DRAFT",
@@ -44,7 +43,6 @@
 				},
 				preProcess: [addStringIDs]
 			};
-			// ]]>
 	  </script>
 	  <style>
 	  	var {

--- a/a11y-meta-display-guide/2.0/guidelines/guidelines-draft-note-20240906.html
+++ b/a11y-meta-display-guide/2.0/guidelines/guidelines-draft-note-20240906.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.1.1">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.0/guidelines/guidelines-draft-note-20241101.html
+++ b/a11y-meta-display-guide/2.0/guidelines/guidelines-draft-note-20241101.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.1.2">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.0/guidelines/guidelines-draft-note-20250220.html
+++ b/a11y-meta-display-guide/2.0/guidelines/guidelines-draft-note-20250220.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.2.2">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.0/guidelines/index.html
+++ b/a11y-meta-display-guide/2.0/guidelines/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.2.2">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.0/implementations/index.html
+++ b/a11y-meta-display-guide/2.0/implementations/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Accessibility Metadata Display Guide for Digital Publications 2.0 — Implementation Report</title>
 		<meta http-equiv="refresh" content="0;URL='../../implementations/'" />
 	</head>

--- a/a11y-meta-display-guide/2.0/techniques/epub-metadata/epub-metadata-draft-note-20240906.html
+++ b/a11y-meta-display-guide/2.0/techniques/epub-metadata/epub-metadata-draft-note-20240906.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.1.1">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.0/techniques/epub-metadata/epub-metadata-draft-note-20241101.html
+++ b/a11y-meta-display-guide/2.0/techniques/epub-metadata/epub-metadata-draft-note-20241101.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.1.2">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.0/techniques/epub-metadata/epub-metadata-draft-note-20250220.html
+++ b/a11y-meta-display-guide/2.0/techniques/epub-metadata/epub-metadata-draft-note-20250220.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.2.2">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.0/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/techniques/epub-metadata/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.2.2">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.0/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.0/techniques/onix-metadata/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.2.2">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.0/techniques/onix-metadata/onix-metadata-draft-note-20240906.html
+++ b/a11y-meta-display-guide/2.0/techniques/onix-metadata/onix-metadata-draft-note-20240906.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.1.1">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.0/techniques/onix-metadata/onix-metadata-draft-note-20241101.html
+++ b/a11y-meta-display-guide/2.0/techniques/onix-metadata/onix-metadata-draft-note-20241101.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.1.2">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.0/techniques/onix-metadata/onix-metadata-draft-note-20250220.html
+++ b/a11y-meta-display-guide/2.0/techniques/onix-metadata/onix-metadata-draft-note-20250220.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+<!DOCTYPE html><html lang="en-US"><head>
 <meta charset="utf-8">
 <meta name="generator" content="ReSpec 35.2.2">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/a11y-meta-display-guide/2.1/draft/guidelines/index.html
+++ b/a11y-meta-display-guide/2.1/draft/guidelines/index.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 <head>
-	<meta charset="utf-8" />
+	<meta charset="utf-8">
 	<title>Accessibility Metadata Display Guide for Digital Publications
 		2.1</title>
 	<script src="https://www.w3.org/Tools/respec/respec-w3c"
 		class="remove" defer="defer"></script>
 	<script class="remove">
-		// <![CDATA[
 		var respecConfig = {
 			shortName: "a11y-display-guidelines",
 			group: "publishingcg",
@@ -68,7 +67,6 @@
 				}
 			}
 		};
-		// ]]>
 	</script>
 	<style>
 		.responsive {
@@ -276,7 +274,7 @@
 
 			<img class="responsive" src="media/MetadataProcessing.png"
 				aria-details="ecosystem"
-				alt="Outline of the processing for EPUB, PDF, ONIX and MARC metadata. Description follows." />
+				alt="Outline of the processing for EPUB, PDF, ONIX and MARC metadata. Description follows.">
 
 			<div class="note">
 				<p>Work on integrating PDF and MARC is ongoing. The

--- a/a11y-meta-display-guide/2.1/draft/localizations/index.html
+++ b/a11y-meta-display-guide/2.1/draft/localizations/index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
     <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         <title>Display guide localization strings visualiser</title>
          <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script class="remove">
-		// <![CDATA[
 		var respecConfig = {
 			group: "publishingcg",
 			specStatus: "CG-DRAFT",
@@ -50,7 +49,6 @@
 			},
 
 		};
-		// ]]>
 	</script>
 		<style>
 			.responsive {

--- a/a11y-meta-display-guide/2.1/draft/techniques/epub-metadata/index.html
+++ b/a11y-meta-display-guide/2.1/draft/techniques/epub-metadata/index.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Display Techniques for EPUB Accessibility Metadata 2.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script src="../../common/js/add_ids.js" class="remove"></script>
 		<script class="remove">
-			// <![CDATA[
 			var respecConfig = {
 				shortName: "epub-techniques",
 				group: "publishingcg",
@@ -34,7 +33,6 @@
 				},
 				preProcess: [addStringIDs]
 			};
-			// ]]>
 	  </script>
 		<style>
 	  	var {

--- a/a11y-meta-display-guide/2.1/draft/techniques/onix-metadata/index.html
+++ b/a11y-meta-display-guide/2.1/draft/techniques/onix-metadata/index.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Display Techniques for ONIX Accessibility Metadata 2.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script src="../../common/js/add_ids.js" class="remove"></script>
 		<script class="remove">
-			// <![CDATA[
 			var respecConfig = {
 				shortName: "onix-techniques",
 				group: "publishingcg",
@@ -45,7 +44,6 @@
 				},
 				preProcess: [addStringIDs]
 			};
-			// ]]>
 	  </script>
 	  <style>
 	  	var {

--- a/a11y-meta-display-guide/implementations/index.html
+++ b/a11y-meta-display-guide/implementations/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Accessibility Metadata Display Guide for Digital Publications — Implementation Report</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 		<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" />
@@ -29,7 +29,7 @@
 				<h1 id="title" class="title">Accessibility Metadata Display Guide for Digital Publications</h1>
 				<p class="subtitle">Implementation Report</p>
 			</hgroup>
-			<hr title="Separator for header" />
+			<hr title="Separator for header">
 		</div>
 		<nav id="toc">
 			<h2 class="introductory" id="table-of-contents">Table of Contents</h2>
@@ -86,7 +86,7 @@
 				<div class="snapshots">
 					<figure id="catalogo-lia-interface">
 						<img src="graphics/catalogo-lia/display.png"
-							alt="screeshot of Fondazione LIA implementation: the texts are in Italian, the main title is «accessibility features», the sub-sections are «certification», «navigation», «reading modes» (with subsections «Customization of graphical aspects» and «Additional features») and «Content enrichment». Each section has the texts as suggested by the guidelines. Each section is accompanied by an icon." />
+							alt="screeshot of Fondazione LIA implementation: the texts are in Italian, the main title is «accessibility features», the sub-sections are «certification», «navigation», «reading modes» (with subsections «Customization of graphical aspects» and «Additional features») and «Content enrichment». Each section has the texts as suggested by the guidelines. Each section is accompanied by an icon.">
 						<figcaption>Accessibility features' box is shown on the detail page of each ebook</figcaption>
 						
 					</figure>
@@ -119,7 +119,7 @@
 				<div class="snapshots">
 					<figure id="daisy-viewer-interface">
 						<img src="graphics/daisy-viewer/display.png"
-							alt="DAISY Accessibility Metadata Viewer result dialog" />
+							alt="DAISY Accessibility Metadata Viewer result dialog">
 						<figcaption>The result dialog for the DAISY Accessibility Metadata Viewer has options at the top
 							to control the display of the metadata. The metadata headings are laid out in a tabular
 							format with their corresponding display statements to their right.</figcaption>
@@ -147,7 +147,7 @@
 				<div class="snapshots">
 					<figure id="readium-mobile-interface">
 						<img src="graphics/readium-mobile/display.png"
-							alt="Readium Mobile test app screenshot" />
+							alt="Readium Mobile test app screenshot">
 						<figcaption>TThe book information panel contains Title, Identifier, Author, Publisher and Publication Date. After a separator, the section titled "Accessibility Claims" begins. The first toggle button allows to hide or show fields with no metadata, a second button allows to use descriptive instead of compact statements. Then the list of accessibility information is visible, starting with Ways of reading, followed by Navigation, Additional accessibility information, Hazards and Conformance.</figcaption>
 					</figure>
 				</div>
@@ -177,7 +177,7 @@
 				<div class="snapshots">
 					<figure id="thorium-desktop-interface">
 						<img src="graphics/thorium-desktop/display.png"
-							alt="Thorium Desktop book information panel screenshot" />
+							alt="Thorium Desktop book information panel screenshot">
 						<figcaption>
 							The book information panel shows two titles: Publication details and Accessibility. The accessibility section is composed of the always shown titles Ways of Reading and Navigation. Then a "More Information" toggle button can include other accessibility information if they are available. The compact sentences are displayed and the descriptive ones are available as title of the line element, visually marked by a question mark pictogram.
 						</figcaption>

--- a/drafts/a11y-crosswalk-MARC/index.html
+++ b/drafts/a11y-crosswalk-MARC/index.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 
 <head>
-	<meta charset="utf-8" />
+	<meta charset="utf-8">
 	<title>Accessibility Properties Crosswalk (schema.org, ONIX, MARC21 &amp; UNIMARC)</title>
     <meta http-equiv="refresh" content="10; URL=https://w3c.github.io/a11y-discov-vocab/crosswalk/"/>
 	<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 	<script src="../common/js/permalink-a11y.js" class="remove"></script>
 	<script class="remove">
-		//<![CDATA[
 		var respecConfig = {
 			group: "a11y-crosswalk-MARC",
 			specStatus: "CG-DRAFT",
@@ -46,7 +45,8 @@
 				repoURL: "https://github.com/w3c/a11y-discov-vocab",
 				branch: "main"
 			}
-		};//]]></script>
+		};
+	</script>
 	<style>
 		/* Table zebra style... */
 
@@ -958,7 +958,7 @@
 							href="https://ns.editeur.org/onix/en/196/10">List: 196; Code: 10</a> means all text is
 						actual text. Note that List: 81; Code: 10 on its own (without List: 196; Code: 10) admits
 						the possibility that the "text" is inaccessible because it is an image of text.
-						<br />Note : on this point ONIX is unclear. Codes <a
+						<br>Note : on this point ONIX is unclear. Codes <a
 							href="https://ns.editeur.org/onix/en/196/09">16</a> and <a
 							href="https://ns.editeur.org/onix/en/196/09">14</a> or <a
 							href="https://ns.editeur.org/onix/en/196/09">15</a> should also be mobilised<a

--- a/drafts/audio-playback/index.html
+++ b/drafts/audio-playback/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Publishing Guide to Audio Playback and Text-To-Speech</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script class="remove">

--- a/drafts/page-source-id/index.html
+++ b/drafts/page-source-id/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Page Source Identification</title>
 		<script src="js/css-inline.js" class="remove"></script>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>

--- a/drafts/schema-a11y-summary/index.html
+++ b/drafts/schema-a11y-summary/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Accessibility Summary Authoring Guidelines for EPUB Publications</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script>
@@ -246,16 +246,16 @@
 						<tr>
 							<td><em>displayTransformability</em></td>
 							
-							<td>The initial chapter headings are highly stylized and are provided as images. These are marked as proper headings, and alt text is provided, which should minimize the issue of having text represented as images.<br/>
-							<br/>
+							<td>The initial chapter headings are highly stylized and are provided as images. These are marked as proper headings, and alt text is provided, which should minimize the issue of having text represented as images.<br>
+							<br>
 							The tables are represented as images, and the full text of the table is provided below the image within the details element, which can be expanded.</td>
 							<td>Sometimes contented is formatted in such a way that it cannot be reflowed or other features cannot be adjusted. Tables, which cannot be encoded and are presented as images is one common example of this. Another case is where a highly stylized chapter heading is used that cannot be enlarged or transformed. These shortcomings should be noted and if there is any work around, such as  a long description provided in addition to the image.</td>
 						</tr>
 											<tr>
 							<td><em>index</em></td>
 							
-							<td>A comprehensive index is included with links to the top of the page.<br/>
-							<br/>
+							<td>A comprehensive index is included with links to the top of the page.<br>
+							<br>
 							A comprehensive index is included with links to the paragraph being referenced.</td>
 							<td>Provide information about the index other than it is present. A comprehensive list and where the words link to is worth highlighting.</td>
 						</tr>
@@ -280,8 +280,8 @@
 						<tr>
 							<td><em>MathML</em></td>
 
-							<td>All displayed Math is represented with MathML. <br/>
-							<br/>
+							<td>All displayed Math is represented with MathML. <br>
+							<br>
 							The chemical formulae are displayed and encoded as MathML with the proper labels for Chemistry.</td>
 							<td>The presence of MathML is important especially in STEM materials. The amount is also important. If there is a mix of math as plain text  and MathML, it should be noted. Also if Chemistry isencoded as MathML using the newer mechanisms for indicating these semantics, it should be noted.</td>
 						</tr>

--- a/drafts/zero-tolerance-conformance/index.html
+++ b/drafts/zero-tolerance-conformance/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Zero-Tolerance Accessibility Conformance Approaches for Publishing</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script class="remove">

--- a/epub-a11y-meta-guide/1.0/draft/index.html
+++ b/epub-a11y-meta-guide/1.0/draft/index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Expressing Accessibility Metadata in the EPUB Package Document</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script class="remove">
-			//<![CDATA[
             var respecConfig = {
 				shortName: "epub-a11y-meta-guide",
 				group: "publishingcg",
@@ -64,7 +63,7 @@
 						"publisher": "W3C"
 					}
                 }
-            };//]]>
+            };
       </script>
 		<style>
 			/*prevent examples from horizontal scrolling*/

--- a/templates/cg-note.html
+++ b/templates/cg-note.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<html lang="en-US">
 	<head>
-		<meta charset="utf-8" />
+		<meta charset="utf-8">
 		<title>Title</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script class="remove">


### PR DESCRIPTION
Same fix as in https://github.com/w3c/epub-specs/pull/2784

I did a search/replace on the root elements so this probably captured some unnecessary files, but no harm in fixing old stuff.