### PR TITLE
Add appendix covering how to assess access modes

### DIFF
--- a/package-metadata-authoring-guide/index.html
+++ b/package-metadata-authoring-guide/index.html
@@ -4128,6 +4128,10 @@
 							<p>If the answer is <strong>no</strong>, skip to <a href="#check-visual">check 2</a>.</p>
 						</li>
 						<li>
+							<p>If the answer is <strong>yes</strong> but the only content of the publication is a list
+								of headings for audio synchronization, skip to <a href="#check-mo">check 6</a>.</p>
+						</li>
+						<li>
 							<p>Otherwise, add a textual access mode declaration to the package document metadata:</p>
 							<pre>&lt;meta property="schema:accessMode">textual&lt;/meta></pre>
 						</li>
@@ -4151,6 +4155,10 @@
 							comics, manga, and children's books, are entirely image based.</p>
 						<p>In the case there is no text content, or the work is not entirely textual, the evaluation
 							continues at the next check for visual content.</p>
+						<p>If the only text is the headings of the work &#8212; to provide support for structured audio
+							playback via media overlays &#8212; there is no need to perform the subsequent checks for
+							the other access modes. A textual access mode is not reported because in this case the work
+							will be treated like an audiobook.</p>
 						<p>If the work consists entirely of text content, such as is often the case with novels, there
 							is no need to perform the additional access mode checks. A textual sufficient access mode
 							can be declared and the next check jumps ahead to determine if there is audio


### PR DESCRIPTION
The checks in the appendix should lead to the correct access modes and sufficient access modes being set. This isn't quite the same as what I did in smart as there the wizard is also trying to set accessibility features. I'm assuming this is for people to read to determine the metadata, so I also tried to avoid formatting it too much like pseudo-code.

***

[Preview](https://raw.githack.com/w3c/publ-a11y/editorial/access-mode-detection/package-metadata-authoring-guide/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/package-metadata-authoring-guide/index.html&doc2=https://raw.githack.com/w3c/publ-a11y/editorial/access-mode-detection/package-metadata-authoring-guide/index.html)

(Looks like the diff generator is getting a 403 forbidden error trying to get the file from raw.githack.com. Hopefully the problem clears up at some point.)