### PR TITLE
Updated package metadata guide

### DIFF
--- a/epub-a11y-meta-guide/1.0/draft/index.html
+++ b/epub-a11y-meta-guide/1.0/draft/index.html
@@ -3181,10 +3181,10 @@
 				<section id="evaluator">
 					<h4>Adding an evaluator's name</h4>
 
-					<p>Providing the name of the evaluator can be helpful to users in terms of assessing the quality of
-						the evaluation performed. A user might be warier of a publisher self-certifying their work, for
-						example, especially if they do not declare any <a href="#credential">evaluation credentials</a>,
-						than a trusted evaluation agency.</p>
+					<p>Providing the name of the evaluator is required when a conformance claim is made. It is helpful
+						to users in terms of assessing the quality of the evaluation performed. A user might be warier
+						of a publisher self-certifying their work, for example, especially if they do not declare any <a
+							href="#credential">evaluation credentials</a>, than a trusted evaluation agency.</p>
 
 					<p>The name of the evaluator is provided in the package document metadata using the <dfn
 							id="a11y:certifiedBy">a11y:certifiedBy</dfn> property. It is strongly recommended to attach


### PR DESCRIPTION
I've now gone over the document and also expanded it to include all the accessibility and conformance metadata, not just the original schema.org metadata that was covered under the EPUB Accessibility standard's discovery requirements.

I still need to go back and read the whole thing again for consistency and accuracy, but it's a huge document and I don't want to sit on this forever waiting to get it in an ideal state.

The diff will probably be useless given the scope of the changes made, but I'll add links for both the preview and diff below.

@GeorgeKerscher @clapierre if you want some time to review this, just say so, but it's probably simpler to merge it and then start logging specific issues.

***

[Preview](https://raw.githack.com/w3c/publ-a11y/editorial/meta-review/epub-a11y-meta-guide/1.0/draft/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/epub-a11y-meta-guide/1.0/draft/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/editorial/meta-review/epub-a11y-meta-guide/1.0/draft/index.html)