### PR TITLE
Add note to visual content indicators

### DIFF
--- a/package-metadata-authoring-guide/index.html
+++ b/package-metadata-authoring-guide/index.html
@@ -678,9 +678,10 @@
 					element, the <a href="#chartOnVisual">chart on visual</a> could be set.</p>
 
 				<div class="note">
-					<p>Similar to setting any of the primary access modes, whether or not the content identified by a
-						visual indicator is also accessible in another mode (e.g., through the provision of alternative
-						text) is not considered. Affordances are only used to determine the sufficient access modes.</p>
+					<p>Similar to setting any of the <a href="#accessmode-primary">primary access modes</a>, whether or
+						not the content identified by a visual indicator is also accessible in another mode (e.g.,
+						through the provision of alternative text) is not considered. Affordances are only used to
+						determine the sufficient access modes.</p>
 				</div>
 
 				<p>More than one visual content indicator can apply to a piece of visual content. A publication with an


### PR DESCRIPTION
I added a note to the top of the section to say that, as primary modes, affordances similarly don't factor in to whether the content indicators are set. It would be too repetitive to have this in each definition.

Fixes #785 

***

[Preview](https://raw.githack.com/w3c/publ-a11y/editorial/issue-785/package-metadata-authoring-guide/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/package-metadata-authoring-guide/index.html&doc2=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/editorial/issue-785/package-metadata-authoring-guide/index.html)
