### PR TITLE
Add additional context for audio via media overlays

### DIFF
--- a/package-metadata-authoring-guide/index.html
+++ b/package-metadata-authoring-guide/index.html
@@ -1246,7 +1246,8 @@
 								synchronized text-audio playback.</p>
 
 							<p>For example, a publication with media overlays that has text and images (with text
-								alternatives) would only declare the following sufficient access modes:</p>
+								alternatives sufficient to understand their content) would only declare the following
+								sufficient access modes:</p>
 
 							<pre>&lt;meta property="schema:accessModeSufficient">textual&lt;/meta>
 &lt;meta property="schema:accessModeSufficient">auditory&lt;/meta>
@@ -1254,6 +1255,10 @@
 
 							<p>It would <strong>not</strong> include declarations for "<code>textual,auditory</code>" or
 									"<code>textual,visual,auditory</code>".</p>
+
+							<p>(Note that the final "<code>textual,visual</code>" set captures the two access modes
+								needed to read the default content &#8212; <code>textual</code> for the text content and
+									<code>visual</code> for the images.)</p>
 						</div>
 
 						<div class="note">


### PR DESCRIPTION
Clarifies the issue about whether text means unicode character data and adds additional context and linking from the sections where audio is discussed to the subsection that details media overlays relative to access modes and sufficient access modes.

The pull request also clarifies that not all tts tech have to be used when setting ttsMarkup. I noticed that wasn't clear while reading the aural rendering features section.

Fixes #794 

***

[Preview](https://raw.githack.com/w3c/publ-a11y/editorial/mo-review/package-metadata-authoring-guide/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://www.w3.org/publications/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/publ-a11y/package-metadata-authoring-guide/index.html&doc2=https:%2F%2Fwww.w3.org%2Fpublications%2Fspec-generator%2F%3Ftype=respec%26url=https:%2F%2Fraw.githubusercontent.com%2Fw3c%2Fpubl-a11y%2Feditorial%2Fmo-review%2Fpackage-metadata-authoring-guide%2Findex.html)

(Edit: the diff should now be working again.)