### PR TITLE
Move crosswalk file from a11y-discov-vocab repository for continued maintenance

### DIFF
--- a/metadata-crosswalk/index.html
+++ b/metadata-crosswalk/index.html
@@ -41,6 +41,11 @@
 			permalinkEdge: true,
 			permalinkHide: false,
 			localBiblio: {
+				"dpub-aria": {
+					"title": "Digital Publishing WAI-ARIA Module",
+					"href": "https://www.w3.org/TR/dpub-aria/",
+					"publisher": "W3C"
+				},
 				"epub-3": {
 					"title": "EPUB 3",
 					"href": "https://www.w3.org/TR/epub/",
@@ -1416,7 +1421,7 @@
 					<tr>
 						<td>
 							<p>The resource includes static page markers, such as those identified by the doc-pagebreak
-								role [[dpub-aria-1.1]].</p>
+								role [[dpub-aria]].</p>
 							<p>This value is most commonly used with ebooks for which there is a statically paginated
 								equivalent, such as a print edition, but it is not required that the page markers
 								correspond to another work. The markers may exist solely to facilitate navigation in
@@ -1445,7 +1450,7 @@
 							<p>The resource includes a means of navigating to static page break locations.</p>
 							<p>The most common way of providing page navigation in digital publications is through a
 								page list. The EPUB page-list navigation feature [[epub-3]] and the pagelist role
-								[[dpub-aria-1.1]] are two examples.</p>
+								[[dpub-aria]] are two examples.</p>
 						</td>
 						<td>
 							<p>


### PR DESCRIPTION
@clapierre when I went to update the metadata I noticed that there were a few issues with the references - some going to the wrong versions (e.g., mathml 1.01) and some linking across to the references section of the vocabulary (looks like a copy paste from that file). I also lowercased all the references to match the convention in the other w3c docs we publish. I'm going to make the same fixes to the vocabulary before publishing it, too.

I figure it's just as easy to move the file at the same time as making these fixes, so if you're okay with this pull request I'll merge and then continue on to publish it. Just skim the references appendix in the preview to check that everything looks right now.

I didn't copy the other files that were under /crosswalk in the a11y-discov-vocab directory as I wasn't sure if those were obsolete now. If you want them added, though, just let me know and I'll append them to this pull request.

***

[Preview](https://raw.githack.com/w3c/publ-a11y/editorial/add-crosswalk/metadata-crosswalk/index.html)