### PR TITLE
Update spec-generator URLs

### DIFF
--- a/UX-Guide-Metadata/bin/1.0/publish-principles.sh
+++ b/UX-Guide-Metadata/bin/1.0/publish-principles.sh
@@ -25,7 +25,7 @@ curl \
     -G \
     --data-urlencode "type=respec" \
     --data-urlencode "url=https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/principles/?specStatus=CG-FINAL&publishDate=$publishDate" \
-    https://labs.w3.org/spec-generator/ \
+    https://www.w3.org/publications/spec-generator/ \
     -o $BASEDIR/_tmp/index.html
 
 # generates the static version

--- a/UX-Guide-Metadata/bin/1.0/publish-techniques.sh
+++ b/UX-Guide-Metadata/bin/1.0/publish-techniques.sh
@@ -32,7 +32,7 @@ do
 		-G \
 		--data-urlencode "type=respec" \
 		--data-urlencode "url=https://w3c.github.io/publ-a11y/UX-Guide-Metadata/draft/techniques/$technique-metadata/?specStatus=CG-FINAL&publishDate=$publishDate" \
-		https://labs.w3.org/spec-generator/ \
+		https://www.w3.org/publications/spec-generator/ \
 		-o $BASEDIR/../techniques/$technique-metadata/index.html
 
 	# generates the static version

--- a/a11y-meta-display-guide/bin/publish-drafts.sh
+++ b/a11y-meta-display-guide/bin/publish-drafts.sh
@@ -38,7 +38,7 @@ do
 		-G \
 		--data-urlencode "type=respec" \
 		--data-urlencode "url=https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/$document/?specStatus=CG-DRAFT&publishDate=$publishDate&thisVersion=$versionURL" \
-		https://labs.w3.org/spec-generator/ \
+		https://www.w3.org/publications/spec-generator/ \
 		-o "$tmpdir/index.html"
 	
 	# runs nuchecker


### PR DESCRIPTION
This updates spec-generator URLs to point to the new location announced in https://lists.w3.org/Archives/Public/spec-prod/2025OctDec/0008.html