### PR TITLE
Add content readability section and explainer

### DIFF
--- a/package-metadata-authoring-guide/index.html
+++ b/package-metadata-authoring-guide/index.html
@@ -279,9 +279,9 @@
 					about what their different roles are. Their definitions are also nuanced:</p>
 
 				<ul>
-					<li><a href="https://schema.org/accessMode"><code>accessMode</code></a> [[schema-org]]
-						identifies a "human sensory perceptual system or cognitive faculty through which a person may
-						process or perceive information";</li>
+					<li><a href="https://schema.org/accessMode"><code>accessMode</code></a> [[schema-org]] identifies a
+						"human sensory perceptual system or cognitive faculty through which a person may process or
+						perceive information";</li>
 
 					<li><a href="https://schema.org/accessModeSufficient"><code>accessModeSufficient</code></a>
 						[[schema-org]], on the other hand, identifies "a list of single or combined [access modes] that
@@ -327,7 +327,7 @@
 					primary audience. (The complete set of pathways by which the content can be read are captured by the
 					sufficient access modes, to spoil the secret!)</p>
 
-				<p>The next question is invariably why this distinction necessary. It is because each adaptation is a
+				<p>The next question is invariably why this distinction is necessary. It is because each adaptation is a
 					repetition of the information in another form. The adaptations do not capture new information that
 					all readers must be able to process. They may also result in some loss of information in being
 					adapted (e.g., a description of an image has to generalize it in some ways as it can never fully
@@ -469,8 +469,7 @@
 						<h5>EPUB Accessibility conformance</h5>
 
 						<p>[[[epub-a11y]]] [[epub-a11y]] only recommends that the access modes of a publication be
-							specified in the <a
-								href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessMode"
+							specified in the <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessMode"
 									><code>accessMode</code> property</a> [[a11y-discov-vocab]] as they are not as
 							important for determining usability as the <a href="#accessModeSufficient">sufficient access
 								modes</a>.</p>


### PR DESCRIPTION
This pull request is primarily to add an explainer on access mode vs. access mode sufficient. But to make this more readable I created a new section called "content readability" to group the accessMode and accessModeSufficient property definitions.

I've rewritten the explainer several times over now trying to get it to be as helpful as possible, so at this point I'm just spinning my wheels. Let me know if there's anything that could use improvement and I'll keep working on it.

Fixes #786 

***

[Preview](https://raw.githack.com/w3c/publ-a11y/editorial/issue-786/package-metadata-authoring-guide/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/package-metadata-authoring-guide/index.html&doc2=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/publ-a11y/editorial/issue-786/package-metadata-authoring-guide/index.html)
